### PR TITLE
ARAM balance overrides ingest with shell visualization

### DIFF
--- a/src/App.css
+++ b/src/App.css
@@ -249,6 +249,21 @@ h1 {
   background-color: #2a2a30;
 }
 
+/* ARAM overrides */
+.aram-badge {
+  font-size: 0.7em;
+  padding: 0.1em 0.4em;
+  margin-left: 0.5em;
+  border-radius: 3px;
+  color: #7cb3ff;
+  background-color: #1a2a40;
+  vertical-align: middle;
+}
+
+.aram-overrides {
+  margin-top: 0.5em;
+}
+
 /* Runes */
 .rune-entry {
   padding: 0.25em 0;

--- a/src/components/ChampionList.tsx
+++ b/src/components/ChampionList.tsx
@@ -1,8 +1,27 @@
 import { useState } from "react";
-import type { Champion } from "../lib/data-ingest/types";
+import type { Champion, AramOverrides } from "../lib/data-ingest/types";
 
 interface ChampionListProps {
   champions: Map<string, Champion>;
+}
+
+function formatModifier(value: number): string {
+  const pct = Math.round((value - 1) * 100);
+  if (pct === 0) return "0%";
+  return pct > 0 ? `+${pct}%` : `${pct}%`;
+}
+
+function hasNonNeutralOverrides(aram: AramOverrides): boolean {
+  return (
+    aram.dmgDealt !== 1 ||
+    aram.dmgTaken !== 1 ||
+    aram.healing !== undefined ||
+    aram.shielding !== undefined ||
+    aram.tenacity !== undefined ||
+    aram.energyRegenMod !== undefined ||
+    aram.totalAs !== undefined ||
+    aram.abilityHaste !== undefined
+  );
 }
 
 export function ChampionList({ champions }: ChampionListProps) {
@@ -19,7 +38,13 @@ export function ChampionList({ champions }: ChampionListProps) {
             className="entity-header"
             onClick={() => setExpanded(expanded === champ.id ? null : champ.id)}
           >
-            <span className="entity-name">{champ.name}</span>
+            <span className="entity-name">
+              {champ.name}
+              {champ.aramOverrides &&
+                hasNonNeutralOverrides(champ.aramOverrides) && (
+                  <span className="aram-badge">ARAM</span>
+                )}
+            </span>
             <span className="entity-meta">
               {champ.tags.join(", ")} | {champ.partype}
             </span>
@@ -36,6 +61,60 @@ export function ChampionList({ champions }: ChampionListProps) {
                 <span>Range: {champ.stats.attackrange}</span>
                 <span>MS: {champ.stats.movespeed}</span>
               </div>
+              {champ.aramOverrides &&
+                hasNonNeutralOverrides(champ.aramOverrides) && (
+                  <div className="aram-overrides">
+                    <p className="entity-title">ARAM Balance</p>
+                    <div className="stat-grid">
+                      {champ.aramOverrides.dmgDealt !== 1 && (
+                        <span>
+                          Dmg Dealt:{" "}
+                          {formatModifier(champ.aramOverrides.dmgDealt)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.dmgTaken !== 1 && (
+                        <span>
+                          Dmg Taken:{" "}
+                          {formatModifier(champ.aramOverrides.dmgTaken)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.healing !== undefined && (
+                        <span>
+                          Healing: {formatModifier(champ.aramOverrides.healing)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.shielding !== undefined && (
+                        <span>
+                          Shielding:{" "}
+                          {formatModifier(champ.aramOverrides.shielding)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.tenacity !== undefined && (
+                        <span>
+                          Tenacity:{" "}
+                          {formatModifier(champ.aramOverrides.tenacity)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.energyRegenMod !== undefined && (
+                        <span>
+                          Energy Regen:{" "}
+                          {formatModifier(champ.aramOverrides.energyRegenMod)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.totalAs !== undefined && (
+                        <span>
+                          Atk Speed:{" "}
+                          {formatModifier(champ.aramOverrides.totalAs)}
+                        </span>
+                      )}
+                      {champ.aramOverrides.abilityHaste !== undefined && (
+                        <span>
+                          Ability Haste: +{champ.aramOverrides.abilityHaste}
+                        </span>
+                      )}
+                    </div>
+                  </div>
+                )}
             </div>
           )}
         </div>

--- a/src/lib/data-ingest/index.test.ts
+++ b/src/lib/data-ingest/index.test.ts
@@ -3,12 +3,14 @@ import { loadGameData } from "./index";
 import * as dataDragon from "./sources/data-dragon";
 import * as wikiAugments from "./sources/wiki-augments";
 import * as communityDragon from "./sources/community-dragon";
+import * as aramOverrides from "./sources/wiki-aram-overrides";
 import * as cache from "./cache";
-import type { Champion, Item, Augment, RuneTree } from "./types";
+import type { AramOverrides, Champion, Item, Augment, RuneTree } from "./types";
 
 vi.mock("./sources/data-dragon");
 vi.mock("./sources/wiki-augments");
 vi.mock("./sources/community-dragon");
+vi.mock("./sources/wiki-aram-overrides");
 vi.mock("./cache", async (importOriginal) => {
   const actual = await importOriginal<typeof cache>();
   return {
@@ -18,21 +20,23 @@ vi.mock("./cache", async (importOriginal) => {
   };
 });
 
-const mockChampions = new Map<string, Champion>([
-  [
-    "aatrox",
-    {
-      id: "Aatrox",
-      key: 266,
-      name: "Aatrox",
-      title: "the Darkin Blade",
-      tags: ["Fighter"],
-      partype: "Blood Well",
-      stats: {} as Champion["stats"],
-      image: "",
-    },
-  ],
-]);
+function createMockChampions() {
+  return new Map<string, Champion>([
+    [
+      "aatrox",
+      {
+        id: "Aatrox",
+        key: 266,
+        name: "Aatrox",
+        title: "the Darkin Blade",
+        tags: ["Fighter"],
+        partype: "Blood Well",
+        stats: {} as Champion["stats"],
+        image: "",
+      },
+    ],
+  ]);
+}
 
 const mockItems = new Map<number, Item>([
   [
@@ -80,11 +84,12 @@ beforeEach(() => {
   vi.mocked(cache.readCache).mockResolvedValue(null);
   vi.mocked(cache.writeCache).mockResolvedValue(undefined);
   vi.mocked(dataDragon.fetchLatestVersion).mockResolvedValue("15.6.1");
-  vi.mocked(dataDragon.fetchChampions).mockResolvedValue(mockChampions);
+  vi.mocked(dataDragon.fetchChampions).mockResolvedValue(createMockChampions());
   vi.mocked(dataDragon.fetchItems).mockResolvedValue(mockItems);
   vi.mocked(dataDragon.fetchRunes).mockResolvedValue(mockRunes);
   vi.mocked(wikiAugments.fetchWikiAugments).mockResolvedValue(mockAugments);
   vi.mocked(communityDragon.mergeAugmentIds).mockResolvedValue(undefined);
+  vi.mocked(aramOverrides.fetchAramOverrides).mockResolvedValue(new Map());
 });
 
 describe("loadGameData", () => {
@@ -107,6 +112,7 @@ describe("loadGameData", () => {
     expect(dataDragon.fetchRunes).toHaveBeenCalledWith("15.6.1");
     expect(wikiAugments.fetchWikiAugments).toHaveBeenCalled();
     expect(communityDragon.mergeAugmentIds).toHaveBeenCalledWith(mockAugments);
+    expect(aramOverrides.fetchAramOverrides).toHaveBeenCalled();
   });
 
   it("writes fetched data to cache", async () => {
@@ -122,7 +128,7 @@ describe("loadGameData", () => {
 
     vi.mocked(cache.readCache).mockResolvedValue({
       version: "15.5.1",
-      champions: { aatrox: mockChampions.get("aatrox") },
+      champions: { aatrox: createMockChampions().get("aatrox") },
       items: { "1001": mockItems.get(1001) },
       runes: mockRunes,
       augments: { typhoon: mockAugments.get("typhoon") },
@@ -149,5 +155,26 @@ describe("loadGameData", () => {
     const results = data.dictionary.search("aatrox");
     expect(results[0].name).toBe("Aatrox");
     expect(results[0].type).toBe("champion");
+  });
+
+  it("merges ARAM overrides onto matching champions", async () => {
+    const mockOverrides = new Map<string, AramOverrides>([
+      ["aatrox", { dmgDealt: 1.05, dmgTaken: 1 }],
+    ]);
+    vi.mocked(aramOverrides.fetchAramOverrides).mockResolvedValue(
+      mockOverrides
+    );
+
+    const data = await loadGameData();
+    const aatrox = data.champions.get("aatrox");
+    expect(aatrox!.aramOverrides).toEqual({ dmgDealt: 1.05, dmgTaken: 1 });
+  });
+
+  it("leaves aramOverrides undefined for champions without overrides", async () => {
+    vi.mocked(aramOverrides.fetchAramOverrides).mockResolvedValue(new Map());
+
+    const data = await loadGameData();
+    const aatrox = data.champions.get("aatrox");
+    expect(aatrox!.aramOverrides).toBeUndefined();
   });
 });

--- a/src/lib/data-ingest/index.ts
+++ b/src/lib/data-ingest/index.ts
@@ -1,5 +1,6 @@
 import type {
   GameData,
+  AramOverrides,
   Champion,
   Item,
   Augment,
@@ -14,6 +15,7 @@ import {
 } from "./sources/data-dragon";
 import { fetchWikiAugments } from "./sources/wiki-augments";
 import { mergeAugmentIds } from "./sources/community-dragon";
+import { fetchAramOverrides } from "./sources/wiki-aram-overrides";
 import { readCache, writeCache, mapToObject, objectToMap } from "./cache";
 import { buildEntityDictionary } from "./entity-dictionary";
 
@@ -47,14 +49,17 @@ export async function loadGameData(): Promise<LoadedGameData> {
 
 export async function fetchAndCache(): Promise<LoadedGameData> {
   const version = await fetchLatestVersion();
-  const [champions, items, runes, augments] = await Promise.all([
-    fetchChampions(version),
-    fetchItems(version),
-    fetchRunes(version),
-    fetchWikiAugments(),
-  ]);
+  const [champions, items, runes, augments, aramOverrideMap] =
+    await Promise.all([
+      fetchChampions(version),
+      fetchItems(version),
+      fetchRunes(version),
+      fetchWikiAugments(),
+      fetchAramOverrides(),
+    ]);
 
   await mergeAugmentIds(augments);
+  mergeAramOverrides(champions, aramOverrideMap);
 
   const data: CachedGameData = {
     version,
@@ -67,6 +72,18 @@ export async function fetchAndCache(): Promise<LoadedGameData> {
   await writeCache(CACHE_KEY, data);
 
   return fromCached(data);
+}
+
+function mergeAramOverrides(
+  champions: Map<string, Champion>,
+  overrides: Map<string, AramOverrides>
+): void {
+  for (const [key, champion] of champions) {
+    const aram = overrides.get(key);
+    if (aram) {
+      champion.aramOverrides = aram;
+    }
+  }
 }
 
 function fromCached(cached: CachedGameData): LoadedGameData {

--- a/src/lib/data-ingest/sources/wiki-aram-overrides.test.ts
+++ b/src/lib/data-ingest/sources/wiki-aram-overrides.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { fetchAramOverrides } from "./wiki-aram-overrides";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  mockFetch.mockReset();
+});
+
+const SAMPLE_LUA = `-- <pre>
+return {
+  ["Aatrox"] = {
+    ["id"] = 266,
+    ["apiname"] = "Aatrox",
+    ["stats"] = {
+      ["hp_base"] = 650,
+      ["aram"] = {
+        ["dmg_dealt"] = 1.05,
+        ["dmg_taken"] = 1,
+      },
+    },
+  },
+  ["Ahri"] = {
+    ["id"] = 103,
+    ["apiname"] = "Ahri",
+    ["stats"] = {
+      ["hp_base"] = 590,
+      ["aram"] = {
+        ["dmg_dealt"] = 1,
+        ["dmg_taken"] = 1,
+        ["healing"] = 0.9,
+      },
+    },
+  },
+  ["Akali"] = {
+    ["id"] = 84,
+    ["apiname"] = "Akali",
+    ["stats"] = {
+      ["hp_base"] = 600,
+      ["aram"] = {
+        ["dmg_dealt"] = 1,
+        ["dmg_taken"] = 0.95,
+        ["energyregen_mod"] = 1.2,
+        ["tenacity"] = 1.2,
+      },
+    },
+  },
+  ["Garen"] = {
+    ["id"] = 86,
+    ["apiname"] = "Garen",
+    ["stats"] = {
+      ["hp_base"] = 690,
+    },
+  },
+}`;
+
+function textResponse(text: string) {
+  return { ok: true, text: () => Promise.resolve(text) };
+}
+
+describe("fetchAramOverrides", () => {
+  it("extracts ARAM overrides keyed by lowercase champion name", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    expect(overrides.size).toBe(3);
+    expect(overrides.has("aatrox")).toBe(true);
+    expect(overrides.has("ahri")).toBe(true);
+    expect(overrides.has("akali")).toBe(true);
+  });
+
+  it("skips champions without ARAM overrides", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    expect(overrides.has("garen")).toBe(false);
+  });
+
+  it("parses damage dealt/taken multipliers", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    const aatrox = overrides.get("aatrox")!;
+    expect(aatrox.dmgDealt).toBe(1.05);
+    expect(aatrox.dmgTaken).toBe(1);
+  });
+
+  it("parses healing modifier", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    const ahri = overrides.get("ahri")!;
+    expect(ahri.healing).toBe(0.9);
+  });
+
+  it("parses energy regen and tenacity modifiers", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    const akali = overrides.get("akali")!;
+    expect(akali.energyRegenMod).toBe(1.2);
+    expect(akali.tenacity).toBe(1.2);
+  });
+
+  it("omits optional fields when not present", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    const aatrox = overrides.get("aatrox")!;
+    expect(aatrox.healing).toBeUndefined();
+    expect(aatrox.shielding).toBeUndefined();
+    expect(aatrox.tenacity).toBeUndefined();
+  });
+
+  it("returns champion name as display name, not apiname", async () => {
+    mockFetch.mockResolvedValue(textResponse(SAMPLE_LUA));
+
+    const overrides = await fetchAramOverrides();
+    // Keys are lowercase versions of the Lua table keys (display names)
+    expect(overrides.has("aatrox")).toBe(true);
+    expect(overrides.has("ahri")).toBe(true);
+  });
+});

--- a/src/lib/data-ingest/sources/wiki-aram-overrides.ts
+++ b/src/lib/data-ingest/sources/wiki-aram-overrides.ts
@@ -1,0 +1,111 @@
+import * as luaparse from "luaparse";
+import type { AramOverrides } from "../types";
+
+const CHAMPION_DATA_URL =
+  "https://wiki.leagueoflegends.com/en-us/Module:ChampionData/data?action=raw";
+
+/**
+ * Fetch ARAM balance overrides from the League Wiki ChampionData Lua module.
+ * Each champion's stats block may contain an ["aram"] table with multipliers
+ * for damage dealt/taken, healing, shielding, tenacity, etc.
+ *
+ * Returns a map keyed by lowercase champion name.
+ */
+export async function fetchAramOverrides(): Promise<
+  Map<string, AramOverrides>
+> {
+  const res = await fetch(CHAMPION_DATA_URL);
+  if (!res.ok) throw new Error(`Failed to fetch ChampionData: ${res.status}`);
+
+  let lua = await res.text();
+  lua = lua.replace(/^--\s*<pre>\s*\n?/, "").replace(/\n?--\s*<\/pre>\s*$/, "");
+  // Replace unicode quotes/dashes that luaparse can't handle
+  lua = lua
+    .replace(/[\u2018\u2019\u201A]/g, "'")
+    .replace(/[\u201C\u201D\u201E]/g, '"')
+    .replace(/[\u2013\u2014]/g, "-");
+
+  const ast = luaparse.parse(lua, { encodingMode: "x-user-defined" });
+  const overrides = new Map<string, AramOverrides>();
+
+  const returnStmt = ast.body[0];
+  if (!returnStmt || returnStmt.type !== "ReturnStatement") return overrides;
+
+  const table = returnStmt.arguments[0];
+  if (!table || table.type !== "TableConstructorExpression") return overrides;
+
+  for (const field of table.fields) {
+    if (field.type !== "TableKey") continue;
+
+    const champName = extractString(field.key);
+    if (!champName) continue;
+
+    const champTable = field.value;
+    if (champTable.type !== "TableConstructorExpression") continue;
+
+    const aram = extractAramBlock(champTable);
+    if (aram) {
+      overrides.set(champName.toLowerCase(), aram);
+    }
+  }
+
+  return overrides;
+}
+
+function extractAramBlock(
+  champTable: luaparse.TableConstructorExpression
+): AramOverrides | null {
+  for (const field of champTable.fields) {
+    if (field.type !== "TableKey") continue;
+    if (extractString(field.key) !== "stats") continue;
+
+    const statsTable = field.value;
+    if (statsTable.type !== "TableConstructorExpression") continue;
+
+    for (const sf of statsTable.fields) {
+      if (sf.type !== "TableKey") continue;
+      if (extractString(sf.key) !== "aram") continue;
+
+      const aramTable = sf.value;
+      if (aramTable.type !== "TableConstructorExpression") continue;
+
+      return parseAramFields(aramTable);
+    }
+  }
+  return null;
+}
+
+function parseAramFields(
+  table: luaparse.TableConstructorExpression
+): AramOverrides {
+  const raw: Record<string, number> = {};
+  for (const field of table.fields) {
+    if (field.type !== "TableKey") continue;
+    const key = extractString(field.key);
+    if (!key) continue;
+    if (field.value.type === "NumericLiteral") {
+      raw[key] = field.value.value;
+    }
+  }
+
+  const result: AramOverrides = {
+    dmgDealt: raw.dmg_dealt ?? 1,
+    dmgTaken: raw.dmg_taken ?? 1,
+  };
+  if (raw.healing !== undefined) result.healing = raw.healing;
+  if (raw.shielding !== undefined) result.shielding = raw.shielding;
+  if (raw.tenacity !== undefined) result.tenacity = raw.tenacity;
+  if (raw.energyregen_mod !== undefined)
+    result.energyRegenMod = raw.energyregen_mod;
+  if (raw.total_as !== undefined) result.totalAs = raw.total_as;
+  if (raw.ability_haste !== undefined) result.abilityHaste = raw.ability_haste;
+
+  return result;
+}
+
+function extractString(node: luaparse.Node): string | null {
+  if (node.type === "StringLiteral") {
+    return node.raw.slice(1, -1);
+  }
+  return null;
+}

--- a/src/lib/data-ingest/types.ts
+++ b/src/lib/data-ingest/types.ts
@@ -7,6 +7,18 @@ export interface Champion {
   partype: string;
   stats: ChampionStats;
   image: string;
+  aramOverrides?: AramOverrides;
+}
+
+export interface AramOverrides {
+  dmgDealt: number;
+  dmgTaken: number;
+  healing?: number;
+  shielding?: number;
+  tenacity?: number;
+  energyRegenMod?: number;
+  totalAs?: number;
+  abilityHaste?: number;
 }
 
 export interface ChampionStats {


### PR DESCRIPTION
## Summary

- Fetches ARAM champion balance overrides from the League Wiki ChampionData Lua module using luaparse
- Extracts per-champion multipliers: damage dealt/taken, healing, shielding, tenacity, energy regen, attack speed, ability haste
- Merges overrides onto champion data in the ingest pipeline
- Champions with non-neutral ARAM overrides show an "ARAM" badge in the champion list and display balance modifiers when expanded
- 81 tests total (9 new for ARAM override parsing and pipeline integration)

Closes #5