### PR TITLE
Live game state detection and visualization

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -445,15 +445,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
+
+[[package]]
 name = "champ-sage"
 version = "0.1.0"
 dependencies = [
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-global-shortcut",
  "tauri-plugin-opener",
+ "tokio",
 ]
 
 [[package]]
@@ -1272,8 +1280,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "wasi 0.11.1+wasi-snapshot-preview1",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1283,9 +1293,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
 dependencies = [
  "cfg-if",
+ "js-sys",
  "libc",
  "r-efi 5.3.0",
  "wasip2",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -1592,6 +1604,23 @@ dependencies = [
  "smallvec",
  "tokio",
  "want",
+]
+
+[[package]]
+name = "hyper-rustls"
+version = "0.27.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+dependencies = [
+ "http",
+ "hyper",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "webpki-roots",
 ]
 
 [[package]]
@@ -2019,6 +2048,12 @@ name = "log"
 version = "0.4.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+
+[[package]]
+name = "lru-slab"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "mac"
@@ -2807,6 +2842,61 @@ dependencies = [
 ]
 
 [[package]]
+name = "quinn"
+version = "0.11.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "pin-project-lite",
+ "quinn-proto",
+ "quinn-udp",
+ "rustc-hash",
+ "rustls",
+ "socket2",
+ "thiserror 2.0.18",
+ "tokio",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-proto"
+version = "0.11.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
+dependencies = [
+ "bytes",
+ "getrandom 0.3.4",
+ "lru-slab",
+ "rand 0.9.2",
+ "ring",
+ "rustc-hash",
+ "rustls",
+ "rustls-pki-types",
+ "slab",
+ "thiserror 2.0.18",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "quinn-udp"
+version = "0.5.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "once_cell",
+ "socket2",
+ "tracing",
+ "windows-sys 0.60.2",
+]
+
+[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2853,6 +2943,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+dependencies = [
+ "rand_chacha 0.9.0",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_chacha"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2873,6 +2973,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "rand_chacha"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
+dependencies = [
+ "ppv-lite86",
+ "rand_core 0.9.5",
+]
+
+[[package]]
 name = "rand_core"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2888,6 +2998,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
  "getrandom 0.2.17",
+]
+
+[[package]]
+name = "rand_core"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+dependencies = [
+ "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -2985,6 +3104,44 @@ checksum = "dc897dd8d9e8bd1ed8cdad82b5966c3e0ecae09fb1907d58efaa013543185d0a"
 
 [[package]]
 name = "reqwest"
+version = "0.12.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eddd3ca559203180a307f12d114c268abf583f59b03cb906fd0b3ff8646c1147"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "js-sys",
+ "log",
+ "percent-encoding",
+ "pin-project-lite",
+ "quinn",
+ "rustls",
+ "rustls-pki-types",
+ "serde",
+ "serde_json",
+ "serde_urlencoded",
+ "sync_wrapper",
+ "tokio",
+ "tokio-rustls",
+ "tower",
+ "tower-http",
+ "tower-service",
+ "url",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "webpki-roots",
+]
+
+[[package]]
+name = "reqwest"
 version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab3f43e3283ab1488b624b44b0e988d0acea0b3214e694730a055cb6b2efa801"
@@ -3018,6 +3175,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "ring"
+version = "0.17.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "getrandom 0.2.17",
+ "libc",
+ "untrusted",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "rustc-hash"
 version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3046,10 +3217,51 @@ dependencies = [
 ]
 
 [[package]]
+name = "rustls"
+version = "0.23.37"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "758025cb5fccfd3bc2fd74708fd4682be41d99e5dff73c377c0646c6012c73a4"
+dependencies = [
+ "once_cell",
+ "ring",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-pki-types"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be040f8b0a225e40375822a563fa9524378b9d63112f53e19ffff34df5d33fdd"
+dependencies = [
+ "web-time",
+ "zeroize",
+]
+
+[[package]]
+name = "rustls-webpki"
+version = "0.103.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7df23109aa6c1567d1c575b9952556388da57401e4ace1d15f79eedad0d8f53"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
+
+[[package]]
 name = "rustversion"
 version = "1.0.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+
+[[package]]
+name = "ryu"
+version = "1.0.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
 
 [[package]]
 name = "same-file"
@@ -3257,6 +3469,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
 dependencies = [
  "serde_core",
+]
+
+[[package]]
+name = "serde_urlencoded"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3491c14715ca2294c4d6a88f15e84739788c1d030eed8c110436aafdaa2f3fd"
+dependencies = [
+ "form_urlencoded",
+ "itoa",
+ "ryu",
+ "serde",
 ]
 
 [[package]]
@@ -3508,6 +3732,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
 
 [[package]]
+name = "subtle"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
+
+[[package]]
 name = "swift-rs"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3658,7 +3888,7 @@ dependencies = [
  "percent-encoding",
  "plist",
  "raw-window-handle",
- "reqwest",
+ "reqwest 0.13.2",
  "serde",
  "serde_json",
  "serde_repr",
@@ -4012,6 +4242,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinyvec"
+version = "1.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
+dependencies = [
+ "tinyvec_macros",
+]
+
+[[package]]
+name = "tinyvec_macros"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
+
+[[package]]
 name = "tokio"
 version = "1.50.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4022,7 +4267,29 @@ dependencies = [
  "mio",
  "pin-project-lite",
  "socket2",
+ "tokio-macros",
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "tokio-macros"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5c55a2eff8b69ce66c84f85e1da1c233edc36ceb85a2058d11b0d6a3c7e7569c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+dependencies = [
+ "rustls",
+ "tokio",
 ]
 
 [[package]]
@@ -4330,6 +4597,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
+name = "untrusted"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
+
+[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4576,6 +4849,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "web-time"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a6580f308b1fad9207618087a65c04e7a10bc77e02c8e84e9b00dd4b12fa0bb"
+dependencies = [
+ "js-sys",
+ "wasm-bindgen",
+]
+
+[[package]]
 name = "web_atoms"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4629,6 +4912,15 @@ dependencies = [
  "pkg-config",
  "soup3-sys",
  "system-deps",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -4859,6 +5151,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
 dependencies = [
  "windows-targets 0.42.2",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.52.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5435,6 +5736,12 @@ dependencies = [
  "syn 2.0.117",
  "synstructure",
 ]
+
+[[package]]
+name = "zeroize"
+version = "1.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
 
 [[package]]
 name = "zerotrie"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -16,5 +16,7 @@ tauri-build = { version = "2", features = [] }
 tauri = { version = "2", features = [] }
 tauri-plugin-opener = "2"
 tauri-plugin-global-shortcut = "2"
+reqwest = { version = "0.12", features = ["json", "rustls-tls"], default-features = false }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+tokio = { version = "1", features = ["macros"] }

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -3,6 +3,40 @@ fn greet(name: &str) -> String {
     format!("Hello, {}! You've been greeted from Rust!", name)
 }
 
+/// Proxy fetch to the Riot Live Client Data API.
+/// The API uses a self-signed certificate on localhost:2999 that browsers
+/// reject, so we proxy through Rust where we can accept invalid certs.
+///
+/// Returns the raw JSON string on success, or an error with a status code hint.
+#[tauri::command]
+async fn fetch_riot_api(endpoint: String) -> Result<String, String> {
+    let url = format!("https://localhost:2999{endpoint}");
+
+    let client = reqwest::Client::builder()
+        .danger_accept_invalid_certs(true)
+        .build()
+        .map_err(|e| format!("Failed to build HTTP client: {e}"))?;
+
+    let response = client
+        .get(&url)
+        .send()
+        .await
+        .map_err(|e| format!("CONNECTION_FAILED:{e}"))?;
+
+    let status = response.status().as_u16();
+    if status == 404 {
+        return Err("LOADING".to_string());
+    }
+    if !response.status().is_success() {
+        return Err(format!("HTTP_{status}"));
+    }
+
+    response
+        .text()
+        .await
+        .map_err(|e| format!("Failed to read response: {e}"))
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     tauri::Builder::default()
@@ -13,7 +47,7 @@ pub fn run() {
                 .plugin(tauri_plugin_global_shortcut::Builder::new().build())?;
             Ok(())
         })
-        .invoke_handler(tauri::generate_handler![greet])
+        .invoke_handler(tauri::generate_handler![greet, fetch_riot_api])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");
 }

--- a/src/App.css
+++ b/src/App.css
@@ -264,6 +264,88 @@ h1 {
   margin-top: 0.5em;
 }
 
+/* Game state */
+.game-status {
+  margin-bottom: 1rem;
+}
+
+.game-status-label {
+  font-weight: 600;
+  font-size: 1.1em;
+  margin: 0.25em 0;
+}
+
+.game-status-label.connected {
+  color: #4ade80;
+}
+
+.game-status-label.loading {
+  color: #fbbf24;
+}
+
+.game-status-label.disconnected {
+  color: #888;
+}
+
+.status-dot {
+  display: inline-block;
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  margin-left: 0.4em;
+  vertical-align: middle;
+}
+
+.status-dot.connected {
+  background-color: #4ade80;
+}
+
+.status-dot.loading {
+  background-color: #fbbf24;
+}
+
+.status-dot.disconnected {
+  background-color: #666;
+}
+
+.active-player-card {
+  background-color: #1a2a30;
+  border: 1px solid #2a4a50;
+  border-radius: 6px;
+  margin-bottom: 1rem;
+}
+
+.active-player-card .entity-details {
+  border-top: 1px solid #2a4a50;
+}
+
+.team-section {
+  margin-bottom: 1rem;
+}
+
+.team-section .entity-title {
+  margin-bottom: 0.5em;
+}
+
+.active-player {
+  border-left: 2px solid #4ade80;
+}
+
+.player-items {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.3em;
+  padding: 0.25em 0.75em 0.5em;
+}
+
+.player-item {
+  font-size: 0.8em;
+  padding: 0.15em 0.4em;
+  border-radius: 3px;
+  background-color: #2a2a30;
+  color: #aaa;
+}
+
 /* Runes */
 .rune-entry {
   padding: 0.25em 0;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,11 @@
 import "./App.css";
 import { useGameData } from "./hooks/useGameData";
+import { useGameState } from "./hooks/useGameState";
 import { DataBrowser } from "./components/DataBrowser";
 
 function App() {
   const { data, loading, error, refresh } = useGameData();
+  const gameState = useGameState();
 
   return (
     <main className="container">
@@ -24,7 +26,7 @@ function App() {
         {error && <p className="error">Error: {error}</p>}
         {data && <p className="version">Patch {data.version}</p>}
       </div>
-      {data && <DataBrowser data={data} />}
+      {data && <DataBrowser data={data} gameState={gameState} />}
     </main>
   );
 }

--- a/src/components/DataBrowser.tsx
+++ b/src/components/DataBrowser.tsx
@@ -1,18 +1,22 @@
 import { useState } from "react";
 import type { LoadedGameData } from "../lib/data-ingest";
+import type { GameState } from "../lib/game-state";
 import { ChampionList } from "./ChampionList";
 import { ItemList } from "./ItemList";
 import { RuneList } from "./RuneList";
 import { AugmentList } from "./AugmentList";
 import { EntitySearch } from "./EntitySearch";
+import { GameStateView } from "./GameStateView";
 
-type Tab = "champions" | "items" | "runes" | "augments" | "search";
+type Tab = "game" | "champions" | "items" | "runes" | "augments" | "search";
 
 interface DataBrowserProps {
   data: LoadedGameData;
+  gameState: GameState;
 }
 
 const TABS: { key: Tab; label: string }[] = [
+  { key: "game", label: "Game" },
   { key: "champions", label: "Champions" },
   { key: "items", label: "Items" },
   { key: "runes", label: "Runes" },
@@ -20,8 +24,8 @@ const TABS: { key: Tab; label: string }[] = [
   { key: "search", label: "Search" },
 ];
 
-export function DataBrowser({ data }: DataBrowserProps) {
-  const [activeTab, setActiveTab] = useState<Tab>("champions");
+export function DataBrowser({ data, gameState }: DataBrowserProps) {
+  const [activeTab, setActiveTab] = useState<Tab>("game");
 
   return (
     <>
@@ -33,13 +37,17 @@ export function DataBrowser({ data }: DataBrowserProps) {
             onClick={() => setActiveTab(tab.key)}
           >
             {tab.label}
-            {tab.key !== "search" && (
+            {tab.key === "game" && (
+              <span className={`status-dot ${gameState.status}`} />
+            )}
+            {tab.key !== "search" && tab.key !== "game" && (
               <span className="count">{getCount(data, tab.key)}</span>
             )}
           </button>
         ))}
       </div>
       <div className="tab-content">
+        {activeTab === "game" && <GameStateView state={gameState} />}
         {activeTab === "champions" && (
           <ChampionList champions={data.champions} />
         )}

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -1,0 +1,126 @@
+import type { GameState, PlayerInfo } from "../lib/game-state";
+
+interface GameStateViewProps {
+  state: GameState;
+}
+
+export function GameStateView({ state }: GameStateViewProps) {
+  if (state.status === "disconnected") {
+    return (
+      <div className="game-status">
+        <p className="game-status-label disconnected">No game detected</p>
+        <p className="entity-meta">
+          Start a game (or Practice Tool) to see live data.
+        </p>
+      </div>
+    );
+  }
+
+  if (state.status === "loading") {
+    return (
+      <div className="game-status">
+        <p className="game-status-label loading">Game loading...</p>
+        <p className="entity-meta">Waiting for the game to finish loading.</p>
+      </div>
+    );
+  }
+
+  const minutes = Math.floor(state.gameTime / 60);
+  const seconds = Math.floor(state.gameTime % 60);
+  const timeStr = `${minutes}:${seconds.toString().padStart(2, "0")}`;
+  const active = state.activePlayer;
+
+  const orderPlayers = state.players.filter((p) => p.team === "ORDER");
+  const chaosPlayers = state.players.filter((p) => p.team === "CHAOS");
+
+  return (
+    <div>
+      <div className="game-status">
+        <p className="game-status-label connected">
+          {state.gameMode} | {timeStr}
+        </p>
+      </div>
+
+      {active && (
+        <div className="active-player-card">
+          <div className="entity-header">
+            <span className="entity-name">{active.championName} (You)</span>
+            <span className="entity-meta">
+              Lv{active.level} | {Math.floor(active.currentGold)}g
+            </span>
+          </div>
+          <div className="entity-details">
+            <div className="stat-grid">
+              <span>
+                HP: {Math.floor(active.stats.currentHealth)}/
+                {Math.floor(active.stats.maxHealth)}
+              </span>
+              <span>AD: {Math.floor(active.stats.attackDamage)}</span>
+              <span>AP: {Math.floor(active.stats.abilityPower)}</span>
+              <span>Armor: {Math.floor(active.stats.armor)}</span>
+              <span>MR: {Math.floor(active.stats.magicResist)}</span>
+              <span>AS: {active.stats.attackSpeed.toFixed(2)}</span>
+              <span>AH: {Math.floor(active.stats.abilityHaste)}</span>
+              <span>MS: {Math.floor(active.stats.moveSpeed)}</span>
+            </div>
+            <p className="entity-meta">
+              {active.runes.keystone} ({active.runes.primaryTree} /{" "}
+              {active.runes.secondaryTree})
+            </p>
+          </div>
+        </div>
+      )}
+
+      <TeamSection label="Your Team" players={orderPlayers} />
+      <TeamSection label="Enemy Team" players={chaosPlayers} />
+    </div>
+  );
+}
+
+function TeamSection({
+  label,
+  players,
+}: {
+  label: string;
+  players: PlayerInfo[];
+}) {
+  if (players.length === 0) return null;
+
+  return (
+    <div className="team-section">
+      <p className="entity-title">{label}</p>
+      <div className="entity-list">
+        {players.map((p) => (
+          <div
+            key={p.riotIdGameName}
+            className={`entity-item${p.isActivePlayer ? " active-player" : ""}`}
+          >
+            <div className="entity-header">
+              <span className="entity-name">
+                {p.championName}
+                {p.isActivePlayer && " (You)"}
+              </span>
+              <span className="entity-meta">
+                Lv{p.level} | {p.kills}/{p.deaths}/{p.assists}
+              </span>
+            </div>
+            <div className="player-items">
+              {p.items.length > 0 ? (
+                p.items.map((item) => (
+                  <span
+                    key={`${p.riotIdGameName}-${item.id}`}
+                    className="player-item"
+                  >
+                    {item.name}
+                  </span>
+                ))
+              ) : (
+                <span className="entity-meta">No items</span>
+              )}
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useGameState.ts
+++ b/src/hooks/useGameState.ts
@@ -1,0 +1,27 @@
+import { useState, useEffect, useRef } from "react";
+import { GameStateManager, type GameState } from "../lib/game-state";
+
+const POLL_INTERVAL_MS = 2000;
+
+export function useGameState(): GameState {
+  const managerRef = useRef<GameStateManager | null>(null);
+
+  if (managerRef.current === null) {
+    managerRef.current = new GameStateManager();
+  }
+
+  const [state, setState] = useState<GameState>(managerRef.current.getState());
+
+  useEffect(() => {
+    const manager = managerRef.current!;
+    const unsubscribe = manager.subscribe(setState);
+    manager.start(POLL_INTERVAL_MS);
+
+    return () => {
+      unsubscribe();
+      manager.stop();
+    };
+  }, []);
+
+  return state;
+}

--- a/src/lib/game-state/index.ts
+++ b/src/lib/game-state/index.ts
@@ -1,0 +1,11 @@
+export { GameStateManager } from "./manager";
+export { normalizeGameState } from "./normalize";
+export type {
+  GameState,
+  ActivePlayer,
+  ActivePlayerRunes,
+  ActivePlayerStats,
+  PlayerInfo,
+  PlayerItem,
+  ConnectionStatus,
+} from "./types";

--- a/src/lib/game-state/manager.test.ts
+++ b/src/lib/game-state/manager.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { GameStateManager, type RiotApiFetcher } from "./manager";
+import type { GameState } from "./types";
+
+const SAMPLE_RESPONSE = {
+  activePlayer: {
+    riotIdGameName: "TestPlayer",
+    level: 5,
+    currentGold: 1000,
+    fullRunes: {
+      keystone: { displayName: "Electrocute" },
+      primaryRuneTree: { displayName: "Domination" },
+      secondaryRuneTree: { displayName: "Precision" },
+      generalRunes: [],
+    },
+    championStats: {
+      abilityPower: 0,
+      armor: 30,
+      attackDamage: 60,
+      attackSpeed: 0.65,
+      abilityHaste: 0,
+      critChance: 0,
+      magicResist: 30,
+      moveSpeed: 340,
+      maxHealth: 800,
+      currentHealth: 800,
+    },
+  },
+  allPlayers: [
+    {
+      championName: "Aatrox",
+      team: "ORDER",
+      level: 5,
+      riotIdGameName: "TestPlayer",
+      scores: { kills: 1, deaths: 0, assists: 2 },
+      items: [],
+      summonerSpells: {
+        summonerSpellOne: { displayName: "Flash" },
+        summonerSpellTwo: { displayName: "Ignite" },
+      },
+    },
+  ],
+  gameData: { gameMode: "ARAM", gameTime: 120 },
+};
+
+describe("GameStateManager", () => {
+  let manager: GameStateManager;
+  let mockFetcher: ReturnType<typeof vi.fn<RiotApiFetcher>>;
+
+  beforeEach(() => {
+    mockFetcher = vi.fn();
+    manager = new GameStateManager(mockFetcher);
+  });
+
+  afterEach(() => {
+    manager.stop();
+  });
+
+  it("starts in disconnected state", () => {
+    const state = manager.getState();
+    expect(state.status).toBe("disconnected");
+    expect(state.activePlayer).toBeNull();
+    expect(state.players).toEqual([]);
+  });
+
+  it("transitions to connected when fetcher returns data", async () => {
+    mockFetcher.mockResolvedValueOnce(SAMPLE_RESPONSE);
+
+    await manager.poll();
+    const state = manager.getState();
+
+    expect(state.status).toBe("connected");
+    expect(state.activePlayer?.championName).toBe("Aatrox");
+    expect(state.gameMode).toBe("ARAM");
+  });
+
+  it("transitions to loading when fetcher throws LOADING", async () => {
+    mockFetcher.mockRejectedValueOnce(new Error("LOADING"));
+
+    await manager.poll();
+    expect(manager.getState().status).toBe("loading");
+  });
+
+  it("transitions to disconnected when fetcher throws other error", async () => {
+    mockFetcher.mockRejectedValueOnce(new Error("CONNECTION_FAILED"));
+
+    await manager.poll();
+    expect(manager.getState().status).toBe("disconnected");
+  });
+
+  it("notifies subscribers on state change", async () => {
+    const subscriber = vi.fn();
+    manager.subscribe(subscriber);
+
+    mockFetcher.mockResolvedValueOnce(SAMPLE_RESPONSE);
+
+    await manager.poll();
+    expect(subscriber).toHaveBeenCalledTimes(1);
+
+    const state: GameState = subscriber.mock.calls[0][0];
+    expect(state.status).toBe("connected");
+  });
+
+  it("does not notify subscribers when state hasn't changed", async () => {
+    const subscriber = vi.fn();
+    manager.subscribe(subscriber);
+
+    mockFetcher.mockRejectedValue(new Error("CONNECTION_FAILED"));
+
+    // Already disconnected, poll returns disconnected again
+    await manager.poll();
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("allows unsubscribing", async () => {
+    const subscriber = vi.fn();
+    const unsubscribe = manager.subscribe(subscriber);
+    unsubscribe();
+
+    mockFetcher.mockResolvedValueOnce(SAMPLE_RESPONSE);
+
+    await manager.poll();
+    expect(subscriber).not.toHaveBeenCalled();
+  });
+
+  it("transitions back to disconnected when game ends", async () => {
+    // First: game is running
+    mockFetcher.mockResolvedValueOnce(SAMPLE_RESPONSE);
+    await manager.poll();
+    expect(manager.getState().status).toBe("connected");
+
+    // Then: game ends
+    mockFetcher.mockRejectedValueOnce(new Error("CONNECTION_FAILED"));
+    await manager.poll();
+    expect(manager.getState().status).toBe("disconnected");
+    expect(manager.getState().activePlayer).toBeNull();
+  });
+});

--- a/src/lib/game-state/manager.ts
+++ b/src/lib/game-state/manager.ts
@@ -1,0 +1,125 @@
+import type { GameState, ConnectionStatus } from "./types";
+import { normalizeGameState } from "./normalize";
+
+type Subscriber = (state: GameState) => void;
+
+/**
+ * Function that fetches raw game data from the Riot API.
+ * Returns the parsed JSON on success.
+ * Throws with message "LOADING" when the game is on the loading screen (404).
+ * Throws with any other message when the game is not running.
+ */
+export type RiotApiFetcher = () => Promise<unknown>;
+
+function createDisconnectedState(): GameState {
+  return {
+    status: "disconnected",
+    activePlayer: null,
+    players: [],
+    gameMode: "",
+    gameTime: 0,
+  };
+}
+
+function createLoadingState(): GameState {
+  return {
+    status: "loading",
+    activePlayer: null,
+    players: [],
+    gameMode: "",
+    gameTime: 0,
+  };
+}
+
+export class GameStateManager {
+  private state: GameState = createDisconnectedState();
+  private subscribers = new Set<Subscriber>();
+  private intervalId: ReturnType<typeof setInterval> | null = null;
+  private fetcher: RiotApiFetcher;
+
+  constructor(fetcher?: RiotApiFetcher) {
+    this.fetcher = fetcher ?? createDefaultFetcher();
+  }
+
+  getState(): GameState {
+    return this.state;
+  }
+
+  subscribe(fn: Subscriber): () => void {
+    this.subscribers.add(fn);
+    return () => this.subscribers.delete(fn);
+  }
+
+  start(intervalMs = 2000): void {
+    this.stop();
+    this.poll();
+    this.intervalId = setInterval(() => this.poll(), intervalMs);
+  }
+
+  stop(): void {
+    if (this.intervalId !== null) {
+      clearInterval(this.intervalId);
+      this.intervalId = null;
+    }
+  }
+
+  async poll(): Promise<void> {
+    const previousStatus = this.state.status;
+    let nextState: GameState;
+
+    try {
+      const data = await this.fetcher();
+      nextState = normalizeGameState(data);
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      if (message === "LOADING") {
+        nextState = createLoadingState();
+      } else {
+        nextState = createDisconnectedState();
+      }
+    }
+
+    const changed = hasStateChanged(previousStatus, nextState, this.state);
+    this.state = nextState;
+
+    if (changed) {
+      this.notify();
+    }
+  }
+
+  private notify(): void {
+    for (const fn of this.subscribers) {
+      fn(this.state);
+    }
+  }
+}
+
+/**
+ * Determine if the state has meaningfully changed. We always notify on
+ * status transitions. When status is "connected", we also notify on
+ * game time changes (which implies data has updated).
+ */
+function hasStateChanged(
+  previousStatus: ConnectionStatus,
+  next: GameState,
+  prev: GameState
+): boolean {
+  if (next.status !== previousStatus) return true;
+  if (next.status === "connected" && next.gameTime !== prev.gameTime)
+    return true;
+  return false;
+}
+
+/**
+ * Default fetcher that uses the Tauri command to proxy through Rust,
+ * which handles the self-signed cert on localhost:2999.
+ */
+function createDefaultFetcher(): RiotApiFetcher {
+  return async () => {
+    const { invoke } = await import("@tauri-apps/api/core");
+    const json = await invoke<string>("fetch_riot_api", {
+      endpoint: "/liveclientdata/allgamedata",
+    });
+    return JSON.parse(json);
+  };
+}

--- a/src/lib/game-state/normalize.test.ts
+++ b/src/lib/game-state/normalize.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect } from "vitest";
+import { normalizeGameState } from "./normalize";
+
+const SAMPLE_API_RESPONSE = {
+  activePlayer: {
+    riotIdGameName: "TestPlayer",
+    level: 8,
+    currentGold: 2340,
+    fullRunes: {
+      keystone: { displayName: "Dark Harvest" },
+      primaryRuneTree: { displayName: "Domination" },
+      secondaryRuneTree: { displayName: "Sorcery" },
+      generalRunes: [],
+    },
+    championStats: {
+      abilityPower: 120,
+      armor: 45,
+      attackDamage: 75,
+      attackSpeed: 0.8,
+      abilityHaste: 20,
+      critChance: 0,
+      magicResist: 35,
+      moveSpeed: 350,
+      maxHealth: 1200,
+      currentHealth: 950,
+    },
+  },
+  allPlayers: [
+    {
+      championName: "Aurelion Sol",
+      team: "ORDER",
+      level: 8,
+      riotIdGameName: "TestPlayer",
+      scores: { kills: 3, deaths: 1, assists: 5 },
+      items: [
+        { itemID: 2508, displayName: "Fated Ashes" },
+        { itemID: 3340, displayName: "Stealth Ward" },
+      ],
+      summonerSpells: {
+        summonerSpellOne: { displayName: "Flash" },
+        summonerSpellTwo: { displayName: "Ignite" },
+      },
+    },
+    {
+      championName: "Darius",
+      team: "CHAOS",
+      level: 7,
+      riotIdGameName: "EnemyPlayer",
+      scores: { kills: 2, deaths: 3, assists: 1 },
+      items: [{ itemID: 1055, displayName: "Doran's Blade" }],
+      summonerSpells: {
+        summonerSpellOne: { displayName: "Flash" },
+        summonerSpellTwo: { displayName: "Teleport" },
+      },
+    },
+  ],
+  gameData: {
+    gameMode: "ARAM",
+    gameTime: 542.5,
+  },
+};
+
+describe("normalizeGameState", () => {
+  it("normalizes a full API response into GameState", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+
+    expect(state.status).toBe("connected");
+    expect(state.gameMode).toBe("ARAM");
+    expect(state.gameTime).toBe(542.5);
+  });
+
+  it("extracts active player data", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+    const active = state.activePlayer;
+
+    expect(active).not.toBeNull();
+    expect(active!.championName).toBe("Aurelion Sol");
+    expect(active!.level).toBe(8);
+    expect(active!.currentGold).toBe(2340);
+  });
+
+  it("extracts active player runes", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+    const runes = state.activePlayer!.runes;
+
+    expect(runes.keystone).toBe("Dark Harvest");
+    expect(runes.primaryTree).toBe("Domination");
+    expect(runes.secondaryTree).toBe("Sorcery");
+  });
+
+  it("extracts active player stats", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+    const stats = state.activePlayer!.stats;
+
+    expect(stats.abilityPower).toBe(120);
+    expect(stats.attackDamage).toBe(75);
+    expect(stats.maxHealth).toBe(1200);
+    expect(stats.moveSpeed).toBe(350);
+  });
+
+  it("normalizes all players with items and scores", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+
+    expect(state.players).toHaveLength(2);
+    expect(state.players[0].championName).toBe("Aurelion Sol");
+    expect(state.players[0].team).toBe("ORDER");
+    expect(state.players[0].kills).toBe(3);
+    expect(state.players[0].items).toHaveLength(2);
+    expect(state.players[0].items[0].name).toBe("Fated Ashes");
+  });
+
+  it("marks the active player in the players list", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+
+    const active = state.players.find((p) => p.isActivePlayer);
+    expect(active).toBeDefined();
+    expect(active!.championName).toBe("Aurelion Sol");
+
+    const enemy = state.players.find((p) => !p.isActivePlayer);
+    expect(enemy).toBeDefined();
+    expect(enemy!.championName).toBe("Darius");
+  });
+
+  it("extracts summoner spells", () => {
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+
+    expect(state.players[0].summonerSpells).toEqual(["Flash", "Ignite"]);
+    expect(state.players[1].summonerSpells).toEqual(["Flash", "Teleport"]);
+  });
+
+  it("resolves active player champion name from allPlayers", () => {
+    // The activePlayer block in the API doesn't always have championName,
+    // so we resolve it by matching riotIdGameName in allPlayers
+    const state = normalizeGameState(SAMPLE_API_RESPONSE);
+
+    expect(state.activePlayer!.championName).toBe("Aurelion Sol");
+  });
+});

--- a/src/lib/game-state/normalize.ts
+++ b/src/lib/game-state/normalize.ts
@@ -1,0 +1,96 @@
+import type {
+  GameState,
+  ActivePlayer,
+  ActivePlayerRunes,
+  ActivePlayerStats,
+  PlayerInfo,
+  PlayerItem,
+} from "./types";
+
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+/**
+ * Normalize a raw Riot Live Client Data API response into our GameState shape.
+ * The raw response structure is documented at:
+ * https://developer.riotgames.com/docs/lol#game-client-api
+ */
+export function normalizeGameState(raw: any): GameState {
+  const activePlayerRaw = raw.activePlayer;
+  const allPlayersRaw: any[] = raw.allPlayers ?? [];
+  const gameDataRaw = raw.gameData;
+
+  const activeRiotId: string = activePlayerRaw?.riotIdGameName ?? "";
+  const activePlayerMatch = allPlayersRaw.find(
+    (p) => p.riotIdGameName === activeRiotId
+  );
+
+  const activePlayer: ActivePlayer | null = activePlayerRaw
+    ? {
+        championName: activePlayerMatch?.championName ?? "",
+        level: activePlayerRaw.level,
+        currentGold: activePlayerRaw.currentGold,
+        runes: normalizeRunes(activePlayerRaw.fullRunes),
+        stats: normalizeStats(activePlayerRaw.championStats),
+      }
+    : null;
+
+  const players: PlayerInfo[] = allPlayersRaw.map((p) =>
+    normalizePlayer(p, activeRiotId)
+  );
+
+  return {
+    status: "connected",
+    activePlayer,
+    players,
+    gameMode: gameDataRaw?.gameMode ?? "",
+    gameTime: gameDataRaw?.gameTime ?? 0,
+  };
+}
+
+function normalizeRunes(raw: any): ActivePlayerRunes {
+  return {
+    keystone: raw?.keystone?.displayName ?? "",
+    primaryTree: raw?.primaryRuneTree?.displayName ?? "",
+    secondaryTree: raw?.secondaryRuneTree?.displayName ?? "",
+  };
+}
+
+function normalizeStats(raw: any): ActivePlayerStats {
+  return {
+    abilityPower: raw?.abilityPower ?? 0,
+    armor: raw?.armor ?? 0,
+    attackDamage: raw?.attackDamage ?? 0,
+    attackSpeed: raw?.attackSpeed ?? 0,
+    abilityHaste: raw?.abilityHaste ?? 0,
+    critChance: raw?.critChance ?? 0,
+    magicResist: raw?.magicResist ?? 0,
+    moveSpeed: raw?.moveSpeed ?? 0,
+    maxHealth: raw?.maxHealth ?? 0,
+    currentHealth: raw?.currentHealth ?? 0,
+  };
+}
+
+function normalizePlayer(raw: any, activeRiotId: string): PlayerInfo {
+  return {
+    championName: raw.championName ?? "",
+    team: raw.team === "CHAOS" ? "CHAOS" : "ORDER",
+    level: raw.level ?? 0,
+    kills: raw.scores?.kills ?? 0,
+    deaths: raw.scores?.deaths ?? 0,
+    assists: raw.scores?.assists ?? 0,
+    items: (raw.items ?? []).map(normalizeItem),
+    summonerSpells: [
+      raw.summonerSpells?.summonerSpellOne?.displayName ?? "",
+      raw.summonerSpells?.summonerSpellTwo?.displayName ?? "",
+    ],
+    riotIdGameName: raw.riotIdGameName ?? "",
+    isActivePlayer: raw.riotIdGameName === activeRiotId,
+  };
+}
+
+function normalizeItem(raw: any): PlayerItem {
+  return {
+    id: raw.itemID ?? 0,
+    name: raw.displayName ?? "",
+  };
+}

--- a/src/lib/game-state/normalize.ts
+++ b/src/lib/game-state/normalize.ts
@@ -27,8 +27,8 @@ export function normalizeGameState(raw: any): GameState {
   const activePlayer: ActivePlayer | null = activePlayerRaw
     ? {
         championName: activePlayerMatch?.championName ?? "",
-        level: activePlayerRaw.level,
-        currentGold: activePlayerRaw.currentGold,
+        level: activePlayerRaw.level ?? 0,
+        currentGold: activePlayerRaw.currentGold ?? 0,
         runes: normalizeRunes(activePlayerRaw.fullRunes),
         stats: normalizeStats(activePlayerRaw.championStats),
       }
@@ -84,7 +84,7 @@ function normalizePlayer(raw: any, activeRiotId: string): PlayerInfo {
       raw.summonerSpells?.summonerSpellTwo?.displayName ?? "",
     ],
     riotIdGameName: raw.riotIdGameName ?? "",
-    isActivePlayer: raw.riotIdGameName === activeRiotId,
+    isActivePlayer: activeRiotId !== "" && raw.riotIdGameName === activeRiotId,
   };
 }
 

--- a/src/lib/game-state/types.ts
+++ b/src/lib/game-state/types.ts
@@ -1,0 +1,54 @@
+export type ConnectionStatus = "disconnected" | "loading" | "connected";
+
+export interface GameState {
+  status: ConnectionStatus;
+  activePlayer: ActivePlayer | null;
+  players: PlayerInfo[];
+  gameMode: string;
+  gameTime: number;
+}
+
+export interface ActivePlayer {
+  championName: string;
+  level: number;
+  currentGold: number;
+  runes: ActivePlayerRunes;
+  stats: ActivePlayerStats;
+}
+
+export interface ActivePlayerRunes {
+  keystone: string;
+  primaryTree: string;
+  secondaryTree: string;
+}
+
+export interface ActivePlayerStats {
+  abilityPower: number;
+  armor: number;
+  attackDamage: number;
+  attackSpeed: number;
+  abilityHaste: number;
+  critChance: number;
+  magicResist: number;
+  moveSpeed: number;
+  maxHealth: number;
+  currentHealth: number;
+}
+
+export interface PlayerInfo {
+  championName: string;
+  team: "ORDER" | "CHAOS";
+  level: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  items: PlayerItem[];
+  summonerSpells: [string, string];
+  riotIdGameName: string;
+  isActivePlayer: boolean;
+}
+
+export interface PlayerItem {
+  id: number;
+  name: string;
+}


### PR DESCRIPTION
## Summary

- Game State Manager polls the Riot Live Client Data API via a Rust proxy command (handles the self-signed cert on localhost:2999)
- Detects three connection states: disconnected (no game), loading (loading screen, 404), connected (in-game with live data)
- Normalizes API responses into typed GameState: active player stats/runes/gold, all players with items/KDA/teams, game mode and time
- New "Game" tab in the shell with status indicator dot (green/yellow/gray), active player card with stats, and team rosters with items
- Fetcher is injectable for testability; 16 new tests for normalization and state management
- 88 tests total

Closes #3

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a dedicated "Game" tab (now the default) showing real-time game state with connection/loading/disconnected indicators and a status dot
  * Live active-player card (champion, level, gold, stats, runes, items) and separate Your Team / Enemy Team sections
  * Game time display and automatic polling/refresh of live data

* **Style**
  * New UI styles for game status, active-player card, team sections, and item pills

* **Tests**
  * Added tests for game-state manager and data normalization
<!-- end of auto-generated comment: release notes by coderabbit.ai -->