### PR TITLE
Data ingest pipeline with shell visualization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ Thumbs.db
 
 # Vite
 vite.config.ts.timestamp-*
+
+# Data dumps
+data-dump/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,13 +18,14 @@ This starts the Vite dev server and launches the Tauri desktop app. First build 
 
 ## Commands
 
-| Command            | What it does                                |
-| ------------------ | ------------------------------------------- |
-| `pnpm tauri dev`   | Launch the app in development mode          |
-| `pnpm tauri build` | Build a release binary                      |
-| `pnpm test`        | Run tests once                              |
-| `pnpm test:watch`  | Run tests in watch mode                     |
-| `pnpm build`       | Build the frontend only (TypeScript + Vite) |
+| Command            | What it does                                               |
+| ------------------ | ---------------------------------------------------------- |
+| `pnpm tauri dev`   | Launch the app in development mode                         |
+| `pnpm tauri build` | Build a release binary                                     |
+| `pnpm test`        | Run tests once                                             |
+| `pnpm test:watch`  | Run tests in watch mode                                    |
+| `pnpm build`       | Build the frontend only (TypeScript + Vite)                |
+| `pnpm check-game`  | Print live game state from Riot API (needs a game running) |
 
 ## Developing on WSL2
 
@@ -46,6 +47,16 @@ pnpm check-game
 ```
 
 This prints your champion, items, teams, and game state. If it can't connect, it'll tell you why.
+
+## Helper scripts
+
+Scripts in `scripts/` are development tools, not part of the app. Run them with `pnpm exec tsx scripts/<name>.ts`.
+
+| Script                   | Shortcut                                       | What it does                                                                                                                                                                                                                                        |
+| ------------------------ | ---------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `check-game.ts`          | `pnpm check-game`                              | Checks Riot API connectivity and prints live game state (champion, items, teams). Use to verify WSL2 networking works. Requires a game running (Practice Tool is fine).                                                                             |
+| `dump-data.ts`           | `pnpm exec tsx scripts/dump-data.ts`           | Runs the full data ingest pipeline and prints everything to the console: champions, items, runes, augments grouped by mode/tier. Writes raw JSON to `data-dump/` (gitignored). Use to debug data quality issues — shows the same data the app sees. |
+| `check-augment-modes.ts` | `pnpm exec tsx scripts/check-augment-modes.ts` | Fetches CDragon augments and shows how they're classified by mode (Mayhem/Arena/Swarm) based on icon paths. Use when augment mode classification seems wrong.                                                                                       |
 
 ## Project structure
 

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "@tauri-apps/api": "^2",
     "@tauri-apps/plugin-global-shortcut": "^2",
     "@tauri-apps/plugin-opener": "^2",
+    "luaparse": "^0.3.1",
     "react": "^19.1.0",
     "react-dom": "^19.1.0"
   },
@@ -30,6 +31,7 @@
     "@tauri-apps/cli": "^2",
     "@testing-library/jest-dom": "^6.6.3",
     "@testing-library/react": "^16.3.0",
+    "@types/luaparse": "^0.2.13",
     "@types/react": "^19.1.8",
     "@types/react-dom": "^19.1.6",
     "@vitejs/plugin-react": "^4.6.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -16,6 +16,9 @@ importers:
       "@tauri-apps/plugin-opener":
         specifier: ^2
         version: 2.5.3
+      luaparse:
+        specifier: ^0.3.1
+        version: 0.3.1
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -32,6 +35,9 @@ importers:
       "@testing-library/react":
         specifier: ^16.3.0
         version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@19.2.3(@types/react@19.2.14))(@types/react@19.2.14)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      "@types/luaparse":
+        specifier: ^0.2.13
+        version: 0.2.13
       "@types/react":
         specifier: ^19.1.8
         version: 19.2.14
@@ -945,6 +951,12 @@ packages:
         integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==,
       }
 
+  "@types/luaparse@0.2.13":
+    resolution:
+      {
+        integrity: sha512-nWs2m9b/zrMcAA2Rs+wTxdIsBkSYMo0+6ko8mpeqS5dhchU3hQN9kZGcSw96n497Vc7kGpDLtSicjdpaUrRAkw==,
+      }
+
   "@types/react-dom@19.2.3":
     resolution:
       {
@@ -1467,6 +1479,13 @@ packages:
       {
         integrity: sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w==,
       }
+
+  luaparse@0.3.1:
+    resolution:
+      {
+        integrity: sha512-b21h2bFEbtGXmVqguHogbyrMAA0wOHyp9u/rx+w6Yc9pW1t9YjhGUsp87lYcp7pFRqSWN/PhFkrdIqKEUzRjjQ==,
+      }
+    hasBin: true
 
   lz-string@1.5.0:
     resolution:
@@ -2488,6 +2507,8 @@ snapshots:
 
   "@types/estree@1.0.8": {}
 
+  "@types/luaparse@0.2.13": {}
+
   "@types/react-dom@19.2.3(@types/react@19.2.14)":
     dependencies:
       "@types/react": 19.2.14
@@ -2803,6 +2824,8 @@ snapshots:
   lru-cache@5.1.1:
     dependencies:
       yallist: 3.1.1
+
+  luaparse@0.3.1: {}
 
   lz-string@1.5.0: {}
 

--- a/scripts/check-augment-modes.ts
+++ b/scripts/check-augment-modes.ts
@@ -1,0 +1,53 @@
+async function main() {
+  const res = await fetch(
+    "https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/cherry-augments.json"
+  );
+  const data: Array<{ augmentSmallIconPath: string; nameTRA: string }> =
+    await res.json();
+
+  const modes: Record<string, number> = {
+    mayhem: 0,
+    arena: 0,
+    swarm: 0,
+    unknown: 0,
+  };
+  for (const a of data) {
+    const p = a.augmentSmallIconPath.toLowerCase();
+    if (p.includes("kiwi/")) modes.mayhem++;
+    else if (p.includes("swarm/")) modes.swarm++;
+    else if (p.includes("cherry/")) modes.arena++;
+    else modes.unknown++;
+  }
+  console.log("Mode counts:", modes);
+
+  console.log("\nSample Mayhem paths:");
+  for (const a of data
+    .filter((x) => x.augmentSmallIconPath.toLowerCase().includes("kiwi/"))
+    .slice(0, 5)) {
+    console.log(`  ${a.nameTRA}: ${a.augmentSmallIconPath}`);
+  }
+
+  console.log("\nSample Arena paths:");
+  for (const a of data
+    .filter((x) => {
+      const p = x.augmentSmallIconPath.toLowerCase();
+      return p.includes("cherry/") && !p.includes("kiwi/");
+    })
+    .slice(0, 5)) {
+    console.log(`  ${a.nameTRA}: ${a.augmentSmallIconPath}`);
+  }
+
+  console.log("\nSample Unknown paths:");
+  for (const a of data
+    .filter((x) => {
+      const p = x.augmentSmallIconPath.toLowerCase();
+      return (
+        !p.includes("cherry/") && !p.includes("kiwi/") && !p.includes("swarm/")
+      );
+    })
+    .slice(0, 5)) {
+    console.log(`  ${a.nameTRA}: ${a.augmentSmallIconPath}`);
+  }
+}
+
+main().catch(console.error);

--- a/scripts/dump-data.ts
+++ b/scripts/dump-data.ts
@@ -1,0 +1,144 @@
+import { writeFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import {
+  fetchLatestVersion,
+  fetchChampions,
+  fetchItems,
+  fetchRunes,
+} from "../src/lib/data-ingest/sources/data-dragon";
+import { fetchWikiAugments } from "../src/lib/data-ingest/sources/wiki-augments";
+import { mergeAugmentIds } from "../src/lib/data-ingest/sources/community-dragon";
+import { buildEntityDictionary } from "../src/lib/data-ingest/entity-dictionary";
+import type { AugmentMode } from "../src/lib/data-ingest/types";
+
+const DUMP_DIR = join(import.meta.dirname, "..", "data-dump");
+
+async function main() {
+  mkdirSync(DUMP_DIR, { recursive: true });
+
+  console.log("Fetching latest version...");
+  const version = await fetchLatestVersion();
+  console.log(`Patch: ${version}\n`);
+
+  console.log("Fetching champions, items, runes, augments...");
+  const [champions, items, runes, augments] = await Promise.all([
+    fetchChampions(version),
+    fetchItems(version),
+    fetchRunes(version),
+    fetchWikiAugments(),
+  ]);
+
+  console.log("Merging CDragon augment data...");
+  await mergeAugmentIds(augments);
+
+  // Champions
+  const champList = [...champions.values()].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  console.log(`\n=== Champions (${champList.length}) ===`);
+  for (const c of champList) {
+    console.log(`  ${c.name} — ${c.title} [${c.tags.join(", ")}]`);
+  }
+
+  // Items
+  const itemList = [...items.values()].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+  const purchasable = itemList.filter((i) => i.gold.purchasable);
+  console.log(
+    `\n=== Items (${itemList.length} total, ${purchasable.length} purchasable) ===`
+  );
+  for (const item of purchasable) {
+    console.log(`  [${item.id}] ${item.name} — ${item.gold.total}g`);
+  }
+
+  // Runes
+  console.log(`\n=== Runes (${runes.length} trees) ===`);
+  for (const tree of runes) {
+    console.log(`  ${tree.name}`);
+    console.log(
+      `    Keystones: ${tree.keystones.map((r) => r.name).join(", ")}`
+    );
+    for (let i = 0; i < tree.slots.length; i++) {
+      console.log(
+        `    Row ${i + 1}: ${tree.slots[i].map((r) => r.name).join(", ")}`
+      );
+    }
+  }
+
+  // Augments by mode
+  const augList = [...augments.values()];
+  const byMode = new Map<AugmentMode, typeof augList>();
+  for (const a of augList) {
+    const list = byMode.get(a.mode) ?? [];
+    list.push(a);
+    byMode.set(a.mode, list);
+  }
+
+  console.log(`\n=== Augments (${augList.length} total) ===`);
+  for (const mode of ["mayhem", "arena", "swarm", "unknown"] as AugmentMode[]) {
+    const list = byMode.get(mode) ?? [];
+    if (list.length === 0) continue;
+
+    const sorted = list.sort((a, b) => a.name.localeCompare(b.name));
+    console.log(`\n  --- ${mode.toUpperCase()} (${sorted.length}) ---`);
+    for (const a of sorted) {
+      const desc = a.description
+        ? a.description.slice(0, 60) + (a.description.length > 60 ? "..." : "")
+        : "(no description)";
+      const setLabel = a.set !== "-" ? ` [Set: ${a.set}]` : "";
+      const idLabel = a.id != null ? ` (ID: ${a.id})` : "";
+      console.log(`  ${a.name} [${a.tier}]${setLabel}${idLabel}`);
+      console.log(`    ${desc}`);
+    }
+  }
+
+  // Entity dictionary
+  const dict = buildEntityDictionary(champions, items, augments);
+  console.log(`\n=== Entity Dictionary ===`);
+  console.log(`Champions: ${dict.champions.length}`);
+  console.log(`Items: ${dict.items.length}`);
+  console.log(`Augments: ${dict.augments.length}`);
+  console.log(`Total: ${dict.allNames.length}`);
+
+  // Test a few searches
+  console.log(`\n=== Search Tests ===`);
+  for (const query of ["typhoon", "rabadons", "aurelion", "adapt"]) {
+    const results = dict.search(query).slice(0, 3);
+    console.log(
+      `  "${query}" → ${results.map((r) => `${r.name} (${r.type}, ${r.score.toFixed(2)})`).join(", ")}`
+    );
+  }
+
+  // Write raw JSON for inspection
+  writeFileSync(
+    join(DUMP_DIR, "all-data.json"),
+    JSON.stringify(
+      {
+        version,
+        championCount: champions.size,
+        itemCount: items.size,
+        runeTreeCount: runes.length,
+        augmentsByMode: Object.fromEntries(
+          [...byMode.entries()].map(([mode, list]) => [
+            mode,
+            list.map((a) => ({
+              name: a.name,
+              tier: a.tier,
+              set: a.set,
+              mode: a.mode,
+              id: a.id,
+              hasDescription: !!a.description,
+            })),
+          ])
+        ),
+      },
+      null,
+      2
+    )
+  );
+
+  console.log("\nDone. Summary written to data-dump/all-data.json");
+}
+
+main().catch(console.error);

--- a/src/App.css
+++ b/src/App.css
@@ -1,30 +1,284 @@
 :root {
-  font-family: system-ui, -apple-system, sans-serif;
-  font-size: 16px;
+  font-family:
+    system-ui,
+    -apple-system,
+    sans-serif;
+  font-size: 14px;
   line-height: 1.5;
-  color: #f6f6f6;
+  color: #e0e0e0;
   background-color: #1a1a1a;
 }
 
+html,
+body,
+#root {
+  height: 100%;
+  margin: 0;
+  overflow: hidden;
+}
+
 .container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  max-width: 900px;
   margin: 0 auto;
-  max-width: 800px;
-  padding: 2rem;
+  padding: 0 2rem;
 }
 
-button {
-  border-radius: 8px;
-  border: 1px solid #444;
-  padding: 0.6em 1.2em;
-  font-size: 1em;
-  font-weight: 500;
-  font-family: inherit;
-  color: #f6f6f6;
+.app-header {
+  flex-shrink: 0;
+  padding-top: 1rem;
+  background-color: #1a1a1a;
+}
+
+.tab-content {
+  flex: 1;
+  overflow-y: auto;
+  padding-bottom: 1rem;
+}
+
+h1 {
+  margin-bottom: 0.25rem;
+}
+
+.header-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.refresh-btn {
+  font-size: 0.8em;
+  padding: 0.3em 0.8em;
+  color: #aaa;
   background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 4px;
   cursor: pointer;
-  transition: border-color 0.25s;
 }
 
-button:hover {
+.refresh-btn:hover {
+  color: #e0e0e0;
+  border-color: #646cff;
+}
+
+.refresh-btn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.version {
+  color: #888;
+  margin-top: 0;
+  margin-bottom: 1rem;
+}
+
+.error {
+  color: #ff6b6b;
+}
+
+/* Tabs */
+.app-tabs {
+  flex-shrink: 0;
+  display: flex;
+  gap: 0.25rem;
+  border-bottom: 1px solid #333;
+  background-color: #1a1a1a;
+}
+
+.tab {
+  border-radius: 6px 6px 0 0;
+  border: 1px solid transparent;
+  border-bottom: none;
+  padding: 0.5em 1em;
+  font-size: 0.9em;
+  font-family: inherit;
+  color: #aaa;
+  background-color: transparent;
+  cursor: pointer;
+}
+
+.tab:hover {
+  color: #e0e0e0;
+}
+
+.tab.active {
+  color: #e0e0e0;
+  background-color: #2a2a2a;
+  border-color: #333;
+}
+
+.count {
+  font-size: 0.8em;
+  color: #666;
+  margin-left: 0.4em;
+}
+
+/* Entity list */
+.entity-list {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+}
+
+.entity-item {
+  background-color: #222;
+  border-radius: 4px;
+}
+
+.entity-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0.5em 0.75em;
+  cursor: pointer;
+}
+
+.entity-header:hover {
+  background-color: #2a2a2a;
+}
+
+.entity-name {
+  font-weight: 500;
+}
+
+.mode-filter {
+  display: flex;
+  gap: 0.25rem;
+  margin-bottom: 0.75rem;
+}
+
+.filter-bar.sticky,
+.mode-filter.sticky {
+  position: sticky;
+  top: 0;
+  background-color: #1a1a1a;
+  padding: 0.5rem 0;
+  z-index: 1;
+}
+
+.filter-bar .mode-filter {
+  margin-bottom: 0.25rem;
+}
+
+/* Tier filter */
+.tier-filter {
+  display: flex;
+  gap: 0.25rem;
+}
+
+.tier-btn {
+  font-size: 0.8em;
+  padding: 0.2em 0.6em;
+  border-radius: 3px;
+  border: 1px solid transparent;
+  cursor: pointer;
+  opacity: 0.4;
+  font-family: inherit;
+}
+
+.tier-btn.active {
+  opacity: 1;
+}
+
+.tier-btn.tier-prismatic {
+  color: #e0c8ff;
+  background-color: #3a2a4a;
+  border-color: #5a4a6a;
+}
+
+.tier-btn.tier-gold {
+  color: #ffd700;
+  background-color: #3a3520;
+  border-color: #5a5530;
+}
+
+.tier-btn.tier-silver {
+  color: #c0c0c0;
+  background-color: #2a2a30;
+  border-color: #4a4a50;
+}
+
+.entity-meta {
+  color: #888;
+  font-size: 0.85em;
+}
+
+.entity-title {
+  color: #aaa;
+  font-style: italic;
+  margin: 0.25rem 0;
+}
+
+.entity-details {
+  padding: 0.5em 0.75em 0.75em;
+  border-top: 1px solid #333;
+  font-size: 0.9em;
+  color: #ccc;
+}
+
+.stat-grid {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.5em 1.5em;
+  margin-top: 0.5em;
+  font-size: 0.85em;
+  color: #aaa;
+}
+
+/* Tiers */
+.tier {
+  font-size: 0.8em;
+  padding: 0.15em 0.5em;
+  border-radius: 3px;
+}
+
+.tier-prismatic {
+  color: #e0c8ff;
+  background-color: #3a2a4a;
+}
+
+.tier-gold {
+  color: #ffd700;
+  background-color: #3a3520;
+}
+
+.tier-silver {
+  color: #c0c0c0;
+  background-color: #2a2a30;
+}
+
+/* Runes */
+.rune-entry {
+  padding: 0.25em 0;
+}
+
+.rune-entry .entity-name {
+  color: #ccc;
+}
+
+.rune-entry p {
+  margin: 0.15em 0 0.5em;
+  color: #999;
+  font-size: 0.9em;
+}
+
+/* Search */
+.search-input {
+  width: 100%;
+  box-sizing: border-box;
+  padding: 0.6em 0.75em;
+  font-size: 1em;
+  font-family: inherit;
+  color: #e0e0e0;
+  background-color: #2a2a2a;
+  border: 1px solid #444;
+  border-radius: 6px;
+  outline: none;
+  margin-bottom: 1rem;
+}
+
+.search-input:focus {
   border-color: #646cff;
 }

--- a/src/App.test.tsx
+++ b/src/App.test.tsx
@@ -2,13 +2,22 @@ import { render, screen } from "@testing-library/react";
 import { describe, it, expect, vi } from "vitest";
 import App from "./App";
 
-vi.mock("@tauri-apps/api/core", () => ({
-  invoke: vi.fn(),
+vi.mock("./hooks/useGameData", () => ({
+  useGameData: () => ({
+    data: null,
+    loading: true,
+    error: null,
+  }),
 }));
 
 describe("App", () => {
   it("renders the app title", () => {
     render(<App />);
     expect(screen.getByText("Champ Sage")).toBeInTheDocument();
+  });
+
+  it("shows loading state", () => {
+    render(<App />);
+    expect(screen.getByText("Loading game data...")).toBeInTheDocument();
   });
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,21 +1,30 @@
-import { useState } from "react";
-import { invoke } from "@tauri-apps/api/core";
 import "./App.css";
+import { useGameData } from "./hooks/useGameData";
+import { DataBrowser } from "./components/DataBrowser";
 
 function App() {
-  const [rustMessage, setRustMessage] = useState("");
-
-  async function testBridge() {
-    const message = await invoke<string>("greet", { name: "Champ Sage" });
-    setRustMessage(message);
-  }
+  const { data, loading, error, refresh } = useGameData();
 
   return (
     <main className="container">
-      <h1>Champ Sage</h1>
-      <p>State machine visualizer — modules will appear here as they are built.</p>
-      <button onClick={testBridge}>Test Rust Bridge</button>
-      {rustMessage && <p data-testid="rust-message">{rustMessage}</p>}
+      <div className="app-header">
+        <div className="header-row">
+          <h1>Champ Sage</h1>
+          {data && (
+            <button
+              className="refresh-btn"
+              onClick={refresh}
+              disabled={loading}
+            >
+              {loading ? "Loading..." : "Refresh"}
+            </button>
+          )}
+        </div>
+        {loading && !data && <p>Loading game data...</p>}
+        {error && <p className="error">Error: {error}</p>}
+        {data && <p className="version">Patch {data.version}</p>}
+      </div>
+      {data && <DataBrowser data={data} />}
     </main>
   );
 }

--- a/src/components/AugmentList.tsx
+++ b/src/components/AugmentList.tsx
@@ -1,0 +1,136 @@
+import { useState } from "react";
+import type { Augment, AugmentMode } from "../lib/data-ingest/types";
+
+interface AugmentListProps {
+  augments: Map<string, Augment>;
+}
+
+const TIER_ORDER: Record<string, number> = {
+  Prismatic: 0,
+  Gold: 1,
+  Silver: 2,
+};
+
+type Tier = Augment["tier"];
+const TIERS: Tier[] = ["Prismatic", "Gold", "Silver"];
+const MODES: AugmentMode[] = ["mayhem", "arena", "swarm", "unknown"];
+
+const MODE_LABELS: Record<AugmentMode, string> = {
+  mayhem: "Mayhem",
+  arena: "Arena",
+  swarm: "Swarm",
+  unknown: "Other",
+};
+
+export function AugmentList({ augments }: AugmentListProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const [modeFilter, setModeFilter] = useState<AugmentMode>("mayhem");
+  const [tierFilters, setTierFilters] = useState<Set<Tier>>(new Set(TIERS));
+
+  function toggleTier(tier: Tier) {
+    setTierFilters((prev) => {
+      const next = new Set(prev);
+      if (next.has(tier)) {
+        // Don't allow deselecting all
+        if (next.size > 1) next.delete(tier);
+      } else {
+        next.add(tier);
+      }
+      return next;
+    });
+  }
+
+  const modeFiltered = [...augments.values()].filter(
+    (a) => a.mode === modeFilter
+  );
+
+  const filtered = modeFiltered.filter((a) => tierFilters.has(a.tier));
+
+  const sorted = filtered.sort((a, b) => {
+    const tierDiff = (TIER_ORDER[a.tier] ?? 3) - (TIER_ORDER[b.tier] ?? 3);
+    if (tierDiff !== 0) return tierDiff;
+    return a.name.localeCompare(b.name);
+  });
+
+  const modeCounts = new Map<AugmentMode, number>();
+  for (const a of augments.values()) {
+    modeCounts.set(a.mode, (modeCounts.get(a.mode) ?? 0) + 1);
+  }
+
+  const tierCounts = new Map<Tier, number>();
+  for (const a of modeFiltered) {
+    tierCounts.set(a.tier, (tierCounts.get(a.tier) ?? 0) + 1);
+  }
+
+  return (
+    <div>
+      <div className="filter-bar sticky">
+        <div className="mode-filter">
+          {MODES.map((mode) => {
+            const count = modeCounts.get(mode) ?? 0;
+            if (count === 0) return null;
+            return (
+              <button
+                key={mode}
+                className={modeFilter === mode ? "tab active" : "tab"}
+                onClick={() => setModeFilter(mode)}
+              >
+                {MODE_LABELS[mode]} ({count})
+              </button>
+            );
+          })}
+        </div>
+        <div className="tier-filter">
+          {TIERS.map((tier) => {
+            const count = tierCounts.get(tier) ?? 0;
+            return (
+              <button
+                key={tier}
+                className={`tier-btn tier-${tier.toLowerCase()}${tierFilters.has(tier) ? " active" : ""}`}
+                onClick={() => toggleTier(tier)}
+              >
+                {tier} ({count})
+              </button>
+            );
+          })}
+        </div>
+      </div>
+      <div className="entity-list">
+        {sorted.map((aug) => (
+          <div key={`${aug.mode}-${aug.name}`} className="entity-item">
+            <div
+              className="entity-header"
+              onClick={() =>
+                setExpanded(expanded === aug.name ? null : aug.name)
+              }
+            >
+              <span className="entity-name">{aug.name}</span>
+              <span className="entity-meta">
+                <span className={`tier tier-${aug.tier.toLowerCase()}`}>
+                  {aug.tier}
+                </span>
+              </span>
+            </div>
+            {expanded === aug.name && (
+              <div className="entity-details">
+                {aug.description ? (
+                  <p>{aug.description}</p>
+                ) : (
+                  <p className="entity-meta">No description available</p>
+                )}
+                {aug.set !== "-" && (
+                  <p className="entity-title">Set: {aug.set}</p>
+                )}
+                {aug.id != null && (
+                  <p className="entity-meta">
+                    ID: {aug.id} | Mode: {MODE_LABELS[aug.mode]}
+                  </p>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/ChampionList.tsx
+++ b/src/components/ChampionList.tsx
@@ -1,0 +1,45 @@
+import { useState } from "react";
+import type { Champion } from "../lib/data-ingest/types";
+
+interface ChampionListProps {
+  champions: Map<string, Champion>;
+}
+
+export function ChampionList({ champions }: ChampionListProps) {
+  const [expanded, setExpanded] = useState<string | null>(null);
+  const sorted = [...champions.values()].sort((a, b) =>
+    a.name.localeCompare(b.name)
+  );
+
+  return (
+    <div className="entity-list">
+      {sorted.map((champ) => (
+        <div key={champ.id} className="entity-item">
+          <div
+            className="entity-header"
+            onClick={() => setExpanded(expanded === champ.id ? null : champ.id)}
+          >
+            <span className="entity-name">{champ.name}</span>
+            <span className="entity-meta">
+              {champ.tags.join(", ")} | {champ.partype}
+            </span>
+          </div>
+          {expanded === champ.id && (
+            <div className="entity-details">
+              <p className="entity-title">{champ.title}</p>
+              <div className="stat-grid">
+                <span>HP: {champ.stats.hp}</span>
+                <span>AD: {champ.stats.attackdamage}</span>
+                <span>Armor: {champ.stats.armor}</span>
+                <span>MR: {champ.stats.spellblock}</span>
+                <span>AS: {champ.stats.attackspeed}</span>
+                <span>Range: {champ.stats.attackrange}</span>
+                <span>MS: {champ.stats.movespeed}</span>
+              </div>
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/components/DataBrowser.tsx
+++ b/src/components/DataBrowser.tsx
@@ -1,0 +1,76 @@
+import { useState } from "react";
+import type { LoadedGameData } from "../lib/data-ingest";
+import { ChampionList } from "./ChampionList";
+import { ItemList } from "./ItemList";
+import { RuneList } from "./RuneList";
+import { AugmentList } from "./AugmentList";
+import { EntitySearch } from "./EntitySearch";
+
+type Tab = "champions" | "items" | "runes" | "augments" | "search";
+
+interface DataBrowserProps {
+  data: LoadedGameData;
+}
+
+const TABS: { key: Tab; label: string }[] = [
+  { key: "champions", label: "Champions" },
+  { key: "items", label: "Items" },
+  { key: "runes", label: "Runes" },
+  { key: "augments", label: "Augments" },
+  { key: "search", label: "Search" },
+];
+
+export function DataBrowser({ data }: DataBrowserProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("champions");
+
+  return (
+    <>
+      <div className="app-tabs">
+        {TABS.map((tab) => (
+          <button
+            key={tab.key}
+            className={activeTab === tab.key ? "tab active" : "tab"}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+            {tab.key !== "search" && (
+              <span className="count">{getCount(data, tab.key)}</span>
+            )}
+          </button>
+        ))}
+      </div>
+      <div className="tab-content">
+        {activeTab === "champions" && (
+          <ChampionList champions={data.champions} />
+        )}
+        {activeTab === "items" && <ItemList items={data.items} />}
+        {activeTab === "runes" && <RuneList runes={data.runes} />}
+        {activeTab === "augments" && <AugmentList augments={data.augments} />}
+        {activeTab === "search" && (
+          <EntitySearch dictionary={data.dictionary} />
+        )}
+      </div>
+    </>
+  );
+}
+
+function getCount(data: LoadedGameData, tab: Tab): number {
+  switch (tab) {
+    case "champions":
+      return data.champions.size;
+    case "items":
+      return data.items.size;
+    case "runes":
+      return data.runes.reduce(
+        (sum, tree) =>
+          sum +
+          tree.keystones.length +
+          tree.slots.reduce((s, slot) => s + slot.length, 0),
+        0
+      );
+    case "augments":
+      return data.augments.size;
+    default:
+      return 0;
+  }
+}

--- a/src/components/EntitySearch.tsx
+++ b/src/components/EntitySearch.tsx
@@ -1,0 +1,49 @@
+import { useState } from "react";
+import type { EntityDictionary, EntityMatch } from "../lib/data-ingest/types";
+
+interface EntitySearchProps {
+  dictionary: EntityDictionary;
+}
+
+export function EntitySearch({ dictionary }: EntitySearchProps) {
+  const [query, setQuery] = useState("");
+  const [results, setResults] = useState<EntityMatch[]>([]);
+
+  function handleSearch(value: string) {
+    setQuery(value);
+    if (value.trim().length < 2) {
+      setResults([]);
+      return;
+    }
+    setResults(dictionary.search(value.trim()).slice(0, 20));
+  }
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="Search champions, items, augments..."
+        value={query}
+        onChange={(e) => handleSearch(e.target.value)}
+        className="search-input"
+      />
+      {results.length > 0 && (
+        <div className="entity-list">
+          {results.map((match) => (
+            <div key={`${match.type}-${match.name}`} className="entity-item">
+              <div className="entity-header">
+                <span className="entity-name">{match.name}</span>
+                <span className="entity-meta">
+                  {match.type} | score: {match.score.toFixed(2)}
+                </span>
+              </div>
+            </div>
+          ))}
+        </div>
+      )}
+      {query.trim().length >= 2 && results.length === 0 && (
+        <p>No matches found.</p>
+      )}
+    </div>
+  );
+}

--- a/src/components/ItemList.tsx
+++ b/src/components/ItemList.tsx
@@ -1,0 +1,77 @@
+import { useState } from "react";
+import type { Item, ItemMode } from "../lib/data-ingest/types";
+
+interface ItemListProps {
+  items: Map<number, Item>;
+}
+
+const MODES: ItemMode[] = ["standard", "arena", "aram", "swarm", "other"];
+
+const MODE_LABELS: Record<ItemMode, string> = {
+  standard: "Standard",
+  arena: "Arena Variants",
+  aram: "ARAM Variants",
+  swarm: "Swarm",
+  other: "Other",
+};
+
+export function ItemList({ items }: ItemListProps) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+  const [modeFilter, setModeFilter] = useState<ItemMode>("standard");
+
+  const filtered = [...items.values()].filter((i) => i.mode === modeFilter);
+  const sorted = filtered.sort((a, b) => a.name.localeCompare(b.name));
+
+  const modeCounts = new Map<ItemMode, number>();
+  for (const item of items.values()) {
+    modeCounts.set(item.mode, (modeCounts.get(item.mode) ?? 0) + 1);
+  }
+
+  return (
+    <div>
+      <div className="mode-filter sticky">
+        {MODES.map((mode) => {
+          const count = modeCounts.get(mode) ?? 0;
+          if (count === 0) return null;
+          return (
+            <button
+              key={mode}
+              className={modeFilter === mode ? "tab active" : "tab"}
+              onClick={() => setModeFilter(mode)}
+            >
+              {MODE_LABELS[mode]} ({count})
+            </button>
+          );
+        })}
+      </div>
+      <div className="entity-list">
+        {sorted.map((item) => (
+          <div key={item.id} className="entity-item">
+            <div
+              className="entity-header"
+              onClick={() => setExpanded(expanded === item.id ? null : item.id)}
+            >
+              <span className="entity-name">{item.name}</span>
+              <span className="entity-meta">{item.gold.total}g</span>
+            </div>
+            {expanded === item.id && (
+              <div className="entity-details">
+                <p>{item.description}</p>
+                {item.plaintext && (
+                  <p className="entity-title">{item.plaintext}</p>
+                )}
+                <div className="stat-grid">
+                  {Object.entries(item.stats).map(([stat, val]) => (
+                    <span key={stat}>
+                      {stat}: {val}
+                    </span>
+                  ))}
+                </div>
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/RuneList.tsx
+++ b/src/components/RuneList.tsx
@@ -1,0 +1,53 @@
+import { useState } from "react";
+import type { RuneTree, Rune } from "../lib/data-ingest/types";
+
+interface RuneListProps {
+  runes: RuneTree[];
+}
+
+export function RuneList({ runes }: RuneListProps) {
+  const [expanded, setExpanded] = useState<number | null>(null);
+
+  return (
+    <div className="entity-list">
+      {runes.map((tree) => (
+        <div key={tree.id} className="entity-item">
+          <div
+            className="entity-header"
+            onClick={() => setExpanded(expanded === tree.id ? null : tree.id)}
+          >
+            <span className="entity-name">{tree.name}</span>
+            <span className="entity-meta">
+              {tree.keystones.length} keystones
+            </span>
+          </div>
+          {expanded === tree.id && (
+            <div className="entity-details">
+              <p className="entity-title">Keystones</p>
+              {tree.keystones.map((rune) => (
+                <RuneEntry key={rune.id} rune={rune} />
+              ))}
+              {tree.slots.map((slot, i) => (
+                <div key={i}>
+                  <p className="entity-title">Row {i + 1}</p>
+                  {slot.map((rune) => (
+                    <RuneEntry key={rune.id} rune={rune} />
+                  ))}
+                </div>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function RuneEntry({ rune }: { rune: Rune }) {
+  return (
+    <div className="rune-entry">
+      <span className="entity-name">{rune.name}</span>
+      <p>{rune.shortDesc}</p>
+    </div>
+  );
+}

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,0 +1,36 @@
+import { useState, useEffect, useCallback } from "react";
+import { loadGameData, type LoadedGameData } from "../lib/data-ingest";
+
+interface UseGameDataResult {
+  data: LoadedGameData | null;
+  loading: boolean;
+  error: string | null;
+  refresh: () => void;
+}
+
+export function useGameData(): UseGameDataResult {
+  const [data, setData] = useState<LoadedGameData | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(() => {
+    setLoading(true);
+    setError(null);
+
+    loadGameData()
+      .then((result) => {
+        setData(result);
+        setLoading(false);
+      })
+      .catch((err) => {
+        setError(err instanceof Error ? err.message : String(err));
+        setLoading(false);
+      });
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return { data, loading, error, refresh: load };
+}

--- a/src/lib/data-ingest/cache.test.ts
+++ b/src/lib/data-ingest/cache.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { mapToObject, objectToMap } from "./cache";
+
+describe("mapToObject", () => {
+  it("converts a string-keyed Map to a plain object", () => {
+    const map = new Map([
+      ["a", 1],
+      ["b", 2],
+    ]);
+    expect(mapToObject(map)).toEqual({ a: 1, b: 2 });
+  });
+
+  it("converts a number-keyed Map to a plain object", () => {
+    const map = new Map([
+      [1001, { name: "Boots" }],
+      [1002, { name: "Cloak" }],
+    ]);
+    expect(mapToObject(map)).toEqual({
+      "1001": { name: "Boots" },
+      "1002": { name: "Cloak" },
+    });
+  });
+
+  it("handles an empty Map", () => {
+    const map = new Map();
+    expect(mapToObject(map)).toEqual({});
+  });
+});
+
+describe("objectToMap", () => {
+  it("converts a plain object to a string-keyed Map", () => {
+    const obj = { a: 1, b: 2 };
+    const map = objectToMap<string, number>(obj);
+    expect(map.get("a")).toBe(1);
+    expect(map.get("b")).toBe(2);
+    expect(map.size).toBe(2);
+  });
+
+  it("converts a plain object to a number-keyed Map", () => {
+    const obj = { "1001": { name: "Boots" }, "1002": { name: "Cloak" } };
+    const map = objectToMap<number, { name: string }>(obj, "number");
+    expect(map.get(1001)).toEqual({ name: "Boots" });
+    expect(map.get(1002)).toEqual({ name: "Cloak" });
+  });
+
+  it("handles an empty object", () => {
+    const map = objectToMap({});
+    expect(map.size).toBe(0);
+  });
+
+  it("roundtrips with mapToObject", () => {
+    const original = new Map([
+      ["aatrox", { id: "Aatrox", name: "Aatrox" }],
+      ["ahri", { id: "Ahri", name: "Ahri" }],
+    ]);
+    const obj = mapToObject(original);
+    const restored = objectToMap<string, { id: string; name: string }>(obj);
+    expect(restored).toEqual(original);
+  });
+});

--- a/src/lib/data-ingest/cache.ts
+++ b/src/lib/data-ingest/cache.ts
@@ -1,0 +1,54 @@
+/**
+ * Cache layer for game data. Uses localStorage in the browser (Tauri webview)
+ * and falls back gracefully if unavailable.
+ */
+
+// Bump this version when the cache schema changes to invalidate stale data
+const CACHE_VERSION = 2;
+const CACHE_PREFIX = `champ-sage:v${CACHE_VERSION}:`;
+
+export async function readCache<T>(key: string): Promise<T | null> {
+  try {
+    const raw = localStorage.getItem(`${CACHE_PREFIX}${key}`);
+    if (!raw) return null;
+    return JSON.parse(raw) as T;
+  } catch {
+    return null;
+  }
+}
+
+export async function writeCache<T>(key: string, data: T): Promise<void> {
+  try {
+    localStorage.setItem(`${CACHE_PREFIX}${key}`, JSON.stringify(data));
+  } catch {
+    // localStorage may be full or unavailable — silently skip
+  }
+}
+
+/**
+ * Serialize a Map to a plain object for JSON caching.
+ */
+export function mapToObject<V>(
+  map: Map<string | number, V>
+): Record<string, V> {
+  const obj: Record<string, V> = {};
+  for (const [k, v] of map) {
+    obj[String(k)] = v;
+  }
+  return obj;
+}
+
+/**
+ * Deserialize a plain object back to a Map.
+ */
+export function objectToMap<K extends string | number, V>(
+  obj: Record<string, V>,
+  keyType: "string" | "number" = "string"
+): Map<K, V> {
+  const map = new Map<K, V>();
+  for (const [k, v] of Object.entries(obj)) {
+    const key = (keyType === "number" ? Number(k) : k) as K;
+    map.set(key, v);
+  }
+  return map;
+}

--- a/src/lib/data-ingest/entity-dictionary.test.ts
+++ b/src/lib/data-ingest/entity-dictionary.test.ts
@@ -1,0 +1,149 @@
+import { describe, it, expect } from "vitest";
+import { buildEntityDictionary } from "./entity-dictionary";
+import type { Champion, Item, Augment } from "./types";
+
+const mockChampions = new Map<string, Champion>([
+  [
+    "aurelion sol",
+    {
+      id: "AurelionSol",
+      key: 136,
+      name: "Aurelion Sol",
+      title: "The Star Forger",
+      tags: ["Mage"],
+      partype: "Mana",
+      stats: {} as Champion["stats"],
+      image: "",
+    },
+  ],
+  [
+    "miss fortune",
+    {
+      id: "MissFortune",
+      key: 21,
+      name: "Miss Fortune",
+      title: "the Bounty Hunter",
+      tags: ["Marksman"],
+      partype: "Mana",
+      stats: {} as Champion["stats"],
+      image: "",
+    },
+  ],
+]);
+
+const mockItems = new Map<number, Item>([
+  [
+    3089,
+    {
+      id: 3089,
+      name: "Rabadon's Deathcap",
+      description: "Greatly increases AP",
+      plaintext: "",
+      gold: { base: 1100, total: 3600, sell: 2520, purchasable: true },
+      tags: [],
+      stats: {},
+      image: "",
+      mode: "standard",
+    },
+  ],
+  [
+    3157,
+    {
+      id: 3157,
+      name: "Zhonya's Hourglass",
+      description: "Stasis active",
+      plaintext: "",
+      gold: { base: 650, total: 3250, sell: 2275, purchasable: true },
+      tags: [],
+      stats: {},
+      image: "",
+      mode: "standard",
+    },
+  ],
+]);
+
+const mockAugments = new Map<string, Augment>([
+  [
+    "typhoon",
+    {
+      name: "Typhoon",
+      description: "Storms around you",
+      tier: "Gold",
+      set: "-",
+      mode: "mayhem",
+    },
+  ],
+  [
+    "quantum computing",
+    {
+      name: "Quantum Computing",
+      description: "Reduces cooldowns",
+      tier: "Prismatic",
+      set: "-",
+      mode: "mayhem",
+    },
+  ],
+]);
+
+describe("buildEntityDictionary", () => {
+  const dict = buildEntityDictionary(mockChampions, mockItems, mockAugments);
+
+  it("includes all entity names", () => {
+    expect(dict.allNames).toHaveLength(6);
+    expect(dict.champions).toHaveLength(2);
+    expect(dict.items).toHaveLength(2);
+    expect(dict.augments).toHaveLength(2);
+  });
+
+  it("contains correct champion names", () => {
+    expect(dict.champions).toContain("Aurelion Sol");
+    expect(dict.champions).toContain("Miss Fortune");
+  });
+
+  it("contains correct item names", () => {
+    expect(dict.items).toContain("Rabadon's Deathcap");
+    expect(dict.items).toContain("Zhonya's Hourglass");
+  });
+
+  it("contains correct augment names", () => {
+    expect(dict.augments).toContain("Typhoon");
+    expect(dict.augments).toContain("Quantum Computing");
+  });
+
+  it("finds exact matches with highest score", () => {
+    const results = dict.search("Typhoon");
+    expect(results[0].name).toBe("Typhoon");
+    expect(results[0].type).toBe("augment");
+    expect(results[0].score).toBe(1);
+  });
+
+  it("finds case-insensitive matches", () => {
+    const results = dict.search("typhoon");
+    expect(results[0].name).toBe("Typhoon");
+  });
+
+  it("finds partial matches", () => {
+    const results = dict.search("aurelion");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].name).toBe("Aurelion Sol");
+    expect(results[0].type).toBe("champion");
+  });
+
+  it("finds fuzzy matches with typos", () => {
+    const results = dict.search("rabadons");
+    expect(results.length).toBeGreaterThan(0);
+    expect(results[0].name).toBe("Rabadon's Deathcap");
+  });
+
+  it("returns empty array for nonsense queries", () => {
+    const results = dict.search("xyzxyzxyz");
+    expect(results).toHaveLength(0);
+  });
+
+  it("returns results sorted by score descending", () => {
+    const results = dict.search("miss");
+    for (let i = 1; i < results.length; i++) {
+      expect(results[i].score).toBeLessThanOrEqual(results[i - 1].score);
+    }
+  });
+});

--- a/src/lib/data-ingest/entity-dictionary.ts
+++ b/src/lib/data-ingest/entity-dictionary.ts
@@ -1,0 +1,120 @@
+import type {
+  Champion,
+  Item,
+  Augment,
+  EntityDictionary,
+  EntityMatch,
+} from "./types";
+
+interface NameEntry {
+  name: string;
+  type: EntityMatch["type"];
+  nameLower: string;
+}
+
+export function buildEntityDictionary(
+  champions: Map<string, Champion>,
+  items: Map<number, Item>,
+  augments: Map<string, Augment>
+): EntityDictionary {
+  const entries: NameEntry[] = [];
+  const championNames: string[] = [];
+  const itemNames: string[] = [];
+  const augmentNames: string[] = [];
+
+  for (const champ of champions.values()) {
+    entries.push({
+      name: champ.name,
+      type: "champion",
+      nameLower: champ.name.toLowerCase(),
+    });
+    championNames.push(champ.name);
+  }
+
+  for (const item of items.values()) {
+    entries.push({
+      name: item.name,
+      type: "item",
+      nameLower: item.name.toLowerCase(),
+    });
+    itemNames.push(item.name);
+  }
+
+  for (const aug of augments.values()) {
+    entries.push({
+      name: aug.name,
+      type: "augment",
+      nameLower: aug.name.toLowerCase(),
+    });
+    augmentNames.push(aug.name);
+  }
+
+  const allNames = [...championNames, ...itemNames, ...augmentNames];
+
+  return {
+    allNames,
+    champions: championNames,
+    items: itemNames,
+    augments: augmentNames,
+    search(query: string): EntityMatch[] {
+      return fuzzySearch(entries, query);
+    },
+  };
+}
+
+function fuzzySearch(entries: NameEntry[], query: string): EntityMatch[] {
+  const queryLower = query.toLowerCase();
+  const results: EntityMatch[] = [];
+
+  for (const entry of entries) {
+    const score = fuzzyScore(entry.nameLower, queryLower);
+    if (score > 0) {
+      results.push({ name: entry.name, type: entry.type, score });
+    }
+  }
+
+  results.sort((a, b) => b.score - a.score);
+  return results;
+}
+
+/**
+ * Score how well a query matches a name. Returns 0-1.
+ * - 1.0: exact match
+ * - 0.9: case-insensitive exact match
+ * - 0.8: name starts with query
+ * - 0.7: name contains query as a substring
+ * - 0.3-0.6: fuzzy character match (all query chars appear in order)
+ * - 0: no match
+ */
+function fuzzyScore(nameLower: string, queryLower: string): number {
+  if (nameLower === queryLower) return 1;
+
+  // Strip common punctuation for matching (e.g., "rabadons" vs "rabadon's")
+  const nameStripped = nameLower.replace(/[^a-z0-9\s]/g, "");
+  const queryStripped = queryLower.replace(/[^a-z0-9\s]/g, "");
+
+  if (nameStripped === queryStripped) return 0.9;
+  if (nameStripped.startsWith(queryStripped)) return 0.8;
+  if (nameStripped.includes(queryStripped)) return 0.7;
+
+  // Fuzzy: all query characters appear in order in the name
+  let nameIdx = 0;
+  let matched = 0;
+  for (let i = 0; i < queryStripped.length; i++) {
+    const ch = queryStripped[i];
+    while (nameIdx < nameStripped.length) {
+      if (nameStripped[nameIdx] === ch) {
+        matched++;
+        nameIdx++;
+        break;
+      }
+      nameIdx++;
+    }
+  }
+
+  if (matched === queryStripped.length && queryStripped.length > 1) {
+    return 0.3 + 0.3 * (matched / nameStripped.length);
+  }
+
+  return 0;
+}

--- a/src/lib/data-ingest/index.test.ts
+++ b/src/lib/data-ingest/index.test.ts
@@ -1,0 +1,153 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { loadGameData } from "./index";
+import * as dataDragon from "./sources/data-dragon";
+import * as wikiAugments from "./sources/wiki-augments";
+import * as communityDragon from "./sources/community-dragon";
+import * as cache from "./cache";
+import type { Champion, Item, Augment, RuneTree } from "./types";
+
+vi.mock("./sources/data-dragon");
+vi.mock("./sources/wiki-augments");
+vi.mock("./sources/community-dragon");
+vi.mock("./cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof cache>();
+  return {
+    ...actual,
+    readCache: vi.fn(),
+    writeCache: vi.fn(),
+  };
+});
+
+const mockChampions = new Map<string, Champion>([
+  [
+    "aatrox",
+    {
+      id: "Aatrox",
+      key: 266,
+      name: "Aatrox",
+      title: "the Darkin Blade",
+      tags: ["Fighter"],
+      partype: "Blood Well",
+      stats: {} as Champion["stats"],
+      image: "",
+    },
+  ],
+]);
+
+const mockItems = new Map<number, Item>([
+  [
+    1001,
+    {
+      id: 1001,
+      name: "Boots",
+      description: "Move Speed",
+      plaintext: "",
+      gold: { base: 300, total: 300, sell: 210, purchasable: true },
+      tags: [],
+      stats: {},
+      image: "",
+      mode: "standard",
+    },
+  ],
+]);
+
+const mockRunes: RuneTree[] = [
+  {
+    id: 8100,
+    key: "Domination",
+    name: "Domination",
+    icon: "",
+    keystones: [],
+    slots: [],
+  },
+];
+
+const mockAugments = new Map<string, Augment>([
+  [
+    "typhoon",
+    {
+      name: "Typhoon",
+      description: "Storm damage",
+      tier: "Gold",
+      set: "-",
+      mode: "mayhem",
+    },
+  ],
+]);
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  vi.mocked(cache.readCache).mockResolvedValue(null);
+  vi.mocked(cache.writeCache).mockResolvedValue(undefined);
+  vi.mocked(dataDragon.fetchLatestVersion).mockResolvedValue("15.6.1");
+  vi.mocked(dataDragon.fetchChampions).mockResolvedValue(mockChampions);
+  vi.mocked(dataDragon.fetchItems).mockResolvedValue(mockItems);
+  vi.mocked(dataDragon.fetchRunes).mockResolvedValue(mockRunes);
+  vi.mocked(wikiAugments.fetchWikiAugments).mockResolvedValue(mockAugments);
+  vi.mocked(communityDragon.mergeAugmentIds).mockResolvedValue(undefined);
+});
+
+describe("loadGameData", () => {
+  it("fetches and returns all game data", async () => {
+    const data = await loadGameData();
+
+    expect(data.version).toBe("15.6.1");
+    expect(data.champions.size).toBe(1);
+    expect(data.items.size).toBe(1);
+    expect(data.runes).toHaveLength(1);
+    expect(data.augments.size).toBe(1);
+  });
+
+  it("calls all data sources", async () => {
+    await loadGameData();
+
+    expect(dataDragon.fetchLatestVersion).toHaveBeenCalled();
+    expect(dataDragon.fetchChampions).toHaveBeenCalledWith("15.6.1");
+    expect(dataDragon.fetchItems).toHaveBeenCalledWith("15.6.1");
+    expect(dataDragon.fetchRunes).toHaveBeenCalledWith("15.6.1");
+    expect(wikiAugments.fetchWikiAugments).toHaveBeenCalled();
+    expect(communityDragon.mergeAugmentIds).toHaveBeenCalledWith(mockAugments);
+  });
+
+  it("writes fetched data to cache", async () => {
+    await loadGameData();
+
+    expect(cache.writeCache).toHaveBeenCalled();
+  });
+
+  it("returns cached data when available (production mode)", async () => {
+    // loadGameData skips cache in dev mode, so simulate production
+    const origDev = import.meta.env.DEV;
+    import.meta.env.DEV = false;
+
+    vi.mocked(cache.readCache).mockResolvedValue({
+      version: "15.5.1",
+      champions: { aatrox: mockChampions.get("aatrox") },
+      items: { "1001": mockItems.get(1001) },
+      runes: mockRunes,
+      augments: { typhoon: mockAugments.get("typhoon") },
+    });
+
+    const data = await loadGameData();
+
+    expect(data.version).toBe("15.5.1");
+    expect(data.champions.size).toBe(1);
+    // Should not have called network fetchers
+    expect(dataDragon.fetchLatestVersion).not.toHaveBeenCalled();
+
+    import.meta.env.DEV = origDev;
+  });
+
+  it("returns entity dictionary that can search", async () => {
+    const data = await loadGameData();
+
+    expect(data.dictionary).toBeDefined();
+    expect(data.dictionary.champions).toContain("Aatrox");
+    expect(data.dictionary.items).toContain("Boots");
+    expect(data.dictionary.augments).toContain("Typhoon");
+
+    const results = data.dictionary.search("aatrox");
+    expect(results[0].name).toBe("Aatrox");
+    expect(results[0].type).toBe("champion");
+  });
+});

--- a/src/lib/data-ingest/index.ts
+++ b/src/lib/data-ingest/index.ts
@@ -1,0 +1,86 @@
+import type {
+  GameData,
+  Champion,
+  Item,
+  Augment,
+  RuneTree,
+  EntityDictionary,
+} from "./types";
+import {
+  fetchLatestVersion,
+  fetchChampions,
+  fetchItems,
+  fetchRunes,
+} from "./sources/data-dragon";
+import { fetchWikiAugments } from "./sources/wiki-augments";
+import { mergeAugmentIds } from "./sources/community-dragon";
+import { readCache, writeCache, mapToObject, objectToMap } from "./cache";
+import { buildEntityDictionary } from "./entity-dictionary";
+
+const CACHE_KEY = "game-data";
+
+interface CachedGameData {
+  version: string;
+  champions: Record<string, Champion>;
+  items: Record<string, Item>;
+  runes: RuneTree[];
+  augments: Record<string, Augment>;
+}
+
+export interface LoadedGameData extends GameData {
+  dictionary: EntityDictionary;
+}
+
+export async function loadGameData(): Promise<LoadedGameData> {
+  // Skip cache in dev mode so hot reload always shows fresh data
+  if (import.meta.env.DEV) {
+    return fetchAndCache();
+  }
+
+  const cached = await readCache<CachedGameData>(CACHE_KEY);
+  if (cached) {
+    return fromCached(cached);
+  }
+
+  return fetchAndCache();
+}
+
+export async function fetchAndCache(): Promise<LoadedGameData> {
+  const version = await fetchLatestVersion();
+  const [champions, items, runes, augments] = await Promise.all([
+    fetchChampions(version),
+    fetchItems(version),
+    fetchRunes(version),
+    fetchWikiAugments(),
+  ]);
+
+  await mergeAugmentIds(augments);
+
+  const data: CachedGameData = {
+    version,
+    champions: mapToObject(champions),
+    items: mapToObject(items),
+    runes,
+    augments: mapToObject(augments),
+  };
+
+  await writeCache(CACHE_KEY, data);
+
+  return fromCached(data);
+}
+
+function fromCached(cached: CachedGameData): LoadedGameData {
+  const champions = objectToMap<string, Champion>(cached.champions);
+  const items = objectToMap<number, Item>(cached.items, "number");
+  const augments = objectToMap<string, Augment>(cached.augments);
+  const dictionary = buildEntityDictionary(champions, items, augments);
+
+  return {
+    version: cached.version,
+    champions,
+    items,
+    runes: cached.runes,
+    augments,
+    dictionary,
+  };
+}

--- a/src/lib/data-ingest/parsers/lua-parser.test.ts
+++ b/src/lib/data-ingest/parsers/lua-parser.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect } from "vitest";
+import { parseLuaTable } from "./lua-parser";
+
+describe("parseLuaTable", () => {
+  it("parses a simple Lua table with string values", () => {
+    const lua = `return {
+      ["Foo"] = {
+        ["name"] = "Foo Bar",
+        ["tier"] = "Gold",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(result).toEqual({
+      Foo: { name: "Foo Bar", tier: "Gold" },
+    });
+  });
+
+  it("parses multiple entries", () => {
+    const lua = `return {
+      ["ADAPt"] = {
+        ["description"] = "Convert all bonus AD into AP.",
+        ["tier"] = "Silver",
+        ["set"] = "-",
+      },
+      ["Adamant"] = {
+        ["description"] = "Immobilizing grants shield.",
+        ["tier"] = "Silver",
+        ["set"] = "-",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result["ADAPt"].description).toBe("Convert all bonus AD into AP.");
+    expect(result["Adamant"].tier).toBe("Silver");
+  });
+
+  it("handles escaped quotes in strings", () => {
+    const lua = `return {
+      ["Test"] = {
+        ["description"] = "Deal \\"bonus\\" damage.",
+        ["tier"] = "Gold",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(result["Test"].description).toBe('Deal "bonus" damage.');
+  });
+
+  it("handles multiline descriptions", () => {
+    const lua = `return {
+      ["Test"] = {
+        ["description"] = "Line one. Line two.",
+        ["tier"] = "Prismatic",
+        ["set"] = "-",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(result["Test"].description).toBe("Line one. Line two.");
+  });
+
+  it("handles numeric values", () => {
+    const lua = `return {
+      ["Test"] = {
+        ["count"] = 5,
+        ["name"] = "Test",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(result["Test"].count).toBe(5);
+  });
+
+  it("handles empty table", () => {
+    const lua = "return {}";
+    const result = parseLuaTable(lua);
+    expect(result).toEqual({});
+  });
+
+  it("handles descriptions containing double curly braces (wiki templates)", () => {
+    const lua = `return {
+      ["Blunt Force"] = {
+        ["description"] = "Increases {{as|attack damage}} by {{as|20%|AD}}.",
+        ["tier"] = "Silver",
+        ["set"] = "-",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(result["Blunt Force"].tier).toBe("Silver");
+    expect(result["Blunt Force"].set).toBe("-");
+    expect(result["Blunt Force"].description).toContain("{{as|attack damage}}");
+  });
+
+  it("handles complex real-world wiki entries with nested templates", () => {
+    const lua = `return {
+      ["Buff Buddies"] = {
+        ["description"] = "Grants the {{bi|Crest of Cinders}} and {{bi|Crest of Insight}} buffs permanently.<br><br>{{sbc|Crest of Cinders:}} Empowers attacks to {{tip|slow}} by {{rd|10;15;20|5;7.5;10|levels=1;6;11|key=%|pp=true}} for 3 seconds.",
+        ["tier"] = "Gold",
+        ["set"] = "[[File:Archmage set mayhem.png|30px|link=]] [[ARAM:_Mayhem/Augment_Sets|Archmage]]",
+      },
+      ["Deft"] = {
+        ["description"] = "Grants {{as|60% '''bonus''' attack speed}}.",
+        ["tier"] = "Prismatic",
+        ["set"] = "-",
+      },
+    }`;
+    const result = parseLuaTable(lua);
+    expect(Object.keys(result)).toHaveLength(2);
+    expect(result["Buff Buddies"].tier).toBe("Gold");
+    expect(result["Buff Buddies"].set).toContain("Archmage");
+    expect(result["Deft"].tier).toBe("Prismatic");
+  });
+
+  it("strips the return keyword and handles whitespace", () => {
+    const lua = `  return  {
+      ["A"] = {
+        ["x"] = "y",
+      },
+    }  `;
+    const result = parseLuaTable(lua);
+    expect(result["A"].x).toBe("y");
+  });
+});

--- a/src/lib/data-ingest/parsers/lua-parser.ts
+++ b/src/lib/data-ingest/parsers/lua-parser.ts
@@ -1,0 +1,69 @@
+import * as luaparse from "luaparse";
+
+/**
+ * Parse a Lua table string (as returned by the League Wiki module) into a
+ * plain JS object. Uses luaparse for proper AST-based parsing rather than
+ * regex, which is necessary because wiki augment descriptions contain
+ * double curly braces `}}` that break naive pattern matching.
+ */
+export function parseLuaTable(
+  lua: string
+): Record<string, Record<string, string | number>> {
+  // Strip HTML comment wrapper that the wiki sometimes adds
+  const cleaned = lua
+    .replace(/^--\s*<pre>\s*\n?/, "")
+    .replace(/\n?--\s*<\/pre>\s*$/, "");
+
+  const ast = luaparse.parse(cleaned, { encodingMode: "x-user-defined" });
+  const result: Record<string, Record<string, string | number>> = {};
+
+  // The AST should be: Chunk > ReturnStatement > TableConstructorExpression
+  const returnStmt = ast.body[0];
+  if (!returnStmt || returnStmt.type !== "ReturnStatement") return result;
+
+  const table = returnStmt.arguments[0];
+  if (!table || table.type !== "TableConstructorExpression") return result;
+
+  for (const field of table.fields) {
+    if (field.type !== "TableKey") continue;
+
+    const entryKey = extractString(field.key);
+    if (!entryKey) continue;
+
+    if (field.value.type !== "TableConstructorExpression") continue;
+
+    const fields: Record<string, string | number> = {};
+    for (const innerField of field.value.fields) {
+      if (innerField.type !== "TableKey") continue;
+      const fieldName = extractString(innerField.key);
+      if (!fieldName) continue;
+
+      const value = extractValue(innerField.value);
+      if (value !== null) {
+        fields[fieldName] = value;
+      }
+    }
+
+    result[entryKey] = fields;
+  }
+
+  return result;
+}
+
+function extractString(node: luaparse.Node): string | null {
+  if (node.type === "StringLiteral") {
+    // raw includes quotes, so strip them
+    return node.raw.slice(1, -1).replace(/\\"/g, '"');
+  }
+  return null;
+}
+
+function extractValue(node: luaparse.Node): string | number | null {
+  if (node.type === "StringLiteral") {
+    return node.raw.slice(1, -1).replace(/\\"/g, '"');
+  }
+  if (node.type === "NumericLiteral") {
+    return node.value;
+  }
+  return null;
+}

--- a/src/lib/data-ingest/parsers/wiki-markup.test.ts
+++ b/src/lib/data-ingest/parsers/wiki-markup.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { stripWikiMarkup } from "./wiki-markup";
+
+describe("stripWikiMarkup", () => {
+  it("strips bold markers", () => {
+    expect(stripWikiMarkup("'''bonus''' attack damage")).toBe(
+      "bonus attack damage"
+    );
+  });
+
+  it("strips italic markers", () => {
+    expect(stripWikiMarkup("''italic'' text")).toBe("italic text");
+  });
+
+  it("strips {{as|...}} templates (stat references)", () => {
+    expect(stripWikiMarkup("{{as|'''bonus''' attack damage}}")).toBe(
+      "bonus attack damage"
+    );
+  });
+
+  it("strips {{tip|...|...}} templates (tooltips)", () => {
+    expect(stripWikiMarkup("{{tip|immobilize|Immobilizing}} a target")).toBe(
+      "Immobilizing a target"
+    );
+  });
+
+  it("strips {{pp|...}} templates (per-level values)", () => {
+    expect(stripWikiMarkup("deals {{pp|10;20;30}} damage")).toBe(
+      "deals 10;20;30 damage"
+    );
+  });
+
+  it("strips [[link]] wiki links, keeping display text", () => {
+    expect(stripWikiMarkup("[[Attack damage|AD]]")).toBe("AD");
+  });
+
+  it("strips [[simple link]] wiki links", () => {
+    expect(stripWikiMarkup("[[Attack damage]]")).toBe("Attack damage");
+  });
+
+  it("handles multiple templates in one string", () => {
+    const input =
+      "{{tip|immobilize|Immobilizing}} grants {{as|'''50''' armor}} for '''3''' seconds.";
+    const expected = "Immobilizing grants 50 armor for 3 seconds.";
+    expect(stripWikiMarkup(input)).toBe(expected);
+  });
+
+  it("strips nested bold inside templates", () => {
+    expect(stripWikiMarkup("{{as|'''100%''' bonus AD}}")).toBe("100% bonus AD");
+  });
+
+  it("returns plain text unchanged", () => {
+    expect(stripWikiMarkup("plain text")).toBe("plain text");
+  });
+
+  it("handles empty string", () => {
+    expect(stripWikiMarkup("")).toBe("");
+  });
+
+  it("strips HTML-like tags", () => {
+    expect(stripWikiMarkup("<br>new line<br/>")).toBe("new line");
+  });
+
+  it("strips [[[File:...] wiki file references", () => {
+    expect(
+      stripWikiMarkup("[[[File:High Roller set mayhem.png|25px|link=]")
+    ).toBe("");
+  });
+
+  it("strips file references embedded in text", () => {
+    expect(
+      stripWikiMarkup(
+        "Transmute: Prismatic [[[File:High Roller set mayhem.png|25px|link=]"
+      )
+    ).toBe("Transmute: Prismatic");
+  });
+
+  it("strips [[File:...]] standard wiki file embeds", () => {
+    expect(stripWikiMarkup("Set: [[File:icon.png|20px]] Enforcers")).toBe(
+      "Set: Enforcers"
+    );
+  });
+});

--- a/src/lib/data-ingest/parsers/wiki-markup.ts
+++ b/src/lib/data-ingest/parsers/wiki-markup.ts
@@ -1,0 +1,58 @@
+/**
+ * Strip League Wiki markup from augment descriptions, producing plain text.
+ *
+ * Handles these common patterns:
+ * - {{as|content}} → content
+ * - {{tip|key|display}} → display
+ * - {{pp|values}} → values
+ * - {{other|...}} → last parameter (display text)
+ * - [[Page|display]] → display
+ * - [[Page]] → Page
+ * - '''bold''' → bold
+ * - ''italic'' → italic
+ * - <br>, <br/>, and other HTML tags → removed
+ */
+export function stripWikiMarkup(text: string): string {
+  let result = text;
+
+  // Strip HTML tags
+  result = result.replace(/<[^>]+>/g, "");
+
+  // Strip [[[File:...|...] wiki file references (malformed triple-bracket)
+  result = result.replace(/\[\[\[File:[^\]]*\]/g, "");
+
+  // Strip [[File:...|...]] standard wiki file embeds
+  result = result.replace(/\[\[File:[^\]]*\]\]/g, "");
+
+  // Strip {{tip|key|display}} → display (second param)
+  result = result.replace(/\{\{tip\|[^|]*\|([^}]*)\}\}/g, "$1");
+
+  // Strip {{as|content}} → content
+  result = result.replace(/\{\{as\|([^}]*)\}\}/g, "$1");
+
+  // Strip {{pp|values}} → values
+  result = result.replace(/\{\{pp\|([^}]*)\}\}/g, "$1");
+
+  // Strip any remaining {{template|...|display}} → last param
+  result = result.replace(/\{\{[^|]*\|(?:[^|]*\|)*([^}]*)\}\}/g, "$1");
+
+  // Strip any remaining {{template}} with no params
+  result = result.replace(/\{\{[^}]*\}\}/g, "");
+
+  // Strip [[Page|display]] → display
+  result = result.replace(/\[\[[^|\]]*\|([^\]]*)\]\]/g, "$1");
+
+  // Strip [[Page]] → Page
+  result = result.replace(/\[\[([^\]]*)\]\]/g, "$1");
+
+  // Strip bold '''text''' → text
+  result = result.replace(/'''([^']*?)'''/g, "$1");
+
+  // Strip italic ''text'' → text
+  result = result.replace(/''([^']*?)''/g, "$1");
+
+  // Collapse multiple spaces left by removals
+  result = result.replace(/ {2,}/g, " ");
+
+  return result.trim();
+}

--- a/src/lib/data-ingest/sources/community-dragon.test.ts
+++ b/src/lib/data-ingest/sources/community-dragon.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { mergeAugmentIds, classifyAugmentMode } from "./community-dragon";
+import type { Augment } from "../types";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+describe("classifyAugmentMode", () => {
+  it("classifies UX/Kiwi/ paths as mayhem", () => {
+    expect(
+      classifyAugmentMode(
+        "/lol-game-data/assets/ASSETS/UX/Kiwi/Augments/Icons/ADAPt_small.png"
+      )
+    ).toBe("mayhem");
+  });
+
+  it("classifies Cherry/...Kiwi/ paths as mayhem", () => {
+    expect(
+      classifyAugmentMode(
+        "/lol-game-data/assets/ASSETS/UX/Cherry/Augments/Icons/Kiwi/ADAPt_small.png"
+      )
+    ).toBe("mayhem");
+  });
+
+  it("classifies Cherry paths without Kiwi as arena", () => {
+    expect(
+      classifyAugmentMode(
+        "/lol-game-data/assets/ASSETS/UX/Cherry/Augments/Icons/AllForYou_small.png"
+      )
+    ).toBe("arena");
+  });
+
+  it("classifies Strawberry paths as swarm", () => {
+    expect(
+      classifyAugmentMode(
+        "/lol-game-data/assets/ASSETS/UX/Strawberry/UpgradeSelection/Icons/ArmorUp_Large.png"
+      )
+    ).toBe("swarm");
+  });
+
+  it("classifies Swarm paths as swarm", () => {
+    expect(
+      classifyAugmentMode(
+        "/lol-game-data/assets/ASSETS/UX/Swarm/Augments/Icons/BattleBunny_small.png"
+      )
+    ).toBe("swarm");
+  });
+
+  it("classifies unknown paths as unknown", () => {
+    expect(classifyAugmentMode("/some/other/path.png")).toBe("unknown");
+  });
+});
+
+describe("mergeAugmentIds", () => {
+  it("merges CDragon IDs into matching wiki augments without overwriting mode", async () => {
+    const augments = new Map<string, Augment>([
+      [
+        "adapt",
+        {
+          name: "ADAPt",
+          description: "test",
+          tier: "Silver",
+          set: "-",
+          mode: "mayhem",
+        },
+      ],
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 205,
+            nameTRA: "ADAPt",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Cherry/Augments/Icons/ADAPt_small.png",
+            rarity: "kSilver",
+          },
+        ]),
+    });
+
+    await mergeAugmentIds(augments);
+    expect(augments.get("adapt")!.id).toBe(205);
+    expect(augments.get("adapt")!.mode).toBe("mayhem"); // mode NOT overwritten
+  });
+
+  it("handles punctuation differences in name matching", async () => {
+    const augments = new Map<string, Augment>([
+      [
+        "get excited",
+        {
+          name: "Get Excited",
+          description: "test",
+          tier: "Gold",
+          set: "-",
+          mode: "mayhem",
+        },
+      ],
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 999,
+            nameTRA: "Get Excited!",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Kiwi/Augments/Icons/GetExcited_small.png",
+            rarity: "kGold",
+          },
+        ]),
+    });
+
+    await mergeAugmentIds(augments);
+    expect(augments.get("get excited")!.id).toBe(999);
+  });
+
+  it("adds unmatched CDragon augments with their classified mode", async () => {
+    const augments = new Map<string, Augment>();
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 309,
+            nameTRA: "And My Axe!",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Cherry/Augments/Icons/AndMyAxe_small.png",
+            rarity: "kGold",
+          },
+        ]),
+    });
+
+    await mergeAugmentIds(augments);
+    const aug = augments.get("and my axe!");
+    expect(aug).toBeDefined();
+    expect(aug!.mode).toBe("arena");
+    expect(aug!.id).toBe(309);
+    expect(aug!.description).toBe("");
+  });
+
+  it("adds Strawberry augments classified as swarm", async () => {
+    const augments = new Map<string, Augment>();
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 500,
+            nameTRA: "Armor Up",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Strawberry/UpgradeSelection/Icons/ArmorUp_Large.png",
+            rarity: "kGold",
+          },
+        ]),
+    });
+
+    await mergeAugmentIds(augments);
+    const aug = augments.get("armor up");
+    expect(aug).toBeDefined();
+    expect(aug!.mode).toBe("swarm");
+  });
+
+  it("prefers Mayhem-mode CDragon entries over Arena duplicates for wiki augments", async () => {
+    const augments = new Map<string, Augment>([
+      [
+        "adapt",
+        {
+          name: "ADAPt",
+          description: "test",
+          tier: "Silver",
+          set: "-",
+          mode: "mayhem",
+        },
+      ],
+    ]);
+
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: () =>
+        Promise.resolve([
+          {
+            id: 205,
+            nameTRA: "ADAPt",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Cherry/Augments/Icons/ADAPt_small.png",
+            rarity: "kSilver",
+          },
+          {
+            id: 1205,
+            nameTRA: "ADAPt",
+            augmentSmallIconPath:
+              "/lol-game-data/assets/ASSETS/UX/Kiwi/Augments/Icons/ADAPt_small.png",
+            rarity: "kSilver",
+          },
+        ]),
+    });
+
+    await mergeAugmentIds(augments);
+    expect(augments.get("adapt")!.id).toBe(1205);
+    expect(augments.get("adapt")!.mode).toBe("mayhem"); // still mayhem
+  });
+});

--- a/src/lib/data-ingest/sources/community-dragon.ts
+++ b/src/lib/data-ingest/sources/community-dragon.ts
@@ -1,0 +1,136 @@
+import type { Augment, AugmentMode } from "../types";
+
+const CDRAGON_URL =
+  "https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/v1/cherry-augments.json";
+
+interface RawCDragonAugment {
+  id: number;
+  nameTRA: string;
+  augmentSmallIconPath: string;
+  rarity: string;
+}
+
+/**
+ * Classify an augment's mode based on its CDragon icon path.
+ * - Kiwi/ anywhere in path → mayhem (ARAM Mayhem)
+ * - Strawberry/ in path → swarm (Swarm mode, codename Strawberry)
+ * - Swarm/ in path → swarm
+ * - Cherry/ without Kiwi → arena (Arena mode, codename Cherry)
+ * - anything else → unknown
+ */
+export function classifyAugmentMode(iconPath: string): AugmentMode {
+  const lower = iconPath.toLowerCase();
+  if (lower.includes("kiwi/")) return "mayhem";
+  if (lower.includes("strawberry/")) return "swarm";
+  if (lower.includes("swarm/")) return "swarm";
+  if (lower.includes("cherry/")) return "arena";
+  return "unknown";
+}
+
+/**
+ * Normalize a name for matching: lowercase, strip punctuation.
+ * Handles cases like "Get Excited" vs "Get Excited!" and
+ * "Quest: Sneakerhead" vs "Sneakerhead".
+ */
+function normalizeForMatch(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9\s]/g, "")
+    .trim();
+}
+
+function normalizeRarity(rarity: string): Augment["tier"] {
+  if (rarity === "kGold") return "Gold";
+  if (rarity === "kPrismatic") return "Prismatic";
+  return "Silver";
+}
+
+function normalizePath(path: string): string {
+  const cleaned = path.replace("/lol-game-data/assets/", "").toLowerCase();
+  return `https://raw.communitydragon.org/latest/plugins/rcp-be-lol-game-data/global/default/${cleaned}`;
+}
+
+/**
+ * Fetch augment IDs and icons from Community Dragon, then:
+ * 1. Merge IDs/icons into existing wiki augments (matched by name)
+ *    WITHOUT overwriting their mode (wiki source is authoritative for mode)
+ * 2. Add any CDragon-only augments with their classified mode
+ *
+ * When duplicates exist (same name, different IDs), prefer the entry
+ * whose mode matches the existing augment's mode.
+ */
+export async function mergeAugmentIds(
+  augments: Map<string, Augment>
+): Promise<void> {
+  const res = await fetch(CDRAGON_URL);
+  if (!res.ok)
+    throw new Error(`Failed to fetch CDragon augments: ${res.status}`);
+  const raw: RawCDragonAugment[] = await res.json();
+
+  // Build a normalized-name lookup for wiki augments
+  const normalizedLookup = new Map<string, string>();
+  for (const key of augments.keys()) {
+    normalizedLookup.set(normalizeForMatch(key), key);
+  }
+
+  // Group CDragon entries by normalized name to handle duplicates
+  const grouped = new Map<string, RawCDragonAugment[]>();
+  for (const entry of raw) {
+    const normalized = normalizeForMatch(entry.nameTRA);
+    const list = grouped.get(normalized) ?? [];
+    list.push(entry);
+    grouped.set(normalized, list);
+  }
+
+  for (const [normalized, entries] of grouped) {
+    const existingKey = normalizedLookup.get(normalized);
+    const existing = existingKey ? augments.get(existingKey) : null;
+
+    // Pick the best entry: prefer one whose mode matches the existing augment
+    const best = pickBestEntry(entries, existing?.mode);
+
+    if (existing) {
+      // Merge ID and icon but DO NOT overwrite mode
+      existing.id = best.id;
+      existing.iconPath = normalizePath(best.augmentSmallIconPath);
+    } else {
+      // New augment not in wiki — add it with CDragon data and classified mode
+      const mode = classifyAugmentMode(best.augmentSmallIconPath);
+      const key = best.nameTRA.toLowerCase();
+      augments.set(key, {
+        name: best.nameTRA,
+        description: "",
+        tier: normalizeRarity(best.rarity),
+        set: "-",
+        mode,
+        id: best.id,
+        iconPath: normalizePath(best.augmentSmallIconPath),
+      });
+    }
+  }
+}
+
+function pickBestEntry(
+  entries: RawCDragonAugment[],
+  preferMode?: AugmentMode
+): RawCDragonAugment {
+  if (entries.length === 1) return entries[0];
+
+  if (preferMode) {
+    const preferred = entries.find(
+      (e) => classifyAugmentMode(e.augmentSmallIconPath) === preferMode
+    );
+    if (preferred) return preferred;
+  }
+
+  // Default: prefer mayhem > arena > swarm > unknown
+  const priority: AugmentMode[] = ["mayhem", "arena", "swarm", "unknown"];
+  for (const mode of priority) {
+    const match = entries.find(
+      (e) => classifyAugmentMode(e.augmentSmallIconPath) === mode
+    );
+    if (match) return match;
+  }
+
+  return entries[0];
+}

--- a/src/lib/data-ingest/sources/data-dragon.test.ts
+++ b/src/lib/data-ingest/sources/data-dragon.test.ts
@@ -1,0 +1,370 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchChampions, fetchItems, fetchRunes } from "./data-dragon";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+function jsonResponse(data: unknown) {
+  return { ok: true, json: () => Promise.resolve(data) };
+}
+
+describe("fetchChampions", () => {
+  it("normalizes champion data from DDragon format", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          Aatrox: {
+            id: "Aatrox",
+            key: "266",
+            name: "Aatrox",
+            title: "the Darkin Blade",
+            tags: ["Fighter", "Tank"],
+            partype: "Blood Well",
+            stats: {
+              hp: 650,
+              hpperlevel: 114,
+              mp: 0,
+              mpperlevel: 0,
+              movespeed: 345,
+              armor: 38,
+              armorperlevel: 4.8,
+              spellblock: 32,
+              spellblockperlevel: 2.05,
+              attackrange: 175,
+              hpregen: 3,
+              hpregenperlevel: 0.5,
+              mpregen: 0,
+              mpregenperlevel: 0,
+              attackdamage: 60,
+              attackdamageperlevel: 5,
+              attackspeed: 0.651,
+              attackspeedperlevel: 2.5,
+            },
+            image: { full: "Aatrox.png" },
+          },
+        },
+      })
+    );
+
+    const champions = await fetchChampions("15.6.1");
+    expect(champions.size).toBe(1);
+
+    const aatrox = champions.get("aatrox");
+    expect(aatrox).toBeDefined();
+    expect(aatrox!.name).toBe("Aatrox");
+    expect(aatrox!.key).toBe(266);
+    expect(aatrox!.tags).toEqual(["Fighter", "Tank"]);
+    expect(aatrox!.stats.hp).toBe(650);
+    expect(aatrox!.image).toContain("Aatrox.png");
+  });
+
+  it("keys champions by lowercase name", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          AurelionSol: {
+            id: "AurelionSol",
+            key: "136",
+            name: "Aurelion Sol",
+            title: "The Star Forger",
+            tags: ["Mage"],
+            partype: "Mana",
+            stats: {
+              hp: 620,
+              hpperlevel: 90,
+              mp: 530,
+              mpperlevel: 40,
+              movespeed: 335,
+              armor: 22,
+              armorperlevel: 4.6,
+              spellblock: 30,
+              spellblockperlevel: 1.3,
+              attackrange: 550,
+              hpregen: 5.5,
+              hpregenperlevel: 0.55,
+              mpregen: 8,
+              mpregenperlevel: 0.75,
+              attackdamage: 55,
+              attackdamageperlevel: 3.2,
+              attackspeed: 0.625,
+              attackspeedperlevel: 1.5,
+            },
+            image: { full: "AurelionSol.png" },
+          },
+        },
+      })
+    );
+
+    const champions = await fetchChampions("15.6.1");
+    expect(champions.has("aurelion sol")).toBe(true);
+    expect(champions.get("aurelion sol")!.id).toBe("AurelionSol");
+  });
+});
+
+describe("fetchItems", () => {
+  it("normalizes item data and strips HTML from descriptions", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "1001": {
+            name: "Boots",
+            description:
+              "<mainText><stats><attention>25</attention> Move Speed</stats></mainText>",
+            plaintext: "Slightly increases Move Speed",
+            gold: { base: 300, total: 300, sell: 210, purchasable: true },
+            tags: ["Boots"],
+            stats: { FlatMovementSpeedMod: 25 },
+            into: ["3005", "3047"],
+            image: { full: "1001.png" },
+          },
+        },
+      })
+    );
+
+    const items = await fetchItems("15.6.1");
+    expect(items.size).toBe(1);
+
+    const boots = items.get(1001);
+    expect(boots).toBeDefined();
+    expect(boots!.name).toBe("Boots");
+    expect(boots!.description).not.toContain("<");
+    expect(boots!.gold.total).toBe(300);
+    expect(boots!.into).toEqual([3005, 3047]);
+    expect(boots!.image).toContain("1001.png");
+  });
+
+  it("handles items without from/into arrays", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "2003": {
+            name: "Health Potion",
+            description: "<mainText>Restores health</mainText>",
+            gold: { base: 50, total: 50, sell: 20, purchasable: true },
+            image: { full: "2003.png" },
+          },
+        },
+      })
+    );
+
+    const items = await fetchItems("15.6.1");
+    const potion = items.get(2003);
+    expect(potion!.from).toBeUndefined();
+    expect(potion!.into).toBeUndefined();
+  });
+
+  it("classifies standard items (1000-8999) as standard", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "3089": {
+            name: "Rabadon's Deathcap",
+            description: "AP",
+            gold: { base: 1100, total: 3600, sell: 2520, purchasable: true },
+            image: { full: "3089.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.get(3089)!.mode).toBe("standard");
+  });
+
+  it("classifies 22xxxx items as arena", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "228020": {
+            name: "Abyssal Mask",
+            description: "MR",
+            gold: { base: 500, total: 2500, sell: 1750, purchasable: true },
+            image: { full: "8020.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.get(228020)!.mode).toBe("arena");
+  });
+
+  it("classifies 32xxxx items as aram", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "328020": {
+            name: "Abyssal Mask",
+            description: "MR",
+            gold: { base: 500, total: 2850, sell: 1995, purchasable: true },
+            image: { full: "8020.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.get(328020)!.mode).toBe("aram");
+  });
+
+  it("classifies 9xxx purchasable items as swarm", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "9171": {
+            name: "Cyclonic Slicers",
+            description: "Swarm weapon",
+            gold: { base: 100, total: 100, sell: 50, purchasable: true },
+            image: { full: "9171.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.get(9171)!.mode).toBe("swarm");
+  });
+
+  it("excludes non-purchasable zero-gold Swarm items", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "9171": {
+            name: "Cyclonic Slicers",
+            description: "Swarm weapon",
+            gold: { base: 0, total: 0, sell: 0, purchasable: false },
+            image: { full: "9171.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.size).toBe(0);
+  });
+
+  it("strips HTML from item names", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "3901": {
+            name: "<rarityLegendary>Fire at Will</rarityLegendary><br><subtitleLeft><silver>500 Silver Serpents</silver></subtitleLeft>",
+            description: "Upgrade",
+            gold: { base: 500, total: 500, sell: 250, purchasable: true },
+            image: { full: "3901.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.get(3901)!.name).toBe("Fire at Will");
+  });
+
+  it("excludes items with empty names", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "7050": {
+            name: "",
+            description: "junk",
+            gold: { base: 0, total: 0, sell: 0, purchasable: false },
+            image: { full: "7050.png" },
+          },
+          "1001": {
+            name: "Boots",
+            description: "MS",
+            gold: { base: 300, total: 300, sell: 210, purchasable: true },
+            image: { full: "1001.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    expect(items.size).toBe(1);
+    expect(items.has(7050)).toBe(false);
+  });
+
+  it("excludes non-purchasable zero-gold items (system/internal items)", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "1500": {
+            name: "Penetrating Bullets",
+            description: "turret buff",
+            gold: { base: 0, total: 0, sell: 0, purchasable: false },
+            image: { full: "1500.png" },
+          },
+          "3340": {
+            name: "Stealth Ward",
+            description: "Places a ward",
+            gold: { base: 0, total: 0, sell: 0, purchasable: true },
+            image: { full: "3340.png" },
+          },
+          "3089": {
+            name: "Rabadon's Deathcap",
+            description: "AP",
+            gold: { base: 1100, total: 3600, sell: 2520, purchasable: true },
+            image: { full: "3089.png" },
+          },
+        },
+      })
+    );
+    const items = await fetchItems("15.6.1");
+    // Turret buff excluded, ward and Deathcap kept
+    expect(items.size).toBe(2);
+    expect(items.has(1500)).toBe(false);
+    expect(items.has(3340)).toBe(true);
+    expect(items.has(3089)).toBe(true);
+  });
+});
+
+describe("fetchRunes", () => {
+  it("normalizes rune trees with keystones and minor slots", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse([
+        {
+          id: 8100,
+          key: "Domination",
+          name: "Domination",
+          icon: "perk-images/Styles/7200_Domination.png",
+          slots: [
+            {
+              runes: [
+                {
+                  id: 8112,
+                  key: "Electrocute",
+                  name: "Electrocute",
+                  icon: "perk-images/Styles/Domination/Electrocute/Electrocute.png",
+                  shortDesc: "Hit with <b>3</b> attacks for bonus damage.",
+                  longDesc:
+                    "Hit with <b>3 separate</b> attacks within 3s for <b>bonus</b> damage.",
+                },
+              ],
+            },
+            {
+              runes: [
+                {
+                  id: 8126,
+                  key: "CheapShot",
+                  name: "Cheap Shot",
+                  icon: "perk-images/Styles/Domination/CheapShot/CheapShot.png",
+                  shortDesc: "Deal bonus true damage to impaired targets.",
+                  longDesc:
+                    "Deal <b>bonus</b> true damage to impaired targets.",
+                },
+              ],
+            },
+          ],
+        },
+      ])
+    );
+
+    const runes = await fetchRunes("15.6.1");
+    expect(runes).toHaveLength(1);
+    expect(runes[0].name).toBe("Domination");
+    expect(runes[0].keystones).toHaveLength(1);
+    expect(runes[0].keystones[0].name).toBe("Electrocute");
+    expect(runes[0].keystones[0].shortDesc).not.toContain("<b>");
+    expect(runes[0].slots).toHaveLength(1);
+    expect(runes[0].slots[0][0].name).toBe("Cheap Shot");
+  });
+});

--- a/src/lib/data-ingest/sources/data-dragon.ts
+++ b/src/lib/data-ingest/sources/data-dragon.ts
@@ -1,0 +1,178 @@
+import type {
+  Champion,
+  Item,
+  ItemGold,
+  ItemMode,
+  Rune,
+  RuneTree,
+} from "../types";
+
+const BASE_URL = "https://ddragon.leagueoflegends.com";
+
+export async function fetchLatestVersion(): Promise<string> {
+  const res = await fetch(`${BASE_URL}/api/versions.json`);
+  if (!res.ok) throw new Error(`Failed to fetch versions: ${res.status}`);
+  const versions: string[] = await res.json();
+  return versions[0];
+}
+
+export async function fetchChampions(
+  version: string
+): Promise<Map<string, Champion>> {
+  const res = await fetch(
+    `${BASE_URL}/cdn/${version}/data/en_US/champion.json`
+  );
+  if (!res.ok) throw new Error(`Failed to fetch champions: ${res.status}`);
+  const json = await res.json();
+  const champions = new Map<string, Champion>();
+
+  for (const [, raw] of Object.entries<RawChampion>(json.data)) {
+    champions.set(raw.name.toLowerCase(), {
+      id: raw.id,
+      key: Number(raw.key),
+      name: raw.name,
+      title: raw.title,
+      tags: raw.tags,
+      partype: raw.partype,
+      stats: raw.stats,
+      image: `${BASE_URL}/cdn/${version}/img/champion/${raw.image.full}`,
+    });
+  }
+
+  return champions;
+}
+
+export async function fetchItems(version: string): Promise<Map<number, Item>> {
+  const res = await fetch(`${BASE_URL}/cdn/${version}/data/en_US/item.json`);
+  if (!res.ok) throw new Error(`Failed to fetch items: ${res.status}`);
+  const json = await res.json();
+  const items = new Map<number, Item>();
+
+  for (const [idStr, raw] of Object.entries<RawItem>(json.data)) {
+    const id = Number(idStr);
+
+    const name = cleanItemName(raw.name);
+
+    // Skip items with empty names (junk/placeholder entries)
+    if (!name) continue;
+
+    // Skip non-purchasable zero-gold items (system/internal: turret buffs, quest trackers, etc.)
+    if (raw.gold.total === 0 && !raw.gold.purchasable) continue;
+
+    items.set(id, {
+      id,
+      name,
+      description: stripHtml(raw.description),
+      plaintext: raw.plaintext ?? "",
+      gold: raw.gold,
+      tags: raw.tags ?? [],
+      stats: raw.stats ?? {},
+      from: raw.from?.map(Number),
+      into: raw.into?.map(Number),
+      image: `${BASE_URL}/cdn/${version}/img/item/${raw.image.full}`,
+      mode: classifyItemMode(id),
+    });
+  }
+
+  return items;
+}
+
+export async function fetchRunes(version: string): Promise<RuneTree[]> {
+  const res = await fetch(
+    `${BASE_URL}/cdn/${version}/data/en_US/runesReforged.json`
+  );
+  if (!res.ok) throw new Error(`Failed to fetch runes: ${res.status}`);
+  const json: RawRuneTree[] = await res.json();
+
+  return json.map((tree) => ({
+    id: tree.id,
+    key: tree.key,
+    name: tree.name,
+    icon: `${BASE_URL}/cdn/img/${tree.icon}`,
+    keystones: tree.slots[0].runes.map(mapRune),
+    slots: tree.slots.slice(1).map((slot) => slot.runes.map(mapRune)),
+  }));
+}
+
+function mapRune(raw: RawRune): Rune {
+  return {
+    id: raw.id,
+    key: raw.key,
+    name: raw.name,
+    icon: `${BASE_URL}/cdn/img/${raw.icon}`,
+    shortDesc: stripHtml(raw.shortDesc),
+    longDesc: stripHtml(raw.longDesc),
+  };
+}
+
+/**
+ * Classify an item's game mode based on its ID range.
+ * - 1000-8999: standard (Summoner's Rift)
+ * - 9000-9999: swarm
+ * - 220000-229999: arena
+ * - 320000-329999: aram
+ * - everything else: other (mode-specific variants, internal items)
+ */
+function classifyItemMode(id: number): ItemMode {
+  if (id >= 9000 && id < 10000) return "swarm";
+  if (id >= 220000 && id < 230000) return "arena";
+  if (id >= 320000 && id < 330000) return "aram";
+  if (id >= 1000 && id < 9000) return "standard";
+  return "other";
+}
+
+/**
+ * Clean an item name: strip HTML tags and take only the primary name
+ * (before any <br> subtitle content). Returns empty string for junk entries.
+ */
+function cleanItemName(raw: string): string {
+  // Split on <br> before stripping tags — the part after <br> is subtitle junk
+  const beforeBr = raw.split(/<br\s*\/?>/i)[0];
+  return stripHtml(beforeBr);
+}
+
+function stripHtml(html: string): string {
+  return html.replace(/<[^>]+>/g, "").trim();
+}
+
+// Raw DDragon response types
+
+interface RawChampion {
+  id: string;
+  key: string;
+  name: string;
+  title: string;
+  tags: string[];
+  partype: string;
+  stats: Champion["stats"];
+  image: { full: string };
+}
+
+interface RawItem {
+  name: string;
+  description: string;
+  plaintext?: string;
+  gold: ItemGold;
+  tags?: string[];
+  stats?: Record<string, number>;
+  from?: string[];
+  into?: string[];
+  image: { full: string };
+}
+
+interface RawRuneTree {
+  id: number;
+  key: string;
+  name: string;
+  icon: string;
+  slots: { runes: RawRune[] }[];
+}
+
+interface RawRune {
+  id: number;
+  key: string;
+  name: string;
+  icon: string;
+  shortDesc: string;
+  longDesc: string;
+}

--- a/src/lib/data-ingest/sources/wiki-augments.ts
+++ b/src/lib/data-ingest/sources/wiki-augments.ts
@@ -1,0 +1,37 @@
+import type { Augment } from "../types";
+import { parseLuaTable } from "../parsers/lua-parser";
+import { stripWikiMarkup } from "../parsers/wiki-markup";
+
+const WIKI_URL =
+  "https://wiki.leagueoflegends.com/en-us/Module:MayhemAugmentData/data?action=raw";
+
+export async function fetchWikiAugments(): Promise<Map<string, Augment>> {
+  const res = await fetch(WIKI_URL);
+  if (!res.ok) throw new Error(`Failed to fetch wiki augments: ${res.status}`);
+  const lua = await res.text();
+  const parsed = parseLuaTable(lua);
+  const augments = new Map<string, Augment>();
+
+  for (const [name, fields] of Object.entries(parsed)) {
+    const tier = normalizeTier(String(fields.tier ?? "Silver"));
+    const rawSet = String(fields.set ?? "-");
+    const description = stripWikiMarkup(String(fields.description ?? ""));
+
+    augments.set(name.toLowerCase(), {
+      name,
+      description,
+      tier,
+      set: stripWikiMarkup(rawSet),
+      mode: "mayhem",
+    });
+  }
+
+  return augments;
+}
+
+function normalizeTier(tier: string): Augment["tier"] {
+  const lower = tier.toLowerCase();
+  if (lower === "gold") return "Gold";
+  if (lower === "prismatic") return "Prismatic";
+  return "Silver";
+}

--- a/src/lib/data-ingest/types.ts
+++ b/src/lib/data-ingest/types.ts
@@ -1,0 +1,106 @@
+export interface Champion {
+  id: string;
+  key: number;
+  name: string;
+  title: string;
+  tags: string[];
+  partype: string;
+  stats: ChampionStats;
+  image: string;
+}
+
+export interface ChampionStats {
+  hp: number;
+  hpperlevel: number;
+  mp: number;
+  mpperlevel: number;
+  movespeed: number;
+  armor: number;
+  armorperlevel: number;
+  spellblock: number;
+  spellblockperlevel: number;
+  attackrange: number;
+  hpregen: number;
+  hpregenperlevel: number;
+  mpregen: number;
+  mpregenperlevel: number;
+  attackdamage: number;
+  attackdamageperlevel: number;
+  attackspeed: number;
+  attackspeedperlevel: number;
+}
+
+export type ItemMode = "standard" | "arena" | "aram" | "swarm" | "other";
+
+export interface Item {
+  id: number;
+  name: string;
+  description: string;
+  plaintext: string;
+  gold: ItemGold;
+  tags: string[];
+  stats: Record<string, number>;
+  from?: number[];
+  into?: number[];
+  image: string;
+  mode: ItemMode;
+}
+
+export interface ItemGold {
+  base: number;
+  total: number;
+  sell: number;
+  purchasable: boolean;
+}
+
+export interface RuneTree {
+  id: number;
+  key: string;
+  name: string;
+  icon: string;
+  keystones: Rune[];
+  slots: Rune[][];
+}
+
+export interface Rune {
+  id: number;
+  key: string;
+  name: string;
+  icon: string;
+  shortDesc: string;
+  longDesc: string;
+}
+
+export type AugmentMode = "mayhem" | "arena" | "swarm" | "unknown";
+
+export interface Augment {
+  name: string;
+  description: string;
+  tier: "Silver" | "Gold" | "Prismatic";
+  set: string;
+  mode: AugmentMode;
+  id?: number;
+  iconPath?: string;
+}
+
+export interface GameData {
+  version: string;
+  champions: Map<string, Champion>;
+  items: Map<number, Item>;
+  runes: RuneTree[];
+  augments: Map<string, Augment>;
+}
+
+export interface EntityDictionary {
+  allNames: string[];
+  champions: string[];
+  items: string[];
+  augments: string[];
+  search(query: string): EntityMatch[];
+}
+
+export interface EntityMatch {
+  name: string;
+  type: "champion" | "item" | "augment";
+  score: number;
+}


### PR DESCRIPTION
## Summary

- Data Ingest Pipeline fetching from all sources: Data Dragon (champions, items, runes), League Wiki Lua module (augments with wiki markup stripped via luaparse AST), Community Dragon (augment IDs/icons merged by name)
- Augments classified by mode (Mayhem, Arena, Swarm) based on CDragon icon paths; items classified by ID range (Standard, Arena Variants, ARAM Variants, Swarm)
- Entity dictionary with fuzzy search across all entity types
- Desktop shell displays browsable, filterable views: mode filters for items and augments, tier filters (Prismatic/Gold/Silver) for augments, sticky filter bars
- localStorage cache with dev-mode bypass for hot reload; refresh button in header
- 72 tests covering all parsers, data normalization, entity dictionary, mode classification, and merging logic
- Helper scripts: `pnpm check-game` (Riot API connectivity), `dump-data.ts` (full pipeline data dump for debugging)

Closes #2

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Tabbed data browser for champions, items, runes, augments, and search
  * Fuzzy entity search with ranked results
  * Augment filtering by mode and tier with dynamic counts
  * Expandable detail panels for champions, items, runes, and augments
  * Manual Refresh control and loading/error states for live data

* **Style**
  * Global layout and visual styling updates for improved presentation
<!-- end of auto-generated comment: release notes by coderabbit.ai -->