### PR TITLE
feat: add manual augment input with card-based picker

### DIFF
--- a/plans/technical-reference.md
+++ b/plans/technical-reference.md
@@ -43,7 +43,8 @@ The API uses a self-signed HTTPS certificate. The Tauri webview can't fetch it d
 
 **Not exposed:**
 
-- Augments (any mode) — requires voice/manual input
+- Augments (any mode) — requires voice/manual input. In ARAM Mayhem, augment selection happens at levels 1, 7, 11, and 15 (4 total per game), but only after the player returns to the Nexus at that level. The API exposes player level but not whether they're at the Nexus or have an augment offer pending.
+- Some augments auto-select a follow-up (e.g., Transmute: Chaos grants two random augments instead of one). This can happen once per game, meaning a player can end up with 5 augments total (4 chosen + 1 granted). The API doesn't expose these auto-selections, so the app needs a way to record the granted augment. The UI should distinguish between "chosen" slots (4 max) and a "granted" slot that appears as a result of choosing certain augments. With voice input, the user can report all augments received in one utterance.
 - Enemy gold (only active player's gold)
 - Ability cooldowns (Riot policy)
 - Detailed stats for other players

--- a/src/App.css
+++ b/src/App.css
@@ -462,7 +462,6 @@ h1 {
   border-radius: 0;
   border: 0.375rem solid #333;
   background: linear-gradient(180deg, #1e1e30 0%, #14141f 100%);
-  cursor: pointer;
   text-align: center;
   font-family: inherit;
   color: inherit;
@@ -471,6 +470,10 @@ h1 {
     background 0.15s;
   overflow: hidden;
   aspect-ratio: 2 / 3;
+}
+
+button.augment-card {
+  cursor: pointer;
 }
 
 .augment-card:hover {
@@ -529,6 +532,7 @@ h1 {
 }
 
 .augment-card-name {
+  display: block;
   font-size: 0.95em;
   font-weight: 600;
   margin: 0;
@@ -538,6 +542,7 @@ h1 {
 }
 
 .augment-card-desc {
+  display: block;
   font-size: 0.7em;
   color: #aaa;
   margin: 0;

--- a/src/App.css
+++ b/src/App.css
@@ -581,12 +581,84 @@ h1 {
   display: none;
 }
 
-/* Selected augments display */
-.selected-augments {
+/* Augment slots */
+.augment-slots-container {
+  margin-bottom: 1rem;
+}
+
+.augment-slots-header {
   display: flex;
-  flex-wrap: wrap;
-  gap: 0.25rem;
-  padding: 0.5rem 0;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.augment-slots {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+  gap: 0.5rem;
+}
+
+.augment-slots .augment-card {
+  aspect-ratio: 2 / 3;
+}
+
+.augment-slot-empty {
+  aspect-ratio: 2 / 3;
+  border: 0.125rem dashed #444;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: #151520;
+}
+
+.augment-slot-clickable {
+  cursor: pointer;
+  border-color: #666;
+}
+
+.augment-slot-clickable:hover {
+  border-color: #888;
+  background-color: #1a1a2a;
+}
+
+.augment-slot-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.5rem;
+  color: #555;
+}
+
+.augment-slot-number {
+  font-size: 1.5rem;
+  font-weight: 700;
+  color: #333;
+}
+
+.augment-slot-hint {
+  font-size: 0.7em;
+  color: #666;
+}
+
+/* Augment picker overlay */
+.augment-picker-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 100;
+  background-color: rgba(10, 10, 15, 0.95);
+  padding: 1.5rem;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+.augment-picker-overlay-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.75rem;
+  flex-shrink: 0;
 }
 
 /* Runes */

--- a/src/App.css
+++ b/src/App.css
@@ -441,6 +441,154 @@ h1 {
   color: #aaa;
 }
 
+/* Augment cards */
+.augment-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.augment-card-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(18rem, 1fr));
+  gap: 0.5rem;
+}
+
+.augment-card {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  padding: 1rem 0.75rem;
+  border-radius: 0;
+  border: 0.375rem solid #333;
+  background: linear-gradient(180deg, #1e1e30 0%, #14141f 100%);
+  cursor: pointer;
+  text-align: center;
+  font-family: inherit;
+  color: inherit;
+  transition:
+    border-color 0.15s,
+    background 0.15s;
+  overflow: hidden;
+  aspect-ratio: 2 / 3;
+}
+
+.augment-card:hover {
+  background: linear-gradient(180deg, #262640 0%, #1a1a2a 100%);
+}
+
+.augment-card.tier-border-prismatic {
+  border-color: #e0c8ff;
+  border-image: linear-gradient(
+      135deg,
+      #ff80ab,
+      #82b1ff,
+      #b388ff,
+      #80cbc4,
+      #fff59d,
+      #ff80ab
+    )
+    1;
+}
+
+.augment-card.tier-border-prismatic:hover {
+  border-image: linear-gradient(
+      135deg,
+      #ffa0c0,
+      #a0c8ff,
+      #c8a0ff,
+      #a0e0d0,
+      #ffe880,
+      #ffa0c0
+    )
+    1;
+}
+
+.augment-card.tier-border-gold {
+  border-color: #c8a820;
+}
+
+.augment-card.tier-border-gold:hover {
+  border-color: #e0c040;
+}
+
+.augment-card.tier-border-silver {
+  border-color: #606068;
+}
+
+.augment-card.tier-border-silver:hover {
+  border-color: #888890;
+}
+
+.augment-card-icon {
+  width: 4.5rem;
+  height: 4.5rem;
+  object-fit: contain;
+  margin: 0.75rem 0;
+  flex-shrink: 0;
+}
+
+.augment-card-name {
+  font-size: 0.95em;
+  font-weight: 600;
+  margin: 0;
+  padding-bottom: 0.4rem;
+  border-bottom: 0.0625rem solid #333;
+  width: 100%;
+}
+
+.augment-card-desc {
+  font-size: 0.7em;
+  color: #aaa;
+  margin: 0;
+  padding-top: 0.4rem;
+  line-height: 1.4;
+  width: 100%;
+}
+
+.augment-card-sets {
+  display: flex;
+  gap: 0.25rem;
+  flex-wrap: wrap;
+  margin-top: auto;
+  padding-top: 0.5rem;
+}
+
+.augment-card-set {
+  font-size: 0.65em;
+  color: #c9a0dc;
+  background-color: #2a1a35;
+  padding: 0.1em 0.4em;
+  border-radius: 0.125rem;
+}
+
+.augment-card-compact {
+  flex-direction: row;
+  gap: 0.5rem;
+  text-align: left;
+  padding: 0.25rem 0.5rem;
+  min-height: auto;
+}
+
+.augment-card-compact .augment-card-icon {
+  width: 2rem;
+  height: 2rem;
+  margin: 0;
+  flex-shrink: 0;
+}
+
+.augment-card-compact .augment-card-sets {
+  display: none;
+}
+
+/* Selected augments display */
+.selected-augments {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.25rem;
+  padding: 0.5rem 0;
+}
+
 /* Runes */
 .rune-entry {
   padding: 0.25em 0;

--- a/src/App.css
+++ b/src/App.css
@@ -622,6 +622,28 @@ h1 {
   background-color: #1a1a2a;
 }
 
+.augment-slot-pending {
+  border-color: #4ade80;
+  border-style: solid;
+  animation: slot-pulse 2s ease-in-out infinite;
+}
+
+@keyframes slot-pulse {
+  0%,
+  100% {
+    border-color: #4ade80;
+  }
+  50% {
+    border-color: #22c55e80;
+  }
+}
+
+.augment-slot-available {
+  font-size: 0.7em;
+  color: #4ade80;
+  font-weight: 500;
+}
+
 .augment-slot-placeholder {
   display: flex;
   flex-direction: column;

--- a/src/App.css
+++ b/src/App.css
@@ -643,6 +643,24 @@ button.augment-card {
   }
 }
 
+.augment-slot-removable {
+  cursor: pointer;
+  position: relative;
+}
+
+.augment-slot-removable:hover::after {
+  content: "Remove";
+  position: absolute;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background-color: rgba(10, 10, 15, 0.8);
+  color: #ff6b6b;
+  font-size: 0.85em;
+  font-weight: 600;
+}
+
 .augment-slot-available {
   font-size: 0.7em;
   color: #4ade80;

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,13 +2,19 @@ import "./App.css";
 import { useGameData } from "./hooks/useGameData";
 import { useGameState } from "./hooks/useGameState";
 import { useEffectiveGameState } from "./hooks/useEffectiveGameState";
+import { useAugmentSelection } from "./hooks/useAugmentSelection";
 import { useZoom } from "./hooks/useZoom";
 import { DataBrowser } from "./components/DataBrowser";
 
 function App() {
   const { data, loading, error, refresh } = useGameData();
   const gameState = useGameState();
-  const effectiveState = useEffectiveGameState(gameState, data);
+  const augmentSelection = useAugmentSelection(gameState.gameMode);
+  const effectiveState = useEffectiveGameState(
+    gameState,
+    data,
+    augmentSelection.selectedAugments
+  );
   const { zoom, resetZoom } = useZoom();
 
   return (
@@ -37,7 +43,13 @@ function App() {
           )}
         </div>
       </div>
-      {data && <DataBrowser data={data} effectiveState={effectiveState} />}
+      {data && (
+        <DataBrowser
+          data={data}
+          effectiveState={effectiveState}
+          augmentSelection={augmentSelection}
+        />
+      )}
     </main>
   );
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,7 +9,9 @@ import { DataBrowser } from "./components/DataBrowser";
 function App() {
   const { data, loading, error, refresh } = useGameData();
   const gameState = useGameState();
-  const augmentSelection = useAugmentSelection(gameState.gameMode);
+  const augmentSelection = useAugmentSelection(
+    `${gameState.status}:${gameState.gameMode}`
+  );
   const effectiveState = useEffectiveGameState(
     gameState,
     data,

--- a/src/components/AugmentCard.tsx
+++ b/src/components/AugmentCard.tsx
@@ -22,18 +22,18 @@ export function AugmentCard({ augment, onClick, compact }: AugmentCardProps) {
           loading="lazy"
         />
       )}
-      <p className="augment-card-name">{augment.name}</p>
+      <span className="augment-card-name">{augment.name}</span>
       {!compact && augment.description && (
-        <p className="augment-card-desc">{augment.description}</p>
+        <span className="augment-card-desc">{augment.description}</span>
       )}
       {!compact && augment.sets.length > 0 && (
-        <div className="augment-card-sets">
+        <span className="augment-card-sets">
           {augment.sets.map((s) => (
             <span key={s} className="augment-card-set">
               {s}
             </span>
           ))}
-        </div>
+        </span>
       )}
     </Tag>
   );

--- a/src/components/AugmentCard.tsx
+++ b/src/components/AugmentCard.tsx
@@ -1,0 +1,40 @@
+import type { Augment } from "../lib/data-ingest/types";
+
+interface AugmentCardProps {
+  augment: Augment;
+  onClick?: (augment: Augment) => void;
+  compact?: boolean;
+}
+
+export function AugmentCard({ augment, onClick, compact }: AugmentCardProps) {
+  const Tag = onClick ? "button" : "div";
+
+  return (
+    <Tag
+      className={`augment-card tier-border-${augment.tier.toLowerCase()}${compact ? " augment-card-compact" : ""}`}
+      onClick={onClick ? () => onClick(augment) : undefined}
+    >
+      {augment.iconPath && (
+        <img
+          className="augment-card-icon"
+          src={augment.iconPath}
+          alt={augment.name}
+          loading="lazy"
+        />
+      )}
+      <p className="augment-card-name">{augment.name}</p>
+      {!compact && augment.description && (
+        <p className="augment-card-desc">{augment.description}</p>
+      )}
+      {!compact && augment.sets.length > 0 && (
+        <div className="augment-card-sets">
+          {augment.sets.map((s) => (
+            <span key={s} className="augment-card-set">
+              {s}
+            </span>
+          ))}
+        </div>
+      )}
+    </Tag>
+  );
+}

--- a/src/components/AugmentList.tsx
+++ b/src/components/AugmentList.tsx
@@ -1,5 +1,6 @@
 import { useState, useMemo } from "react";
 import type { Augment, AugmentMode } from "../lib/data-ingest/types";
+import { AugmentCard } from "./AugmentCard";
 
 interface AugmentListProps {
   augments: Map<string, Augment>;
@@ -17,10 +18,10 @@ const MODE_LABELS: Record<AugmentMode, string> = {
 };
 
 export function AugmentList({ augments }: AugmentListProps) {
-  const [expanded, setExpanded] = useState<string | null>(null);
   const [modeFilter, setModeFilter] = useState<AugmentMode>("mayhem");
   const [tierFilters, setTierFilters] = useState<Set<Tier>>(new Set(TIERS));
   const [setFilter, setSetFilter] = useState<string | null>(null);
+  const [query, setQuery] = useState("");
 
   function toggleTier(tier: Tier) {
     setTierFilters((prev) => {
@@ -38,7 +39,6 @@ export function AugmentList({ augments }: AugmentListProps) {
     (a) => a.mode === modeFilter
   );
 
-  // Collect unique set names for the current mode
   const setNames = useMemo(() => {
     const names = new Set<string>();
     for (const a of modeFiltered) {
@@ -49,7 +49,15 @@ export function AugmentList({ augments }: AugmentListProps) {
 
   const filtered = modeFiltered
     .filter((a) => tierFilters.has(a.tier))
-    .filter((a) => (setFilter ? a.sets.includes(setFilter) : true));
+    .filter((a) => (setFilter ? a.sets.includes(setFilter) : true))
+    .filter((a) => {
+      if (query.trim().length < 2) return true;
+      const lower = query.toLowerCase();
+      return (
+        a.name.toLowerCase().includes(lower) ||
+        a.description.toLowerCase().includes(lower)
+      );
+    });
 
   const sorted = filtered.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -75,7 +83,6 @@ export function AugmentList({ augments }: AugmentListProps) {
                 key={mode}
                 className={modeFilter === mode ? "tab active" : "tab"}
                 onClick={() => {
-                  setExpanded(null);
                   setModeFilter(mode);
                   setSetFilter(null);
                 }}
@@ -118,48 +125,21 @@ export function AugmentList({ augments }: AugmentListProps) {
             ))}
           </div>
         )}
+        <input
+          type="text"
+          placeholder="Search augments..."
+          value={query}
+          onChange={(e) => setQuery(e.target.value)}
+          className="search-input"
+          style={{ marginTop: "0.5rem", marginBottom: 0 }}
+        />
       </div>
-      <p className="entity-meta" style={{ padding: "0 8px" }}>
+      <p className="entity-meta" style={{ padding: "0.25rem 0" }}>
         Showing {sorted.length} augments
       </p>
-      <div className="entity-list">
+      <div className="augment-card-grid">
         {sorted.map((aug) => (
-          <div key={`${aug.mode}-${aug.name}`} className="entity-item">
-            <div
-              className="entity-header"
-              onClick={() =>
-                setExpanded(expanded === aug.name ? null : aug.name)
-              }
-            >
-              <span className="entity-name">
-                {aug.name}
-                {aug.sets.map((s) => (
-                  <span key={s} className="set-badge">
-                    {s}
-                  </span>
-                ))}
-              </span>
-              <span className="entity-meta">
-                <span className={`tier tier-${aug.tier.toLowerCase()}`}>
-                  {aug.tier}
-                </span>
-              </span>
-            </div>
-            {expanded === aug.name && (
-              <div className="entity-details">
-                {aug.description ? (
-                  <p>{aug.description}</p>
-                ) : (
-                  <p className="entity-meta">No description available</p>
-                )}
-                {aug.id != null && (
-                  <p className="entity-meta">
-                    ID: {aug.id} | Mode: {MODE_LABELS[aug.mode]}
-                  </p>
-                )}
-              </div>
-            )}
-          </div>
+          <AugmentCard key={`${aug.mode}-${aug.name}`} augment={aug} />
         ))}
       </div>
     </div>

--- a/src/components/AugmentPicker.tsx
+++ b/src/components/AugmentPicker.tsx
@@ -1,0 +1,49 @@
+import { useState, useMemo } from "react";
+import type { Augment } from "../lib/data-ingest/types";
+import { AugmentCard } from "./AugmentCard";
+
+interface AugmentPickerProps {
+  augments: Map<string, Augment>;
+  onSelect: (augment: Augment) => void;
+}
+
+export function AugmentPicker({ augments, onSelect }: AugmentPickerProps) {
+  const [query, setQuery] = useState("");
+
+  const filtered = useMemo(() => {
+    const all = [...augments.values()].sort((a, b) =>
+      a.name.localeCompare(b.name)
+    );
+    if (query.trim().length < 2) return all;
+
+    const lower = query.toLowerCase();
+    return all.filter(
+      (a) =>
+        a.name.toLowerCase().includes(lower) ||
+        a.description.toLowerCase().includes(lower) ||
+        a.sets.some((s) => s.toLowerCase().includes(lower))
+    );
+  }, [augments, query]);
+
+  return (
+    <div className="augment-picker">
+      <input
+        type="text"
+        placeholder="Search augments..."
+        value={query}
+        onChange={(e) => setQuery(e.target.value)}
+        className="search-input"
+      />
+      <p className="entity-meta">{filtered.length} augments</p>
+      <div className="augment-card-grid">
+        {filtered.map((aug) => (
+          <AugmentCard
+            key={`${aug.mode}-${aug.name}`}
+            augment={aug}
+            onClick={onSelect}
+          />
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/AugmentPicker.tsx
+++ b/src/components/AugmentPicker.tsx
@@ -4,16 +4,21 @@ import { AugmentCard } from "./AugmentCard";
 
 interface AugmentPickerProps {
   augments: Map<string, Augment>;
+  excludeNames?: Set<string>;
   onSelect: (augment: Augment) => void;
 }
 
-export function AugmentPicker({ augments, onSelect }: AugmentPickerProps) {
+export function AugmentPicker({
+  augments,
+  excludeNames,
+  onSelect,
+}: AugmentPickerProps) {
   const [query, setQuery] = useState("");
 
   const filtered = useMemo(() => {
-    const all = [...augments.values()].sort((a, b) =>
-      a.name.localeCompare(b.name)
-    );
+    const all = [...augments.values()]
+      .filter((a) => !excludeNames?.has(a.name))
+      .sort((a, b) => a.name.localeCompare(b.name));
     if (query.trim().length < 2) return all;
 
     const lower = query.toLowerCase();
@@ -23,7 +28,7 @@ export function AugmentPicker({ augments, onSelect }: AugmentPickerProps) {
         a.description.toLowerCase().includes(lower) ||
         a.sets.some((s) => s.toLowerCase().includes(lower))
     );
-  }, [augments, query]);
+  }, [augments, excludeNames, query]);
 
   return (
     <div className="augment-picker">

--- a/src/components/AugmentPicker.tsx
+++ b/src/components/AugmentPicker.tsx
@@ -30,6 +30,7 @@ export function AugmentPicker({ augments, onSelect }: AugmentPickerProps) {
       <input
         type="text"
         placeholder="Search augments..."
+        aria-label="Search augments"
         value={query}
         onChange={(e) => setQuery(e.target.value)}
         className="search-input"

--- a/src/components/AugmentSlots.tsx
+++ b/src/components/AugmentSlots.tsx
@@ -11,6 +11,7 @@ interface AugmentSlotsProps {
   availableAugments: Map<string, Augment>;
   availability?: AugmentAvailability;
   onSelect: (augment: Augment) => void;
+  onRemoveLast: () => void;
   onReset: () => void;
 }
 
@@ -19,6 +20,7 @@ export function AugmentSlots({
   availableAugments,
   availability,
   onSelect,
+  onRemoveLast,
   onReset,
 }: AugmentSlotsProps) {
   const [pickerOpen, setPickerOpen] = useState(false);
@@ -31,6 +33,7 @@ export function AugmentSlots({
   const nextEmptySlot = selectedAugments.length;
   const canPick = nextEmptySlot < MAX_AUGMENT_SLOTS;
   const isPending = availability?.isAvailable ?? false;
+  const selectedNames = new Set(selectedAugments.map((a) => a.name));
 
   return (
     <div className="augment-slots-container">
@@ -47,41 +50,52 @@ export function AugmentSlots({
           const augment = selectedAugments[i];
           const isEmpty = !augment;
           const isClickable = isEmpty && i === nextEmptySlot && canPick;
+          const isLastFilled = !isEmpty && i === nextEmptySlot - 1;
           const isSlotPending = isPending && availability?.pendingSlot === i;
 
-          return isEmpty ? (
+          if (isEmpty) {
+            return (
+              <div
+                key={i}
+                className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}${isSlotPending ? " augment-slot-pending" : ""}`}
+                role={isClickable ? "button" : undefined}
+                tabIndex={isClickable ? 0 : undefined}
+                onClick={isClickable ? () => setPickerOpen(true) : undefined}
+                onKeyDown={
+                  isClickable
+                    ? (e) => {
+                        if (e.key === "Enter" || e.key === " ") {
+                          e.preventDefault();
+                          setPickerOpen(true);
+                        }
+                      }
+                    : undefined
+                }
+              >
+                <div className="augment-slot-placeholder">
+                  <span className="augment-slot-number">{i + 1}</span>
+                  {isSlotPending ? (
+                    <span className="augment-slot-available">
+                      Augment available
+                    </span>
+                  ) : (
+                    isClickable && (
+                      <span className="augment-slot-hint">Tap to choose</span>
+                    )
+                  )}
+                </div>
+              </div>
+            );
+          }
+
+          return (
             <div
               key={i}
-              className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}${isSlotPending ? " augment-slot-pending" : ""}`}
-              role={isClickable ? "button" : undefined}
-              tabIndex={isClickable ? 0 : undefined}
-              onClick={isClickable ? () => setPickerOpen(true) : undefined}
-              onKeyDown={
-                isClickable
-                  ? (e) => {
-                      if (e.key === "Enter" || e.key === " ") {
-                        e.preventDefault();
-                        setPickerOpen(true);
-                      }
-                    }
-                  : undefined
-              }
+              className={`augment-slot${isLastFilled ? " augment-slot-removable" : ""}`}
+              onClick={isLastFilled ? onRemoveLast : undefined}
             >
-              <div className="augment-slot-placeholder">
-                <span className="augment-slot-number">{i + 1}</span>
-                {isSlotPending ? (
-                  <span className="augment-slot-available">
-                    Augment available
-                  </span>
-                ) : (
-                  isClickable && (
-                    <span className="augment-slot-hint">Tap to choose</span>
-                  )
-                )}
-              </div>
+              <AugmentCard augment={augment} />
             </div>
-          ) : (
-            <AugmentCard key={i} augment={augment} />
           );
         })}
       </div>
@@ -97,7 +111,11 @@ export function AugmentSlots({
               Cancel
             </button>
           </div>
-          <AugmentPicker augments={availableAugments} onSelect={handleSelect} />
+          <AugmentPicker
+            augments={availableAugments}
+            excludeNames={selectedNames}
+            onSelect={handleSelect}
+          />
         </div>
       )}
     </div>

--- a/src/components/AugmentSlots.tsx
+++ b/src/components/AugmentSlots.tsx
@@ -1,0 +1,82 @@
+import { useState } from "react";
+import type { Augment } from "../lib/data-ingest/types";
+import { AugmentCard } from "./AugmentCard";
+import { AugmentPicker } from "./AugmentPicker";
+
+const MAX_AUGMENT_SLOTS = 4;
+
+interface AugmentSlotsProps {
+  selectedAugments: Augment[];
+  availableAugments: Map<string, Augment>;
+  onSelect: (augment: Augment) => void;
+  onReset: () => void;
+}
+
+export function AugmentSlots({
+  selectedAugments,
+  availableAugments,
+  onSelect,
+  onReset,
+}: AugmentSlotsProps) {
+  const [pickerOpen, setPickerOpen] = useState(false);
+
+  function handleSelect(augment: Augment) {
+    onSelect(augment);
+    setPickerOpen(false);
+  }
+
+  const nextEmptySlot = selectedAugments.length;
+  const canPick = nextEmptySlot < MAX_AUGMENT_SLOTS;
+
+  return (
+    <div className="augment-slots-container">
+      <div className="augment-slots-header">
+        <p className="entity-title">Your Augments</p>
+        {selectedAugments.length > 0 && (
+          <button className="refresh-btn" onClick={onReset}>
+            Clear
+          </button>
+        )}
+      </div>
+      <div className="augment-slots">
+        {Array.from({ length: MAX_AUGMENT_SLOTS }, (_, i) => {
+          const augment = selectedAugments[i];
+          const isEmpty = !augment;
+          const isClickable = isEmpty && i === nextEmptySlot && canPick;
+
+          return isEmpty ? (
+            <div
+              key={i}
+              className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}`}
+              onClick={isClickable ? () => setPickerOpen(true) : undefined}
+            >
+              <div className="augment-slot-placeholder">
+                <span className="augment-slot-number">{i + 1}</span>
+                {isClickable && (
+                  <span className="augment-slot-hint">Tap to choose</span>
+                )}
+              </div>
+            </div>
+          ) : (
+            <AugmentCard key={i} augment={augment} />
+          );
+        })}
+      </div>
+
+      {pickerOpen && (
+        <div className="augment-picker-overlay">
+          <div className="augment-picker-overlay-header">
+            <p className="entity-title">Choose Augment</p>
+            <button
+              className="refresh-btn"
+              onClick={() => setPickerOpen(false)}
+            >
+              Cancel
+            </button>
+          </div>
+          <AugmentPicker augments={availableAugments} onSelect={handleSelect} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/AugmentSlots.tsx
+++ b/src/components/AugmentSlots.tsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import type { Augment } from "../lib/data-ingest/types";
+import type { AugmentAvailability } from "../lib/mode/augment-availability";
 import { AugmentCard } from "./AugmentCard";
 import { AugmentPicker } from "./AugmentPicker";
 
@@ -8,6 +9,7 @@ const MAX_AUGMENT_SLOTS = 4;
 interface AugmentSlotsProps {
   selectedAugments: Augment[];
   availableAugments: Map<string, Augment>;
+  availability?: AugmentAvailability;
   onSelect: (augment: Augment) => void;
   onReset: () => void;
 }
@@ -15,6 +17,7 @@ interface AugmentSlotsProps {
 export function AugmentSlots({
   selectedAugments,
   availableAugments,
+  availability,
   onSelect,
   onReset,
 }: AugmentSlotsProps) {
@@ -27,6 +30,7 @@ export function AugmentSlots({
 
   const nextEmptySlot = selectedAugments.length;
   const canPick = nextEmptySlot < MAX_AUGMENT_SLOTS;
+  const isPending = availability?.isAvailable ?? false;
 
   return (
     <div className="augment-slots-container">
@@ -43,17 +47,24 @@ export function AugmentSlots({
           const augment = selectedAugments[i];
           const isEmpty = !augment;
           const isClickable = isEmpty && i === nextEmptySlot && canPick;
+          const isSlotPending = isPending && availability?.pendingSlot === i;
 
           return isEmpty ? (
             <div
               key={i}
-              className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}`}
+              className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}${isSlotPending ? " augment-slot-pending" : ""}`}
               onClick={isClickable ? () => setPickerOpen(true) : undefined}
             >
               <div className="augment-slot-placeholder">
                 <span className="augment-slot-number">{i + 1}</span>
-                {isClickable && (
-                  <span className="augment-slot-hint">Tap to choose</span>
+                {isSlotPending ? (
+                  <span className="augment-slot-available">
+                    Augment available
+                  </span>
+                ) : (
+                  isClickable && (
+                    <span className="augment-slot-hint">Tap to choose</span>
+                  )
                 )}
               </div>
             </div>

--- a/src/components/AugmentSlots.tsx
+++ b/src/components/AugmentSlots.tsx
@@ -53,7 +53,19 @@ export function AugmentSlots({
             <div
               key={i}
               className={`augment-slot augment-slot-empty${isClickable ? " augment-slot-clickable" : ""}${isSlotPending ? " augment-slot-pending" : ""}`}
+              role={isClickable ? "button" : undefined}
+              tabIndex={isClickable ? 0 : undefined}
               onClick={isClickable ? () => setPickerOpen(true) : undefined}
+              onKeyDown={
+                isClickable
+                  ? (e) => {
+                      if (e.key === "Enter" || e.key === " ") {
+                        e.preventDefault();
+                        setPickerOpen(true);
+                      }
+                    }
+                  : undefined
+              }
             >
               <div className="augment-slot-placeholder">
                 <span className="augment-slot-number">{i + 1}</span>

--- a/src/components/DataBrowser.tsx
+++ b/src/components/DataBrowser.tsx
@@ -1,4 +1,5 @@
 import { useState } from "react";
+import type { Augment } from "../lib/data-ingest/types";
 import type { LoadedGameData } from "../lib/data-ingest";
 import type { EffectiveGameState } from "../lib/mode";
 import { ChampionList } from "./ChampionList";
@@ -10,9 +11,16 @@ import { GameStateView } from "./GameStateView";
 
 type Tab = "game" | "champions" | "items" | "runes" | "augments" | "search";
 
+interface AugmentSelectionActions {
+  selectedAugments: Augment[];
+  select: (augment: Augment) => void;
+  reset: () => void;
+}
+
 interface DataBrowserProps {
   data: LoadedGameData;
   effectiveState: EffectiveGameState;
+  augmentSelection: AugmentSelectionActions;
 }
 
 const TABS: { key: Tab; label: string }[] = [
@@ -24,7 +32,11 @@ const TABS: { key: Tab; label: string }[] = [
   { key: "search", label: "Search" },
 ];
 
-export function DataBrowser({ data, effectiveState }: DataBrowserProps) {
+export function DataBrowser({
+  data,
+  effectiveState,
+  augmentSelection,
+}: DataBrowserProps) {
   const [activeTab, setActiveTab] = useState<Tab>("game");
 
   return (
@@ -47,7 +59,13 @@ export function DataBrowser({ data, effectiveState }: DataBrowserProps) {
         ))}
       </div>
       <div className="tab-content">
-        {activeTab === "game" && <GameStateView state={effectiveState} />}
+        {activeTab === "game" && (
+          <GameStateView
+            state={effectiveState}
+            modeAugments={effectiveState.modeContext?.modeAugments}
+            augmentSelection={augmentSelection}
+          />
+        )}
         {activeTab === "champions" && (
           <ChampionList champions={data.champions} />
         )}

--- a/src/components/DataBrowser.tsx
+++ b/src/components/DataBrowser.tsx
@@ -14,6 +14,7 @@ type Tab = "game" | "champions" | "items" | "runes" | "augments" | "search";
 interface AugmentSelectionActions {
   selectedAugments: Augment[];
   select: (augment: Augment) => void;
+  removeLast: () => void;
   reset: () => void;
 }
 

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -1,11 +1,25 @@
 import type { EffectiveGameState, EffectivePlayer } from "../lib/mode";
-import type { AramOverrides } from "../lib/data-ingest/types";
+import type { Augment, AramOverrides } from "../lib/data-ingest/types";
+import { AugmentCard } from "./AugmentCard";
+import { AugmentPicker } from "./AugmentPicker";
+
+interface AugmentSelectionActions {
+  selectedAugments: Augment[];
+  select: (augment: Augment) => void;
+  reset: () => void;
+}
 
 interface GameStateViewProps {
   state: EffectiveGameState;
+  modeAugments?: Map<string, Augment>;
+  augmentSelection: AugmentSelectionActions;
 }
 
-export function GameStateView({ state }: GameStateViewProps) {
+export function GameStateView({
+  state,
+  modeAugments,
+  augmentSelection,
+}: GameStateViewProps) {
   if (state.status === "disconnected") {
     return (
       <div className="game-status">
@@ -98,6 +112,34 @@ export function GameStateView({ state }: GameStateViewProps) {
       )}
 
       <TeamsGrid allies={state.allies} enemies={state.enemies} />
+
+      {augmentSelection.selectedAugments.length > 0 && (
+        <div>
+          <div className="header-row">
+            <p className="entity-title">
+              Your Augments ({augmentSelection.selectedAugments.length})
+            </p>
+            <button className="refresh-btn" onClick={augmentSelection.reset}>
+              Clear
+            </button>
+          </div>
+          <div className="selected-augments">
+            {augmentSelection.selectedAugments.map((aug, idx) => (
+              <AugmentCard key={`${aug.name}-${idx}`} augment={aug} compact />
+            ))}
+          </div>
+        </div>
+      )}
+
+      {modeAugments && modeAugments.size > 0 && (
+        <div>
+          <p className="entity-title">Select Augment</p>
+          <AugmentPicker
+            augments={modeAugments}
+            onSelect={augmentSelection.select}
+          />
+        </div>
+      )}
     </div>
   );
 }

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -6,6 +6,7 @@ import { AugmentSlots } from "./AugmentSlots";
 interface AugmentSelectionActions {
   selectedAugments: Augment[];
   select: (augment: Augment) => void;
+  removeLast: () => void;
   reset: () => void;
 }
 
@@ -127,6 +128,7 @@ export function GameStateView({
               : undefined
           }
           onSelect={augmentSelection.select}
+          onRemoveLast={augmentSelection.removeLast}
           onReset={augmentSelection.reset}
         />
       )}

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -1,7 +1,6 @@
 import type { EffectiveGameState, EffectivePlayer } from "../lib/mode";
 import type { Augment, AramOverrides } from "../lib/data-ingest/types";
-import { AugmentCard } from "./AugmentCard";
-import { AugmentPicker } from "./AugmentPicker";
+import { AugmentSlots } from "./AugmentSlots";
 
 interface AugmentSelectionActions {
   selectedAugments: Augment[];
@@ -113,32 +112,13 @@ export function GameStateView({
 
       <TeamsGrid allies={state.allies} enemies={state.enemies} />
 
-      {augmentSelection.selectedAugments.length > 0 && (
-        <div>
-          <div className="header-row">
-            <p className="entity-title">
-              Your Augments ({augmentSelection.selectedAugments.length})
-            </p>
-            <button className="refresh-btn" onClick={augmentSelection.reset}>
-              Clear
-            </button>
-          </div>
-          <div className="selected-augments">
-            {augmentSelection.selectedAugments.map((aug, idx) => (
-              <AugmentCard key={`${aug.name}-${idx}`} augment={aug} compact />
-            ))}
-          </div>
-        </div>
-      )}
-
       {modeAugments && modeAugments.size > 0 && (
-        <div>
-          <p className="entity-title">Select Augment</p>
-          <AugmentPicker
-            augments={modeAugments}
-            onSelect={augmentSelection.select}
-          />
-        </div>
+        <AugmentSlots
+          selectedAugments={augmentSelection.selectedAugments}
+          availableAugments={modeAugments}
+          onSelect={augmentSelection.select}
+          onReset={augmentSelection.reset}
+        />
       )}
     </div>
   );

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -1,5 +1,6 @@
 import type { EffectiveGameState, EffectivePlayer } from "../lib/mode";
 import type { Augment, AramOverrides } from "../lib/data-ingest/types";
+import { checkAugmentAvailability } from "../lib/mode/augment-availability";
 import { AugmentSlots } from "./AugmentSlots";
 
 interface AugmentSelectionActions {
@@ -116,6 +117,15 @@ export function GameStateView({
         <AugmentSlots
           selectedAugments={augmentSelection.selectedAugments}
           availableAugments={modeAugments}
+          availability={
+            modeCtx && active
+              ? checkAugmentAvailability(
+                  active.level,
+                  augmentSelection.selectedAugments.length,
+                  modeCtx.mode
+                )
+              : undefined
+          }
           onSelect={augmentSelection.select}
           onReset={augmentSelection.reset}
         />

--- a/src/hooks/useAugmentSelection.ts
+++ b/src/hooks/useAugmentSelection.ts
@@ -6,6 +6,7 @@ import { addSelectedAugment } from "../lib/mode/augment-selection";
 interface AugmentSelectionState {
   selectedAugments: Augment[];
   select: (augment: Augment) => void;
+  removeLast: () => void;
   reset: () => void;
   applyToContext: (modeContext: ModeContext, playerKey: string) => ModeContext;
 }
@@ -26,6 +27,10 @@ export function useAugmentSelection(resetKey: string): AugmentSelectionState {
     setSelectedAugments((prev) => [...prev, augment]);
   }, []);
 
+  const removeLast = useCallback(() => {
+    setSelectedAugments((prev) => prev.slice(0, -1));
+  }, []);
+
   const reset = useCallback(() => {
     setSelectedAugments([]);
   }, []);
@@ -41,5 +46,5 @@ export function useAugmentSelection(resetKey: string): AugmentSelectionState {
     [selectedAugments]
   );
 
-  return { selectedAugments, select, reset, applyToContext };
+  return { selectedAugments, select, removeLast, reset, applyToContext };
 }

--- a/src/hooks/useAugmentSelection.ts
+++ b/src/hooks/useAugmentSelection.ts
@@ -1,4 +1,4 @@
-import { useState, useCallback, useRef } from "react";
+import { useState, useCallback, useEffect } from "react";
 import type { Augment } from "../lib/data-ingest/types";
 import type { ModeContext } from "../lib/mode";
 import { addSelectedAugment } from "../lib/mode/augment-selection";
@@ -12,20 +12,15 @@ interface AugmentSelectionState {
 
 /**
  * Manages augment selection state for the active player.
- * Selections persist across game state poll updates but reset
- * when a new game is detected (gameMode changes or status changes).
+ * Selections reset when the resetKey changes (derived from gameMode + status
+ * at the call site, so new games or disconnects clear selections).
  */
-export function useAugmentSelection(gameMode: string): AugmentSelectionState {
+export function useAugmentSelection(resetKey: string): AugmentSelectionState {
   const [selectedAugments, setSelectedAugments] = useState<Augment[]>([]);
-  const lastGameModeRef = useRef(gameMode);
 
-  // Reset selections when the game mode changes (new game)
-  if (gameMode !== lastGameModeRef.current) {
-    lastGameModeRef.current = gameMode;
-    if (selectedAugments.length > 0) {
-      setSelectedAugments([]);
-    }
-  }
+  useEffect(() => {
+    setSelectedAugments([]);
+  }, [resetKey]);
 
   const select = useCallback((augment: Augment) => {
     setSelectedAugments((prev) => [...prev, augment]);

--- a/src/hooks/useAugmentSelection.ts
+++ b/src/hooks/useAugmentSelection.ts
@@ -1,0 +1,50 @@
+import { useState, useCallback, useRef } from "react";
+import type { Augment } from "../lib/data-ingest/types";
+import type { ModeContext } from "../lib/mode";
+import { addSelectedAugment } from "../lib/mode/augment-selection";
+
+interface AugmentSelectionState {
+  selectedAugments: Augment[];
+  select: (augment: Augment) => void;
+  reset: () => void;
+  applyToContext: (modeContext: ModeContext, playerKey: string) => ModeContext;
+}
+
+/**
+ * Manages augment selection state for the active player.
+ * Selections persist across game state poll updates but reset
+ * when a new game is detected (gameMode changes or status changes).
+ */
+export function useAugmentSelection(gameMode: string): AugmentSelectionState {
+  const [selectedAugments, setSelectedAugments] = useState<Augment[]>([]);
+  const lastGameModeRef = useRef(gameMode);
+
+  // Reset selections when the game mode changes (new game)
+  if (gameMode !== lastGameModeRef.current) {
+    lastGameModeRef.current = gameMode;
+    if (selectedAugments.length > 0) {
+      setSelectedAugments([]);
+    }
+  }
+
+  const select = useCallback((augment: Augment) => {
+    setSelectedAugments((prev) => [...prev, augment]);
+  }, []);
+
+  const reset = useCallback(() => {
+    setSelectedAugments([]);
+  }, []);
+
+  const applyToContext = useCallback(
+    (modeContext: ModeContext, playerKey: string): ModeContext => {
+      let ctx = modeContext;
+      for (const augment of selectedAugments) {
+        ctx = addSelectedAugment(ctx, playerKey, augment);
+      }
+      return ctx;
+    },
+    [selectedAugments]
+  );
+
+  return { selectedAugments, select, reset, applyToContext };
+}

--- a/src/hooks/useEffectiveGameState.ts
+++ b/src/hooks/useEffectiveGameState.ts
@@ -1,19 +1,22 @@
 import { useMemo } from "react";
+import type { Augment } from "../lib/data-ingest/types";
 import type { GameState } from "../lib/game-state/types";
 import type { LoadedGameData } from "../lib/data-ingest";
-import type { EffectiveGameState } from "../lib/mode";
+import type { EffectiveGameState, ModeContext } from "../lib/mode";
 import {
   createModeRegistry,
   aramMayhemMode,
   buildEffectiveGameState,
 } from "../lib/mode";
+import { addSelectedAugment } from "../lib/mode/augment-selection";
 
 const registry = createModeRegistry();
 registry.register(aramMayhemMode);
 
 export function useEffectiveGameState(
   gameState: GameState,
-  gameData: LoadedGameData | null
+  gameData: LoadedGameData | null,
+  selectedAugments: Augment[] = []
 ): EffectiveGameState {
   return useMemo(() => {
     if (!gameData || gameState.status !== "connected") {
@@ -21,10 +24,24 @@ export function useEffectiveGameState(
     }
 
     const detectedMode = registry.detect(gameState.gameMode);
-    const modeContext = detectedMode
+    let modeContext: ModeContext | null = detectedMode
       ? detectedMode.buildContext(gameState, gameData)
       : null;
 
+    // Apply selected augments to the active player's context
+    if (modeContext && selectedAugments.length > 0) {
+      const activePlayer = gameState.players.find((p) => p.isActivePlayer);
+      if (activePlayer) {
+        for (const augment of selectedAugments) {
+          modeContext = addSelectedAugment(
+            modeContext,
+            activePlayer.riotIdGameName,
+            augment
+          );
+        }
+      }
+    }
+
     return buildEffectiveGameState(gameState, modeContext);
-  }, [gameState, gameData]);
+  }, [gameState, gameData, selectedAugments]);
 }

--- a/src/lib/mode/aram-mayhem.ts
+++ b/src/lib/mode/aram-mayhem.ts
@@ -12,6 +12,7 @@ export const aramMayhemMode: GameMode = {
   id: "aram-mayhem",
   displayName: "ARAM Mayhem",
   decisionTypes: ["augment-selection", "item-purchase", "open-ended-coaching"],
+  augmentSelectionLevels: [1, 7, 11, 15],
 
   matches(gameMode: string): boolean {
     return gameMode === "ARAM";

--- a/src/lib/mode/augment-availability.test.ts
+++ b/src/lib/mode/augment-availability.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { checkAugmentAvailability } from "./augment-availability";
+import type { GameMode, ModeContext } from "./types";
+
+const aramMayhem: GameMode = {
+  id: "aram-mayhem",
+  displayName: "ARAM Mayhem",
+  decisionTypes: ["augment-selection"],
+  augmentSelectionLevels: [1, 7, 11, 15],
+  matches: () => true,
+  buildContext: () => ({}) as ModeContext,
+};
+
+describe("checkAugmentAvailability", () => {
+  it("shows slot 0 available at level 1 with no selections", () => {
+    const result = checkAugmentAvailability(1, 0, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(0);
+  });
+
+  it("not available at level 1 if already selected first augment", () => {
+    const result = checkAugmentAvailability(1, 1, aramMayhem);
+    expect(result.isAvailable).toBe(false);
+    expect(result.pendingSlot).toBe(-1);
+  });
+
+  it("shows slot 1 available at level 7 with 1 selection", () => {
+    const result = checkAugmentAvailability(7, 1, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(1);
+  });
+
+  it("shows slot 1 available at level 9 with 1 selection (past threshold)", () => {
+    const result = checkAugmentAvailability(9, 1, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(1);
+  });
+
+  it("not available at level 6 with 1 selection (below threshold)", () => {
+    const result = checkAugmentAvailability(6, 1, aramMayhem);
+    expect(result.isAvailable).toBe(false);
+    expect(result.pendingSlot).toBe(-1);
+  });
+
+  it("shows slot 2 available at level 11 with 2 selections", () => {
+    const result = checkAugmentAvailability(11, 2, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(2);
+  });
+
+  it("shows slot 3 available at level 15 with 3 selections", () => {
+    const result = checkAugmentAvailability(15, 3, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(3);
+  });
+
+  it("not available when all slots are filled", () => {
+    const result = checkAugmentAvailability(18, 4, aramMayhem);
+    expect(result.isAvailable).toBe(false);
+    expect(result.pendingSlot).toBe(-1);
+  });
+
+  it("detects multiple missed selections (level 11 but only 1 selected)", () => {
+    const result = checkAugmentAvailability(11, 1, aramMayhem);
+    expect(result.isAvailable).toBe(true);
+    expect(result.pendingSlot).toBe(1);
+  });
+
+  it("returns not available for mode with no augment levels", () => {
+    const noAugments: GameMode = {
+      ...aramMayhem,
+      augmentSelectionLevels: [],
+    };
+    const result = checkAugmentAvailability(10, 0, noAugments);
+    expect(result.isAvailable).toBe(false);
+    expect(result.pendingSlot).toBe(-1);
+  });
+});

--- a/src/lib/mode/augment-availability.ts
+++ b/src/lib/mode/augment-availability.ts
@@ -1,0 +1,36 @@
+import type { GameMode } from "./types";
+
+export interface AugmentAvailability {
+  /** Which slot index (0-based) should show the "available" indicator. -1 if none. */
+  pendingSlot: number;
+  /** Whether an augment selection is likely available (level threshold reached, slot empty). */
+  isAvailable: boolean;
+}
+
+/**
+ * Determine whether an augment selection is likely available based on
+ * the player's current level, the mode's selection thresholds, and
+ * how many augments have already been selected.
+ *
+ * The logic: count how many thresholds the player has reached (level >= threshold).
+ * If that's more than the number of augments already selected, a selection is pending.
+ */
+export function checkAugmentAvailability(
+  playerLevel: number,
+  selectedCount: number,
+  mode: GameMode
+): AugmentAvailability {
+  const levels = mode.augmentSelectionLevels;
+  if (levels.length === 0) {
+    return { pendingSlot: -1, isAvailable: false };
+  }
+
+  // How many augment offers the player has reached based on level
+  const reachedCount = levels.filter((lvl) => playerLevel >= lvl).length;
+
+  if (selectedCount >= reachedCount || selectedCount >= levels.length) {
+    return { pendingSlot: -1, isAvailable: false };
+  }
+
+  return { pendingSlot: selectedCount, isAvailable: true };
+}

--- a/src/lib/mode/augment-selection.test.ts
+++ b/src/lib/mode/augment-selection.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect } from "vitest";
+import { addSelectedAugment, computeSetProgress } from "./augment-selection";
+import type { Augment, AugmentSet } from "../data-ingest/types";
+import type { ModeContext, PlayerModeContext, GameMode } from "./types";
+
+const stubMode: GameMode = {
+  id: "test",
+  displayName: "Test",
+  decisionTypes: [],
+  matches: () => true,
+  buildContext: () => ({}) as ModeContext,
+};
+
+function createAugment(name: string, sets: string[] = []): Augment {
+  return {
+    name,
+    description: `${name} description`,
+    tier: "Silver",
+    sets,
+    mode: "mayhem",
+  };
+}
+
+function createModeContext(selectedAugments: Augment[] = []): ModeContext {
+  const playerCtx: PlayerModeContext = {
+    championName: "Ahri",
+    team: "ORDER",
+    tags: ["Mage"],
+    balanceOverrides: null,
+    selectedAugments,
+    setProgress: [],
+  };
+
+  return {
+    mode: stubMode,
+    playerContexts: new Map([["Player1", playerCtx]]),
+    modeItems: new Map(),
+    modeAugments: new Map(),
+    augmentSets: [
+      {
+        name: "Firecracker",
+        bonuses: [
+          { threshold: 2, description: "Bounce to 2 enemies" },
+          { threshold: 4, description: "Bounce to 3 enemies" },
+        ],
+      },
+      {
+        name: "Archmage",
+        bonuses: [{ threshold: 2, description: "30% cooldown refund" }],
+      },
+    ],
+    allyTeamComp: { players: [playerCtx], classCounts: {} },
+    enemyTeamComp: { players: [], classCounts: {} },
+  };
+}
+
+describe("addSelectedAugment", () => {
+  it("adds an augment to the player's selected augments", () => {
+    const ctx = createModeContext();
+    const augment = createAugment("Typhoon", ["Firecracker"]);
+
+    const updated = addSelectedAugment(ctx, "Player1", augment);
+    const player = updated.playerContexts.get("Player1")!;
+
+    expect(player.selectedAugments).toHaveLength(1);
+    expect(player.selectedAugments[0].name).toBe("Typhoon");
+  });
+
+  it("accumulates multiple augments", () => {
+    const ctx = createModeContext([createAugment("Typhoon", ["Firecracker"])]);
+    const augment = createAugment("Magic Missile", ["Firecracker"]);
+
+    const updated = addSelectedAugment(ctx, "Player1", augment);
+    const player = updated.playerContexts.get("Player1")!;
+
+    expect(player.selectedAugments).toHaveLength(2);
+  });
+
+  it("returns a new ModeContext (immutable)", () => {
+    const ctx = createModeContext();
+    const augment = createAugment("Typhoon");
+
+    const updated = addSelectedAugment(ctx, "Player1", augment);
+
+    expect(updated).not.toBe(ctx);
+    expect(updated.playerContexts).not.toBe(ctx.playerContexts);
+    // Original unchanged
+    expect(ctx.playerContexts.get("Player1")!.selectedAugments).toHaveLength(0);
+  });
+
+  it("recomputes set progress after adding an augment", () => {
+    const ctx = createModeContext([createAugment("Typhoon", ["Firecracker"])]);
+    const augment = createAugment("Magic Missile", ["Firecracker"]);
+
+    const updated = addSelectedAugment(ctx, "Player1", augment);
+    const player = updated.playerContexts.get("Player1")!;
+
+    expect(player.setProgress).toHaveLength(1);
+    expect(player.setProgress[0].set.name).toBe("Firecracker");
+    expect(player.setProgress[0].count).toBe(2);
+  });
+
+  it("does nothing if player key not found", () => {
+    const ctx = createModeContext();
+    const augment = createAugment("Typhoon");
+
+    const updated = addSelectedAugment(ctx, "NonExistent", augment);
+    expect(updated).toBe(ctx);
+  });
+});
+
+describe("computeSetProgress", () => {
+  const sets: AugmentSet[] = [
+    {
+      name: "Firecracker",
+      bonuses: [
+        { threshold: 2, description: "Bounce to 2 enemies" },
+        { threshold: 4, description: "Bounce to 3 enemies" },
+      ],
+    },
+    {
+      name: "Archmage",
+      bonuses: [{ threshold: 2, description: "30% cooldown refund" }],
+    },
+  ];
+
+  it("returns empty array when no augments have sets", () => {
+    const augments = [createAugment("Scoped Weapons")];
+    expect(computeSetProgress(augments, sets)).toEqual([]);
+  });
+
+  it("tracks progress for a single set", () => {
+    const augments = [createAugment("Typhoon", ["Firecracker"])];
+    const progress = computeSetProgress(augments, sets);
+
+    expect(progress).toHaveLength(1);
+    expect(progress[0].set.name).toBe("Firecracker");
+    expect(progress[0].count).toBe(1);
+    expect(progress[0].nextBonus).toEqual({
+      threshold: 2,
+      description: "Bounce to 2 enemies",
+    });
+  });
+
+  it("updates next bonus when threshold is reached", () => {
+    const augments = [
+      createAugment("Typhoon", ["Firecracker"]),
+      createAugment("Magic Missile", ["Firecracker"]),
+    ];
+    const progress = computeSetProgress(augments, sets);
+
+    expect(progress[0].count).toBe(2);
+    expect(progress[0].nextBonus).toEqual({
+      threshold: 4,
+      description: "Bounce to 3 enemies",
+    });
+  });
+
+  it("sets nextBonus to null when all thresholds reached", () => {
+    const augments = [
+      createAugment("A", ["Archmage"]),
+      createAugment("B", ["Archmage"]),
+    ];
+    const progress = computeSetProgress(augments, sets);
+
+    expect(progress[0].count).toBe(2);
+    expect(progress[0].nextBonus).toBeNull();
+  });
+
+  it("tracks multiple sets independently", () => {
+    const augments = [
+      createAugment("Typhoon", ["Firecracker"]),
+      createAugment("Buff Buddies", ["Archmage"]),
+    ];
+    const progress = computeSetProgress(augments, sets);
+
+    expect(progress).toHaveLength(2);
+    const names = progress.map((p) => p.set.name).sort();
+    expect(names).toEqual(["Archmage", "Firecracker"]);
+  });
+
+  it("handles augments belonging to multiple sets", () => {
+    const augments = [
+      createAugment("Self Destruct", ["Dive Bomb", "Fully Automated"]),
+    ];
+    const setsWithBoth: AugmentSet[] = [
+      { name: "Dive Bomb", bonuses: [{ threshold: 2, description: "test" }] },
+      {
+        name: "Fully Automated",
+        bonuses: [{ threshold: 2, description: "test" }],
+      },
+    ];
+    const progress = computeSetProgress(augments, setsWithBoth);
+
+    expect(progress).toHaveLength(2);
+  });
+});

--- a/src/lib/mode/augment-selection.test.ts
+++ b/src/lib/mode/augment-selection.test.ts
@@ -7,6 +7,7 @@ const stubMode: GameMode = {
   id: "test",
   displayName: "Test",
   decisionTypes: [],
+  augmentSelectionLevels: [1, 7, 11, 15],
   matches: () => true,
   buildContext: () => ({}) as ModeContext,
 };

--- a/src/lib/mode/augment-selection.ts
+++ b/src/lib/mode/augment-selection.ts
@@ -1,0 +1,66 @@
+import type { Augment, AugmentSet } from "../data-ingest/types";
+import type { ModeContext, PlayerModeContext, SetProgress } from "./types";
+
+/**
+ * Add a selected augment to the active player's context and recompute set progress.
+ * Returns a new ModeContext with the updated player context (immutable).
+ * Returns the original context unchanged if the player key is not found.
+ */
+export function addSelectedAugment(
+  modeContext: ModeContext,
+  playerKey: string,
+  augment: Augment
+): ModeContext {
+  const existing = modeContext.playerContexts.get(playerKey);
+  if (!existing) return modeContext;
+
+  const selectedAugments = [...existing.selectedAugments, augment];
+  const setProgress = computeSetProgress(
+    selectedAugments,
+    modeContext.augmentSets
+  );
+
+  const updatedPlayer: PlayerModeContext = {
+    ...existing,
+    selectedAugments,
+    setProgress,
+  };
+
+  const updatedContexts = new Map(modeContext.playerContexts);
+  updatedContexts.set(playerKey, updatedPlayer);
+
+  return {
+    ...modeContext,
+    playerContexts: updatedContexts,
+  };
+}
+
+/**
+ * Compute set progress from a list of selected augments against available sets.
+ * Only includes sets where the player has at least one augment.
+ */
+export function computeSetProgress(
+  selectedAugments: Augment[],
+  augmentSets: AugmentSet[]
+): SetProgress[] {
+  // Count how many selected augments belong to each set
+  const setCounts = new Map<string, number>();
+  for (const augment of selectedAugments) {
+    for (const setName of augment.sets) {
+      setCounts.set(setName, (setCounts.get(setName) ?? 0) + 1);
+    }
+  }
+
+  const progress: SetProgress[] = [];
+  for (const [setName, count] of setCounts) {
+    const setDef = augmentSets.find((s) => s.name === setName);
+    if (!setDef) continue;
+
+    // Find the next bonus threshold that hasn't been reached
+    const nextBonus = setDef.bonuses.find((b) => b.threshold > count) ?? null;
+
+    progress.push({ set: setDef, count, nextBonus });
+  }
+
+  return progress;
+}

--- a/src/lib/mode/effective-state.test.ts
+++ b/src/lib/mode/effective-state.test.ts
@@ -79,6 +79,7 @@ const stubMode: GameMode = {
   id: "test",
   displayName: "Test",
   decisionTypes: [],
+  augmentSelectionLevels: [],
   matches: () => true,
   buildContext: () => ({}) as ModeContext,
 };

--- a/src/lib/mode/index.ts
+++ b/src/lib/mode/index.ts
@@ -12,3 +12,5 @@ export type {
 export { createModeRegistry } from "./registry";
 export { aramMayhemMode } from "./aram-mayhem";
 export { buildEffectiveGameState } from "./effective-state";
+export { checkAugmentAvailability } from "./augment-availability";
+export type { AugmentAvailability } from "./augment-availability";

--- a/src/lib/mode/registry.test.ts
+++ b/src/lib/mode/registry.test.ts
@@ -10,6 +10,7 @@ function createStubMode(
     id,
     displayName: id,
     decisionTypes: [],
+    augmentSelectionLevels: [],
     matches: matchFn,
     buildContext: () => ({}) as ModeContext,
   };

--- a/src/lib/mode/types.ts
+++ b/src/lib/mode/types.ts
@@ -27,6 +27,8 @@ export interface GameMode {
   id: string;
   displayName: string;
   decisionTypes: DecisionType[];
+  /** Levels at which augment selection becomes available (mode-specific). */
+  augmentSelectionLevels: number[];
   matches(gameMode: string): boolean;
   buildContext(gameState: GameState, gameData: LoadedGameData): ModeContext;
 }


### PR DESCRIPTION
## Summary

Closes #9. Adds a card-based augment selection system for manually recording augment picks during ARAM Mayhem games.

- **AugmentCard**: Reusable card component matching in-game augment card design — icon, name, description, set badges at bottom, thick tier-colored borders (prismatic rainbow gradient, gold, silver), 2:3 aspect ratio, gradient background
- **AugmentPicker**: Searchable overlay grid of augment cards with mode/tier/set filtering, excludes already-selected augments
- **AugmentSlots**: 4-slot UI (levels 1, 7, 11, 15) — tap an empty slot to open the picker overlay, tap to choose, hover the last filled slot to see "Remove" and tap to undo the last pick. Clear button resets all.
- **Augment availability detection**: `checkAugmentAvailability()` compares player level against mode-specific thresholds to show a pulsing green "Augment available" indicator on the pending slot. Thresholds are defined per mode via `augmentSelectionLevels` on the `GameMode` interface.
- **Augment selection state**: `useAugmentSelection` hook manages picks with `useEffect`-based reset keyed on `status:gameMode`, feeds into `useEffectiveGameState` which applies selections to the active player's ModeContext with set progress recomputation
- **augment-selection.ts**: Pure functions for `addSelectedAugment` (immutable context update) and `computeSetProgress` (derives set progress from selected augments against set definitions)
- **Augments tab**: Now uses the same card grid with mode/tier/set filters plus search
- **Technical reference**: Updated with augment selection timing (levels 1, 7, 11, 15), Nexus visit requirement, and Transmute-style double augment edge case (max 5 augments, 4 chosen + 1 granted)

169 tests across 18 files, 21 new tests for augment selection, set progress, and availability detection.