### PR TITLE
feat: voice input pipeline with Rust audio capture, Whisper STT, and vocab hints

### DIFF
--- a/docs/plans/2026-03-23-voice-input-design.md
+++ b/docs/plans/2026-03-23-voice-input-design.md
@@ -1,0 +1,100 @@
+# Voice Input Design — Issue #4
+
+Branch: `feat/4-voice-input` (off main)
+
+## Data Flow
+
+```
+Hold hotkey → Rust: cpal starts recording mic to buffer
+Release hotkey → Rust: stop recording, encode WAV, return bytes via IPC
+Frontend → receives WAV blob, assembles vocab hints from LiveGameState + hard word lists
+Frontend → calls OpenAI Whisper API with audio + glossary prompt
+Frontend → gets transcript, pushes { type: "query", text } into playerIntent$
+Existing coaching pipeline → handles it like typed text
+```
+
+## Components
+
+### 1. Rust: Audio Capture (`src-tauri/src/lib.rs`)
+
+Two Tauri commands with shared `RecordingState` (Arc<Mutex<Option<AudioRecorder>>>):
+
+- `start_recording` — opens default input device via cpal, starts stream, buffers PCM samples
+- `stop_recording` — stops stream, encodes buffered PCM to WAV via hound, returns `Vec<u8>`
+
+Audio format: 16-bit PCM, mono, 16kHz. A 10-second clip is ~320KB.
+
+New Cargo deps: `cpal` (mic access), `hound` (WAV encoding).
+
+### 2. STT Provider (`src/lib/voice/stt-provider.ts`)
+
+```typescript
+interface SttProvider {
+  transcribe(audio: Blob, vocabHints: string[]): Promise<SttResult>;
+}
+
+interface SttResult {
+  transcript: string;
+  latencyMs: number;
+}
+```
+
+Whisper implementation:
+
+- Joins vocabHints into glossary string: `"Glossary: Rabadon's, Zhonya's, Hextech, ..."`
+- Calls `openai.audio.transcriptions.create({ file, model: "whisper-1", prompt: glossary })`
+- Measures and returns latency
+
+### 3. Vocab Hints (`src/lib/voice/vocab-hints.ts`)
+
+Builds the vocabulary hint list sent with each STT request.
+
+Two sources combined:
+
+- **Static:** Hard item words (55) + hard augment words (~37 after dedup). Built from curated lists of fantasy/invented words that STT engines mangle.
+- **Dynamic:** Hard champion words for the 10 match champions, filtered against a set of 89 known hard champion names. Common English names (Annie, Diana) excluded.
+
+Combined, deduplicated output is ~188 tokens — fits Whisper's 224-token limit.
+
+### 4. Voice Input Hook (`src/hooks/useVoiceInput.ts`)
+
+Orchestrates the full pipeline:
+
+- Registers global hotkey via `@tauri-apps/plugin-global-shortcut`
+- Keydown: `invoke("start_recording")`, sets `isRecording: true`
+- Keyup: `invoke("stop_recording")` → build vocab hints → call STT → push transcript into `playerIntent$`
+- Emits debug events to `debugInput$` at each stage
+- Exposes: `{ isRecording, lastTranscript, latencyMs, error }`
+
+### 5. Debug Panel Updates (`src/components/DebugPanel.tsx`)
+
+- New "voice" input source color in debug stream
+- Events: `recording-start`, `recording-stop` (with duration), `transcript` (with text + latency), `vocab-hints` (glossary sent), `error`
+- Voice status card in status grid: recording state, last transcript, latency
+
+### 6. Minimal Game Tab Change
+
+Recording indicator only — small visual signal that the hotkey is active. Full coaching UI integration deferred to the engine branch.
+
+## Testing Strategy
+
+**TDD (tests first):**
+
+- `vocab-hints.test.ts` — hard word extraction, champion filtering, dedup, token budget
+- `stt-provider.test.ts` — glossary prompt assembly, mocked OpenAI client, latency measurement, error handling
+- `useVoiceInput.test.ts` — recording state transitions, transcript flow to playerIntent$, debug events
+
+**Manual (debug panel):**
+
+- Rust audio capture (hardware-dependent)
+- Global hotkey registration (platform-dependent)
+- End-to-end Whisper accuracy (requires real speech)
+
+## Implementation Order
+
+1. Rust audio capture (start/stop commands, cpal + hound)
+2. `vocab-hints.ts` + tests (pure logic, no dependencies)
+3. `stt-provider.ts` + tests (Whisper implementation)
+4. `useVoiceInput.ts` + tests (orchestration hook)
+5. Debug panel updates (wire voice events into existing UI)
+6. Manual end-to-end testing

--- a/docs/voice-input-research.md
+++ b/docs/voice-input-research.md
@@ -1,0 +1,223 @@
+# Voice Input Research — Issue #4
+
+Research conducted 2026-03-23 for STT engine selection, audio capture architecture, and custom vocabulary strategy.
+
+## Audio Capture: Rust (cpal), Not WebView
+
+**Decision: Capture audio in the Rust backend, not the Tauri webview.**
+
+The Web Audio API (`getUserMedia` / `MediaRecorder`) in a Tauri webview has serious problems for our use case:
+
+- **macOS:** Multiple open Tauri/Wry issues. `getUserMedia` throws `NotAllowedError` in production builds. Permission prompt reappears every launch (Wry #1195, Tauri #8979). Root cause is WKWebView's fragile `requestMediaCapturePermissionForOrigin` delegation.
+- **Linux (WebKitGTK):** `getUserMedia` denied by default; requires explicit permission handler wiring.
+- **Global hotkey trigger:** Browser security requires user gesture for `getUserMedia`. When the game is fullscreen and the hotkey fires from Rust, the webview may not honor a programmatic recording start — especially on macOS.
+- **Precedent:** MumbleFlow (production Tauri 2.0 app) uses exactly our target architecture: global hotkey → cpal audio capture in Rust → STT. Works reliably while other apps are in the foreground.
+
+**Architecture:**
+
+```
+Hold hotkey → Rust: cpal starts mic capture
+Release hotkey → Rust: stop capture, encode WAV, return bytes to frontend via IPC
+Frontend → receives audio blob, assembles vocab hints from game state
+Frontend → calls OpenAI Whisper API with audio + prompt glossary
+Frontend → gets transcript, pushes into playerIntent$ as { type: "query", text }
+Existing coaching pipeline → handles it like typed text
+```
+
+**Rust-side implementation:**
+
+- `cpal` for cross-platform mic access, `hound` for WAV encoding
+- Two Tauri commands: `start_recording` and `stop_recording` (returns WAV bytes)
+- Audio format: 16-bit PCM, mono, 16kHz (speech-optimized, what Whisper expects)
+- A 10-second clip at this rate is ~320KB — well within Tauri IPC limits
+
+**Options for Rust-side capture:**
+
+- `tauri-plugin-mic-recorder` (v2.0.0, uses cpal + hound, cross-platform, start/stop API)
+- `cpal` directly for more control
+- Both produce PCM/WAV audio that STT APIs accept natively
+
+## STT Engine: OpenAI Whisper API (Swappable)
+
+**Decision: Start with OpenAI Whisper API, design a provider interface for swappability.**
+
+Whisper was chosen for the POC because it uses the same OpenAI API key we already have for the coaching LLM (GPT-5.4 mini) — no new credentials needed. We also have prior experience with the API. The provider interface allows swapping to Deepgram or local whisper.cpp later.
+
+### Provider Comparison
+
+| Factor                | OpenAI Whisper API              | Deepgram (Nova-3)                | Local whisper.cpp         |
+| --------------------- | ------------------------------- | -------------------------------- | ------------------------- |
+| Vocab mechanism       | `prompt` param (glossary-style) | `keyterm` param (per-word boost) | `--prompt` flag           |
+| Vocab token limit     | **224 tokens**                  | 500 tokens, 100 keyterms         | ~224 tokens (~20 optimal) |
+| Latency (short clips) | ~1-2s                           | ~200-500ms                       | ~1-2s (GPU), ~3-5s (CPU)  |
+| Cost                  | $0.006/min                      | $0.0043/min, $200 free credit    | Free                      |
+| Runs locally          | No                              | No                               | Yes                       |
+| Audio formats         | WAV, MP3, WebM                  | 100+ formats incl. raw PCM       | WAV, MP3                  |
+
+### How Whisper Prompt Hinting Works
+
+The `prompt` parameter accepts a text string (max 224 tokens, silently truncates beyond that). Whisper uses it as style/vocabulary context for decoding. The recommended approach for custom vocabulary is a glossary format:
+
+```
+"Glossary: Rabadon's, Zhonya's, Fimbulwinter, Aatrox, Vel'Koz, Morellonomicon"
+```
+
+From OpenAI's Whisper prompting guide:
+
+- Short prompts are less reliable than longer ones
+- Prompts steer style and spelling, not comprehension
+- Works well for proper nouns, product names, and unusual spellings
+- Formatting is preserved — if you send `Zhonya's`, that's how it appears in output
+
+### How Deepgram Keyterm Prompting Works
+
+Deepgram's `keyterm` parameter (Nova-3/Flux only) takes individual words or phrases and biases the model toward recognizing them. Key characteristics:
+
+- Each keyterm is a separate query parameter: `keyterm=Rabadon's&keyterm=Zhonya's`
+- Supports multi-word phrases: `keyterm=Infinity%20Edge`
+- Preserves formatting/casing in output
+- Limited to 500 tokens and 100 keyterms per request
+- Best practice: focus on 20-50 most important terms
+- Deepgram recommends: industry-specific terminology, product/company names, proper nouns
+- Avoid: generic common words, overly broad terms
+
+### Why Deepgram Remains the Swap Target
+
+Deepgram has a larger vocabulary budget (500 vs 224 tokens), faster latency (~200-500ms vs ~1-2s), and per-word boosting rather than glossary-style hinting. If Whisper accuracy or latency becomes a problem during testing, Deepgram is the upgrade path. The provider interface makes this a config change, not a rewrite.
+
+With Deepgram's larger budget, we could send all 89 hard champion words (~170 tokens) plus all items and augments (~180 tokens deduped) for ~350 tokens total, removing the need to scope champions to the current match.
+
+### Provider Interface Concept
+
+```typescript
+interface SttProvider {
+  transcribe(audio: Blob, vocabHints: string[]): Promise<string>;
+}
+```
+
+Whisper provider builds a glossary prompt string from `vocabHints`. Deepgram provider maps them to `keyterm` query params. Local whisper.cpp provider passes them as `--prompt`. The STT call happens in the frontend (TypeScript), not Rust — the OpenAI SDK is already configured for the coaching LLM.
+
+## Custom Vocabulary Strategy
+
+### The Problem
+
+League of Legends has ~991 unique entity names across champions (172), items (423), and augments (396). Sending all full names would require ~3,400 tokens — far beyond any STT provider's vocabulary limit.
+
+### The Solution: Hard Words Only, Scoped to Match
+
+Two key optimizations stack to make the vocabulary fit:
+
+**1. Send only the hard _words_, not full names.**
+
+Most multi-word names contain common English words that STT handles fine. Only send the invented/fantasy words:
+
+- "Rabadon's Deathcap" → send only `Rabadon's` ("Deathcap" is two common English words)
+- "Zhonya's Hourglass" → send only `Zhonya's`
+- "Fimbulwinter" → send `Fimbulwinter` (single invented word)
+- "Chain Vest" → don't send at all (both words are common English)
+- "Witchful Thinking" → send only `Witchful` ("Thinking" is fine)
+- "Hextech Soul" → send only `Hextech`
+
+**2. Champions scoped to current match only.**
+
+With 89 hard champion words consuming ~170 tokens, sending all of them leaves no room for items and augments under Whisper's 224-token limit. Since players almost exclusively discuss champions in their current match, we send only the 10 match champions' hard words (~18 tokens) and use the remaining budget for items and augments.
+
+### Token Budget (Whisper-Compatible)
+
+| Category                                          | Hard words   | Est. tokens | Notes                         |
+| ------------------------------------------------- | ------------ | ----------- | ----------------------------- |
+| Match champions (10 in game)                      | ~8-10        | ~18         | Dynamic, from LiveGameState   |
+| Items (ARAM-purchasable, hard words, deduped)     | 55           | ~100        | Static list                   |
+| Augments (Mayhem, hard words, deduped with items) | ~37          | ~67         | Static list, after item dedup |
+| Glossary overhead ("Glossary: " prefix)           | —            | ~3          |                               |
+| **Total**                                         | **~100-102** | **~188**    |                               |
+
+**~188 tokens — fits within Whisper's 224-token limit** with some room to spare. Also fits comfortably within Deepgram's 500-token limit if we swap later.
+
+Note: The augment hard word count before dedup with items is 44. After removing words already in the items list (Hextech, Zhonya's, Wooglet's, Witchcap, Thornmail, Sheen, Mikael's), ~37 unique augment-only hard words remain.
+
+### Hard Word Reference Lists
+
+**Items (55):** Actualizer, Anathema's, Atma's, Bami's, Bandleglass, Bandlepipes, Battlesong, Cappa, Caulfield's, Chempunk, Chemtech, Cryptbloom, Dawncore, Fiendhunter, Fimbulwinter, Guinsoo's, Heartsteel, Helia, Hexdrinker, Hexoptics, Hexplate, Hextech, Jak'Sho, Kaenic, Kalista's, Kindlegem, Liandry's, Luden's, Malmortius, Manamune, Morellonomicon, Muramana, Nashor's, Navori, Phreakish, Poro-Snax, Rabadon's, Rageblade, Randuin's, Riftmaker, Rookern, Runaan's, Rylai's, Serylda's, Shojin, Shurelya's, Solari, Statikk, Sterak's, Tal, Witchcap, Wooglet's, Youmuu's, Yun, Zhonya's
+
+**Augments (44 before dedup, ~37 after removing overlap with items):** ADAPt, Brutalizer, Buff, Colossus, Crit, Dawnbringer's, Dropkick, Droppybara, Earthwake, Empyrean, EscAPADe, Fey, Firebrand, Flashbang, Goldrend, Goredrink, Hextech*, Homeguard, Icathia's, Immolate, Keystone, Marksmage, Mikael's*, Minionmancer, Nightstalking, Omni, Popoffs, Poro, ReEnergize, Repulsor, Scopier, Scopiest, Sheen*, Sneakerhead, Snowball, Thornmail*, Transmute, Trueshot, Urf's, Windspeaker's, Witchcap*, Witchful, Wooglet's*, Zhonya's\*
+
+(\*) = overlaps with items list, deduped in combined set
+
+**Champions (89 hard words — full list for Deepgram; match-filter to ~10 for Whisper):** Aatrox, Ahri, Akali, Akshan, Alistar, Ambessa, Amumu, Anivia, Aphelios, Aurelion, Azir, Bel'Veth, Blitzcrank, Cassiopeia, Cho'Gath, Corki, Ezreal, Fiddlesticks, Fizz, Gangplank, Gnar, Gragas, Hecarim, Heimerdinger, Hwei, Illaoi, Jarvan, Jhin, K'Sante, Kai'Sa, Kalista, Karthus, Kassadin, Katarina, Kayn, Kennen, Kha'Zix, Kled, Kog'Maw, LeBlanc, Lillia, Lissandra, Malphite, Malzahar, Maokai, Milio, Mordekaiser, Mundo, Naafiri, Nidalee, Nilah, Orianna, Qiyana, Rakan, Rammus, Rek'Sai, Renekton, Rengar, Ryze, Sejuani, Seraphine, Shaco, Shyvana, Singed, Skarner, Soraka, Sylas, Tahm, Taliyah, Tristana, Tryndamere, Urgot, Veigar, Vel'Koz, Viego, Vladimir, Volibear, Wukong, Xayah, Xerath, Xin, Yasuo, Yone, Yunara, Yuumi, Zaahen, Ziggs, Zilean, Zyra
+
+### Post-Transcription Fuzzy Matching
+
+The vocabulary hints don't need to be perfect. After transcription, we run fuzzy matching against the full entity dictionary to normalize output:
+
+- "rabadons deathcap" → "Rabadon's Deathcap"
+- "fim bull winter" → "Fimbulwinter"
+- "zhonyas" → "Zhonya's Hourglass"
+- "witchful thinking" → "Witchful Thinking" (augment name)
+
+This fuzzy matching infrastructure already exists in the coaching engine's augment name matching code (`CoachingInput.tsx`).
+
+**Real-world testing results (2026-03-23):**
+
+Vocab hints handle most hard words correctly. The expected failure mode is phonetically close but misspelled results — words where Whisper hears the sounds right but picks a different spelling:
+
+- "Naafiri" → transcribed as "Neferi" (despite being in the hint list)
+- "Morellonomicon" → transcribed as "Morelonomicon" (one 'l' off)
+- "Morello" (common abbreviation) → transcribed correctly as-is
+
+These are exactly the cases fuzzy matching is designed to recover. The phonetic similarity is high enough that a reasonable edit-distance or phonetic matching algorithm should map them back to the correct entity names.
+
+## Interaction Model
+
+**Push-to-talk (hold-to-talk):** Hold a global hotkey while speaking, release to send. Simplest model, natural for short game queries. Future iteration could explore toggle or wake-word approaches.
+
+## Implementation Architecture
+
+### Rust Side (Audio Capture Only)
+
+Two Tauri commands with shared recording state:
+
+```rust
+#[tauri::command]
+async fn start_recording(state: State<'_, RecordingState>) -> Result<(), String>
+// Opens default input device, starts cpal stream, stores PCM samples in buffer
+
+#[tauri::command]
+async fn stop_recording(state: State<'_, RecordingState>) -> Result<Vec<u8>, String>
+// Stops cpal stream, encodes buffered PCM to WAV via hound, returns WAV bytes
+```
+
+New Cargo dependencies: `cpal` for mic access, `hound` for WAV encoding.
+
+### TypeScript Side (STT + Integration)
+
+Three new modules:
+
+1. **`src/lib/voice/stt-provider.ts`** — Provider interface + Whisper implementation. Uses OpenAI SDK to call transcriptions endpoint with glossary prompt built from vocab hints.
+
+2. **`src/lib/voice/vocab-hints.ts`** — Builds the hint word list. Static item/augment hard words (built once from data pipeline) + dynamic match champion hard words (from `liveGameState$`). Deduplicates and formats as glossary string.
+
+3. **`src/hooks/useVoiceInput.ts`** — Orchestrates the pipeline. Registers global hotkey, calls Rust commands on keydown/keyup, calls STT provider, pushes transcript into `playerIntent$`. Emits debug events to `debugInput$`.
+
+### Frontend Debug UI
+
+New "voice" input source in debug panel showing: recording start/stop events, raw audio duration, transcript text, Whisper latency, and the vocab hints sent with each request.
+
+## Platform Notes
+
+### WSL2 Limitations
+
+Audio capture and global hotkeys do not work in WSL2:
+
+- **Audio:** ALSA fails with "No such file or directory" — WSL2 doesn't expose host audio devices to the Linux kernel. cpal can't find a microphone.
+- **Global hotkeys:** Tauri's global shortcut plugin registers with the Linux display server, but WSL2 keyboard events go through a different path. Hotkeys register successfully but never fire.
+- **Conclusion:** A native Windows build is required for end-to-end testing of voice input. The Rust audio capture, global hotkey, and Whisper API call have all been verified to compile and wire up correctly — they just need real hardware access.
+
+### Hotkey
+
+Push-to-talk is currently bound to **F8** (configurable in `useVoiceInput.ts`). A "Hold to Talk" button in the UI header provides a fallback for environments where global hotkeys don't work.
+
+## Open Questions
+
+- **Windows build:** Need to set up cross-compilation or a Windows-side build environment for Tauri. The lockfile path logic in `resolve_lockfile_path()` already handles Windows native vs WSL2.
+- **Whisper model version:** API currently uses `whisper-1`. Confirm if newer models are available with better accuracy.

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "@tauri-apps/plugin-opener": "^2",
     "deep-object-diff": "^1.1.9",
     "luaparse": "^0.3.1",
+    "openai": "^6.32.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "rxjs": "^7.8.2"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,6 +22,9 @@ importers:
       luaparse:
         specifier: ^0.3.1
         version: 0.3.1
+      openai:
+        specifier: ^6.32.0
+        version: 6.32.0(ws@8.19.0)
       react:
         specifier: ^19.1.0
         version: 19.2.4
@@ -1577,6 +1580,21 @@ packages:
       }
     engines: { node: ">=18" }
 
+  openai@6.32.0:
+    resolution:
+      {
+        integrity: sha512-j3k+BjydAf8yQlcOI7WUQMQTbbF5GEIMAE2iZYCOzwwB3S2pCheaWYp+XZRNAch4jWVc52PMDGRRjutao3lLCg==,
+      }
+    hasBin: true
+    peerDependencies:
+      ws: ^8.18.0
+      zod: ^3.25 || ^4.0
+    peerDependenciesMeta:
+      ws:
+        optional: true
+      zod:
+        optional: true
+
   parse5@7.3.0:
     resolution:
       {
@@ -2906,6 +2924,10 @@ snapshots:
   onetime@7.0.0:
     dependencies:
       mimic-function: 5.0.1
+
+  openai@6.32.0(ws@8.19.0):
+    optionalDependencies:
+      ws: 8.19.0
 
   parse5@7.3.0:
     dependencies:

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -33,6 +33,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "alsa"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed7572b7ba83a31e20d1b48970ee402d2e3e0537dcfe0a3ff4d6eb7508617d43"
+dependencies = [
+ "alsa-sys",
+ "bitflags 2.11.0",
+ "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "alsa-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db8fee663d06c4e303404ef5f40488a53e062f89ba8bfed81f42325aafad1527"
+dependencies = [
+ "libc",
+ "pkg-config",
+]
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -248,6 +270,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
+name = "bindgen"
+version = "0.72.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
+dependencies = [
+ "bitflags 2.11.0",
+ "cexpr",
+ "clang-sys",
+ "itertools",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -442,6 +482,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfb"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,7 +528,9 @@ name = "champ-sage"
 version = "0.1.0"
 dependencies = [
  "base64 0.22.1",
+ "cpal",
  "futures-util",
+ "hound",
  "reqwest 0.12.28",
  "rustls",
  "serde",
@@ -502,6 +553,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading 0.8.9",
 ]
 
 [[package]]
@@ -586,6 +648,49 @@ dependencies = [
  "bitflags 2.11.0",
  "core-foundation",
  "libc",
+]
+
+[[package]]
+name = "coreaudio-rs"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "321077172d79c662f64f5071a03120748d5bb652f5231570141be24cfcd2bace"
+dependencies = [
+ "bitflags 1.3.2",
+ "core-foundation-sys",
+ "coreaudio-sys",
+]
+
+[[package]]
+name = "coreaudio-sys"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceec7a6067e62d6f931a2baf6f3a751f4a892595bcec1461a3c94ef9949864b6"
+dependencies = [
+ "bindgen",
+]
+
+[[package]]
+name = "cpal"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "873dab07c8f743075e57f524c583985fbaf745602acbe916a01539364369a779"
+dependencies = [
+ "alsa",
+ "core-foundation-sys",
+ "coreaudio-rs",
+ "dasp_sample",
+ "jni",
+ "js-sys",
+ "libc",
+ "mach2",
+ "ndk 0.8.0",
+ "ndk-context",
+ "oboe",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+ "windows 0.54.0",
 ]
 
 [[package]]
@@ -714,6 +819,12 @@ dependencies = [
  "quote",
  "syn 2.0.117",
 ]
+
+[[package]]
+name = "dasp_sample"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c87e182de0887fd5361989c677c4e8f5000cd9491d6d563161a8f3a5519fc7f"
 
 [[package]]
 name = "data-encoding"
@@ -892,6 +1003,12 @@ name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+
+[[package]]
+name = "either"
+version = "1.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
 
 [[package]]
 name = "embed-resource"
@@ -1574,6 +1691,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hound"
+version = "3.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "62adaabb884c94955b19907d60019f4e145d091c75345379e70d1ee696f7854f"
+
+[[package]]
 name = "html5ever"
 version = "0.29.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +2034,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "itertools"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
+dependencies = [
+ "either",
+]
+
+[[package]]
 name = "itoa"
 version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2052,7 +2184,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6e9ec52138abedcc58dc17a7c6c0c00a2bdb4f3427c7f63fa97fd0d859155caf"
 dependencies = [
  "gtk-sys",
- "libloading",
+ "libloading 0.7.4",
  "once_cell",
 ]
 
@@ -2070,6 +2202,16 @@ checksum = "b67380fd3b2fbe7527a606e18729d21c6f3951633d0500574c4dc22d2d638b9f"
 dependencies = [
  "cfg-if",
  "winapi",
+]
+
+[[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -2119,6 +2261,15 @@ name = "mac"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
+
+[[package]]
+name = "mach2"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640282b302c0bb0a2a8e0233ead9035e3bed871f0b7e81fe4a1ec829765db44"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "markup5ever"
@@ -2184,6 +2335,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2227,6 +2384,20 @@ dependencies = [
 
 [[package]]
 name = "ndk"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2076a31b7010b17a38c01907c45b945e8f11495ee4dd588309718901b1f7a5b7"
+dependencies = [
+ "bitflags 2.11.0",
+ "jni-sys",
+ "log",
+ "ndk-sys 0.5.0+25.2.9519653",
+ "num_enum",
+ "thiserror 1.0.69",
+]
+
+[[package]]
+name = "ndk"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3f42e7bbe13d351b6bead8286a43aac9534b82bd3cc43e47037f012ebfd62d4"
@@ -2234,7 +2405,7 @@ dependencies = [
  "bitflags 2.11.0",
  "jni-sys",
  "log",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "num_enum",
  "raw-window-handle",
  "thiserror 1.0.69",
@@ -2245,6 +2416,15 @@ name = "ndk-context"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "ndk-sys"
+version = "0.5.0+25.2.9519653"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8c196769dd60fd4f363e11d948139556a344e79d451aeb2fa2fd040738ef7691"
+dependencies = [
+ "jni-sys",
+]
 
 [[package]]
 name = "ndk-sys"
@@ -2268,10 +2448,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "72ef4a56884ca558e5ddb05a1d1e7e1bfd9a68d9ed024c21704cc98872dae1bb"
 
 [[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
+]
+
+[[package]]
 name = "num-conv"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.117",
+]
 
 [[package]]
 name = "num-traits"
@@ -2425,6 +2626,29 @@ dependencies = [
  "objc2-app-kit",
  "objc2-core-foundation",
  "objc2-foundation",
+]
+
+[[package]]
+name = "oboe"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e8b61bebd49e5d43f5f8cc7ee2891c16e0f41ec7954d36bcb6c14c5e0de867fb"
+dependencies = [
+ "jni",
+ "ndk 0.8.0",
+ "ndk-context",
+ "num-derive",
+ "num-traits",
+ "oboe-sys",
+]
+
+[[package]]
+name = "oboe-sys"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c8bb09a4a2b1d668170cfe0a7d5bc103f8999fb316c98099b6a9939c9f2e79d"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -3703,7 +3927,7 @@ checksum = "aac18da81ebbf05109ab275b157c22a653bb3c12cf884450179942f81bcbf6c3"
 dependencies = [
  "bytemuck",
  "js-sys",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3896,9 +4120,9 @@ dependencies = [
  "jni",
  "libc",
  "log",
- "ndk",
+ "ndk 0.9.0",
  "ndk-context",
- "ndk-sys",
+ "ndk-sys 0.6.0+11769913",
  "objc2",
  "objc2-app-kit",
  "objc2-foundation",
@@ -3908,7 +4132,7 @@ dependencies = [
  "tao-macros",
  "unicode-segmentation",
  "url",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",
@@ -3979,7 +4203,7 @@ dependencies = [
  "webkit2gtk",
  "webview2-com",
  "window-vibrancy",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4095,7 +4319,7 @@ dependencies = [
  "tauri-plugin",
  "thiserror 2.0.18",
  "url",
- "windows",
+ "windows 0.61.3",
  "zbus",
 ]
 
@@ -4121,7 +4345,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
 ]
 
 [[package]]
@@ -4146,7 +4370,7 @@ dependencies = [
  "url",
  "webkit2gtk",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "wry",
 ]
 
@@ -5048,7 +5272,7 @@ checksum = "7130243a7a5b33c54a444e54842e6a9e133de08b5ad7b5861cd8ed9a6a5bc96a"
 dependencies = [
  "webview2-com-macros",
  "webview2-com-sys",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-implement",
  "windows-interface",
@@ -5072,7 +5296,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "381336cfffd772377d291702245447a5251a2ffa5bad679c99e61bc48bacbf9c"
 dependencies = [
  "thiserror 2.0.18",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
 ]
 
@@ -5124,6 +5348,16 @@ dependencies = [
 
 [[package]]
 name = "windows"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9252e5725dbed82865af151df558e754e4a3c2c30818359eb17465f1346a1b49"
+dependencies = [
+ "windows-core 0.54.0",
+ "windows-targets 0.52.6",
+]
+
+[[package]]
+name = "windows"
 version = "0.61.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
@@ -5142,6 +5376,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
 dependencies = [
  "windows-core 0.61.2",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.54.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "12661b9c89351d684a50a8a643ce5f608e20243b9fb84687800163429f161d65"
+dependencies = [
+ "windows-result 0.1.2",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5223,6 +5467,15 @@ checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
 dependencies = [
  "windows-core 0.61.2",
  "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e383302e8ec8515204254685643de10811af0ed97ea37210dc26fb0032647f8"
+dependencies = [
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -5661,7 +5914,7 @@ dependencies = [
  "javascriptcore-rs",
  "jni",
  "libc",
- "ndk",
+ "ndk 0.9.0",
  "objc2",
  "objc2-app-kit",
  "objc2-core-foundation",
@@ -5679,7 +5932,7 @@ dependencies = [
  "webkit2gtk",
  "webkit2gtk-sys",
  "webview2-com",
- "windows",
+ "windows 0.61.3",
  "windows-core 0.61.2",
  "windows-version",
  "x11-dl",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,3 +24,5 @@ tokio-tungstenite = { version = "0.26", features = ["rustls-tls-webpki-roots"] }
 rustls = { version = "0.23", features = ["ring"] }
 futures-util = "0.3"
 base64 = "0.22"
+cpal = "0.15"
+hound = "3.5"

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,8 @@
 use base64::Engine;
+use cpal::traits::{DeviceTrait, HostTrait, StreamTrait};
 use futures_util::{SinkExt, StreamExt};
 use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use std::sync::{Arc, Mutex};
 use tauri::Emitter;
 use tokio_tungstenite::tungstenite;
 
@@ -307,6 +309,216 @@ async fn connect_lcu_websocket(
     Ok(())
 }
 
+// ---------------------------------------------------------------------------
+// Audio capture for voice input (issue #4)
+//
+// Uses cpal to capture microphone audio in Rust, independent of the webview.
+// This is necessary because:
+// 1. WebView getUserMedia has platform bugs (macOS permission issues, Linux
+//    denied by default) — see docs/voice-input-research.md
+// 2. Recording must work while the game is fullscreen and the app window is
+//    unfocused — cpal runs in the Rust process regardless of window state
+// 3. Global hotkey fires from Rust, so starting/stopping recording here
+//    avoids a round-trip through the webview
+//
+// Audio format: 16-bit PCM, mono, 16kHz — optimized for speech recognition.
+// A 10-second clip at this rate is ~320KB, well within Tauri IPC limits.
+// The frontend receives WAV bytes and sends them to the STT API.
+// ---------------------------------------------------------------------------
+
+/// Managed state for audio recording.
+///
+/// cpal::Stream is !Send, so we can't store it in Tauri managed state directly.
+/// Instead, we spawn the stream on a dedicated thread and communicate via
+/// shared state: the buffer collects samples, and `is_recording` signals
+/// the stream thread to stop.
+///
+/// `sample_rate` is set by the recording thread to whatever rate the device
+/// actually supports. We can't hardcode 16kHz because Windows WASAPI devices
+/// often only support 44.1kHz or 48kHz. Whisper resamples internally so any
+/// standard rate works fine.
+struct RecordingState {
+    buffer: Arc<Mutex<Vec<i16>>>,
+    is_recording: Arc<std::sync::atomic::AtomicBool>,
+    sample_rate: Arc<std::sync::atomic::AtomicU32>,
+    channels: Arc<std::sync::atomic::AtomicU16>,
+}
+
+/// Start capturing audio from the default input device.
+///
+/// Opens the default microphone, configures it for 16kHz mono 16-bit PCM,
+/// and begins accumulating samples in memory. The cpal stream runs on a
+/// dedicated thread (since cpal::Stream is !Send and can't live in Tauri
+/// managed state).
+///
+/// Uses a oneshot channel so the command waits for the thread to confirm
+/// the stream is actually recording before returning success. This ensures
+/// errors (no mic, unsupported format) are reported to the frontend rather
+/// than silently failing in the background.
+#[tauri::command]
+fn start_recording(state: tauri::State<'_, RecordingState>) -> Result<(), String> {
+    if state
+        .is_recording
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return Err("Already recording".to_string());
+    }
+
+    // Clear any previous recording data
+    if let Ok(mut buf) = state.buffer.lock() {
+        buf.clear();
+    }
+
+    let buffer = state.buffer.clone();
+    let is_recording = state.is_recording.clone();
+    let sample_rate_store = state.sample_rate.clone();
+    let channels_store = state.channels.clone();
+
+    // Channel for the thread to report whether recording started successfully.
+    // We block the command until we know the stream is actually capturing.
+    let (tx, rx) = std::sync::mpsc::channel::<Result<(), String>>();
+
+    // Spawn a dedicated thread for the cpal stream.
+    // cpal::Stream is !Send so it must be created and live on the same thread.
+    std::thread::spawn(move || {
+        let host = cpal::default_host();
+        let device = match host.default_input_device() {
+            Some(d) => d,
+            None => {
+                let _ = tx.send(Err("No input device available".to_string()));
+                return;
+            }
+        };
+
+        // Use the device's default input config rather than hardcoding 16kHz mono.
+        // Windows WASAPI devices often only support 44.1kHz or 48kHz stereo —
+        // forcing 16kHz causes "configuration not supported" errors.
+        // Whisper resamples internally, so any standard sample rate works fine.
+        let default_config = match device.default_input_config() {
+            Ok(c) => c,
+            Err(e) => {
+                let _ = tx.send(Err(format!("Failed to get default input config: {e}")));
+                return;
+            }
+        };
+
+        let config: cpal::StreamConfig = default_config.into();
+        let actual_sample_rate = config.sample_rate.0;
+        let actual_channels = config.channels;
+
+        // Store the actual format so stop_recording can encode WAV correctly
+        sample_rate_store.store(actual_sample_rate, std::sync::atomic::Ordering::SeqCst);
+        channels_store.store(actual_channels, std::sync::atomic::Ordering::SeqCst);
+
+        let buffer_clone = buffer.clone();
+        let stream = match device.build_input_stream(
+            &config,
+            move |data: &[i16], _: &cpal::InputCallbackInfo| {
+                if let Ok(mut buf) = buffer_clone.lock() {
+                    buf.extend_from_slice(data);
+                }
+            },
+            |err| {
+                eprintln!("Audio input error: {err}");
+            },
+            None,
+        ) {
+            Ok(s) => s,
+            Err(e) => {
+                let _ = tx.send(Err(format!("Failed to build input stream: {e}")));
+                return;
+            }
+        };
+
+        if let Err(e) = stream.play() {
+            let _ = tx.send(Err(format!("Failed to start recording: {e}")));
+            return;
+        }
+
+        // Stream is now capturing — signal success and set the flag
+        is_recording.store(true, std::sync::atomic::Ordering::SeqCst);
+        let _ = tx.send(Ok(()));
+
+        // Keep the stream alive until stop_recording flips the flag
+        while is_recording.load(std::sync::atomic::Ordering::SeqCst) {
+            std::thread::sleep(std::time::Duration::from_millis(50));
+        }
+
+        // Stream is dropped here, stopping capture
+    });
+
+    // Wait for the recording thread to report success or failure.
+    // Timeout after 5 seconds to avoid hanging if the thread panics.
+    rx.recv_timeout(std::time::Duration::from_secs(5))
+        .map_err(|_| "Recording thread timed out".to_string())?
+}
+
+/// Stop recording and return the captured audio as WAV bytes.
+///
+/// Signals the recording thread to stop, then encodes the buffered PCM
+/// samples into a WAV file in memory using hound. Returns the complete
+/// WAV file as a byte vector for the frontend to send to the STT API.
+#[tauri::command]
+fn stop_recording(state: tauri::State<'_, RecordingState>) -> Result<Vec<u8>, String> {
+    if !state
+        .is_recording
+        .load(std::sync::atomic::Ordering::SeqCst)
+    {
+        return Err("Not currently recording".to_string());
+    }
+
+    // Signal the recording thread to stop
+    state
+        .is_recording
+        .store(false, std::sync::atomic::Ordering::SeqCst);
+
+    // Brief pause to let the recording thread finish and drop the stream
+    std::thread::sleep(std::time::Duration::from_millis(100));
+
+    let samples = state
+        .buffer
+        .lock()
+        .map_err(|e| format!("Buffer lock error: {e}"))?;
+
+    if samples.is_empty() {
+        return Err("No audio captured".to_string());
+    }
+
+    // Read the actual sample rate and channel count from the recording thread.
+    // These were stored when the device's default config was queried.
+    let sample_rate = state
+        .sample_rate
+        .load(std::sync::atomic::Ordering::SeqCst);
+    let channels = state.channels.load(std::sync::atomic::Ordering::SeqCst);
+
+    // Encode PCM samples as WAV in memory.
+    // WAV is universally accepted by STT APIs (Whisper, Deepgram, local whisper.cpp).
+    // We use whatever sample rate/channels the device actually captured at —
+    // Whisper resamples internally so this doesn't affect transcription quality.
+    let mut wav_buffer = std::io::Cursor::new(Vec::new());
+    let spec = hound::WavSpec {
+        channels,
+        sample_rate,
+        bits_per_sample: 16,
+        sample_format: hound::SampleFormat::Int,
+    };
+
+    let mut writer = hound::WavWriter::new(&mut wav_buffer, spec)
+        .map_err(|e| format!("Failed to create WAV writer: {e}"))?;
+
+    for &sample in samples.iter() {
+        writer
+            .write_sample(sample)
+            .map_err(|e| format!("Failed to write sample: {e}"))?;
+    }
+
+    writer
+        .finalize()
+        .map_err(|e| format!("Failed to finalize WAV: {e}"))?;
+
+    Ok(wav_buffer.into_inner())
+}
+
 #[cfg_attr(mobile, tauri::mobile_entry_point)]
 pub fn run() {
     // Install ring as the default crypto provider for rustls.
@@ -318,6 +530,12 @@ pub fn run() {
 
     tauri::Builder::default()
         .plugin(tauri_plugin_opener::init())
+        .manage(RecordingState {
+            buffer: Arc::new(Mutex::new(Vec::new())),
+            is_recording: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            sample_rate: Arc::new(std::sync::atomic::AtomicU32::new(16000)),
+            channels: Arc::new(std::sync::atomic::AtomicU16::new(1)),
+        })
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()
@@ -329,7 +547,9 @@ pub fn run() {
             fetch_riot_api,
             discover_lcu,
             fetch_lcu,
-            connect_lcu_websocket
+            connect_lcu_websocket,
+            start_recording,
+            stop_recording
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,9 +4,11 @@ import { useGameData } from "./hooks/useGameData";
 import { useGameLifecycle } from "./hooks/useGameLifecycle";
 import { useLiveGameState } from "./hooks/useLiveGameState";
 import { useUserInput } from "./hooks/useUserInput";
+import { useVoiceInput } from "./hooks/useVoiceInput";
 import { useZoom } from "./hooks/useZoom";
 import { initializeReactiveEngine } from "./lib/reactive";
 import type { ReactiveEngine } from "./lib/reactive";
+import { WhisperProvider } from "./lib/voice/stt-provider";
 import { DataBrowser } from "./components/DataBrowser";
 import {
   createModeRegistry,
@@ -36,6 +38,19 @@ function App() {
   const liveGame = useLiveGameState();
   const { submit } = useUserInput();
   const { zoom, resetZoom } = useZoom();
+
+  // Voice input — Whisper STT provider uses the same OpenAI API key as the coaching LLM.
+  // The provider is created once and persists for the app lifetime.
+  const whisperProvider = useMemo(() => {
+    const apiKey = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
+    if (!apiKey) {
+      console.warn("VITE_OPENAI_API_KEY not set — voice input disabled");
+      return null;
+    }
+    return new WhisperProvider(apiKey);
+  }, []);
+
+  const voice = useVoiceInput(whisperProvider);
 
   const [selectedAugments, setSelectedAugments] = useState<Augment[]>([]);
 
@@ -138,6 +153,30 @@ function App() {
               {Math.round(zoom * 100)}%
             </button>
           )}
+          <span
+            className="voice-indicator"
+            style={{
+              color: voice.isRecording
+                ? "#ef4444"
+                : voice.isTranscribing
+                  ? "#f59e0b"
+                  : "#6b7280",
+              marginLeft: "8px",
+            }}
+          >
+            {voice.isRecording
+              ? "Recording..."
+              : voice.isTranscribing
+                ? "Transcribing..."
+                : `Voice: Num-`}
+          </span>
+          <button
+            style={{ marginLeft: "8px", fontSize: "12px" }}
+            onMouseDown={() => voice.startRecording()}
+            onMouseUp={() => voice.stopAndTranscribe()}
+          >
+            Hold to Talk
+          </button>
         </div>
       </div>
       {data && (

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -139,6 +139,7 @@ const INPUT_COLORS: Record<string, string> = {
   "riot-api": "#34d399",
   "lcu-rest": "#60a5fa",
   "initial-state": "#fbbf24",
+  voice: "#ec4899",
 };
 
 const OUTPUT_COLORS: Record<string, string> = {

--- a/src/hooks/__tests__/useVoiceInput.test.ts
+++ b/src/hooks/__tests__/useVoiceInput.test.ts
@@ -1,0 +1,211 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useVoiceInput } from "../useVoiceInput";
+import type { SttProvider, SttResult } from "../../lib/voice/stt-provider";
+import { playerIntent$, debugInput$ } from "../../lib/reactive";
+
+// Mock Tauri invoke
+vi.mock("@tauri-apps/api/core", () => ({
+  invoke: vi.fn(),
+}));
+
+import { invoke } from "@tauri-apps/api/core";
+const mockInvoke = vi.mocked(invoke);
+
+function createMockProvider(
+  result: SttResult = { transcript: "test transcript", latencyMs: 150 }
+): SttProvider {
+  return {
+    transcribe: vi.fn().mockResolvedValue(result),
+  };
+}
+
+// Fake WAV bytes — just enough to not be empty.
+// Real WAV would have a header, but the hook only cares about byte count for duration calc.
+const fakeWavBytes = new Array(32000).fill(0); // ~1 second at 16kHz 16-bit mono
+
+describe("useVoiceInput", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "start_recording") return undefined;
+      if (cmd === "stop_recording") return fakeWavBytes;
+      throw new Error(`Unknown command: ${cmd}`);
+    });
+  });
+
+  it("starts in idle state", () => {
+    const { result } = renderHook(() => useVoiceInput(createMockProvider()));
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.isTranscribing).toBe(false);
+    expect(result.current.lastTranscript).toBeNull();
+    expect(result.current.lastLatencyMs).toBeNull();
+    expect(result.current.error).toBeNull();
+  });
+
+  it("sets isRecording on startRecording", async () => {
+    const { result } = renderHook(() => useVoiceInput(createMockProvider()));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(true);
+    expect(mockInvoke).toHaveBeenCalledWith("start_recording");
+  });
+
+  it("transcribes on stopAndTranscribe and updates state", async () => {
+    const provider = createMockProvider({
+      transcript: "should I build Rabadon's",
+      latencyMs: 200,
+    });
+    const { result } = renderHook(() => useVoiceInput(provider));
+
+    // Start recording first
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    // Stop and transcribe
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.isTranscribing).toBe(false);
+    expect(result.current.lastTranscript).toBe("should I build Rabadon's");
+    expect(result.current.lastLatencyMs).toBe(200);
+    expect(mockInvoke).toHaveBeenCalledWith("stop_recording");
+  });
+
+  it("pushes transcript into playerIntent$", async () => {
+    const provider = createMockProvider({
+      transcript: "which augment should I pick",
+      latencyMs: 100,
+    });
+
+    const events: Array<{ type: string; text: string }> = [];
+    const sub = playerIntent$.subscribe((e) =>
+      events.push(e as { type: "query"; text: string })
+    );
+
+    const { result } = renderHook(() => useVoiceInput(provider));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    expect(events).toHaveLength(1);
+    expect(events[0]).toEqual({
+      type: "query",
+      text: "which augment should I pick",
+    });
+
+    sub.unsubscribe();
+  });
+
+  it("does not push empty transcripts into playerIntent$", async () => {
+    const provider = createMockProvider({
+      transcript: "   ",
+      latencyMs: 100,
+    });
+
+    const events: unknown[] = [];
+    const sub = playerIntent$.subscribe((e) => events.push(e));
+
+    const { result } = renderHook(() => useVoiceInput(provider));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    expect(events).toHaveLength(0);
+    sub.unsubscribe();
+  });
+
+  it("emits debug events at each stage", async () => {
+    const provider = createMockProvider();
+    const debugEvents: Array<{ source: string; summary: string }> = [];
+    const sub = debugInput$.subscribe((e) => debugEvents.push(e));
+
+    const { result } = renderHook(() => useVoiceInput(provider));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    const voiceEvents = debugEvents.filter((e) => e.source === "voice");
+    expect(voiceEvents.length).toBeGreaterThanOrEqual(4);
+    expect(
+      voiceEvents.some((e) => e.summary.includes("Recording started"))
+    ).toBe(true);
+    expect(
+      voiceEvents.some((e) => e.summary.includes("Recording stopped"))
+    ).toBe(true);
+    expect(voiceEvents.some((e) => e.summary.includes("Audio captured"))).toBe(
+      true
+    );
+    expect(voiceEvents.some((e) => e.summary.includes("Transcript"))).toBe(
+      true
+    );
+
+    sub.unsubscribe();
+  });
+
+  it("handles recording errors gracefully", async () => {
+    mockInvoke.mockImplementation(async (cmd: string) => {
+      if (cmd === "start_recording")
+        throw new Error("No input device available");
+      return undefined;
+    });
+
+    const { result } = renderHook(() => useVoiceInput(createMockProvider()));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+
+    expect(result.current.isRecording).toBe(false);
+    expect(result.current.error).toBe("No input device available");
+  });
+
+  it("handles transcription errors gracefully", async () => {
+    const provider: SttProvider = {
+      transcribe: vi.fn().mockRejectedValue(new Error("API rate limit")),
+    };
+
+    const { result } = renderHook(() => useVoiceInput(provider));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    expect(result.current.isTranscribing).toBe(false);
+    expect(result.current.error).toBe("API rate limit");
+  });
+
+  it("errors when no provider is configured", async () => {
+    const { result } = renderHook(() => useVoiceInput(null));
+
+    await act(async () => {
+      await result.current.startRecording();
+    });
+    await act(async () => {
+      await result.current.stopAndTranscribe();
+    });
+
+    expect(result.current.error).toBe("No STT provider configured");
+  });
+});

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -1,0 +1,236 @@
+/**
+ * Voice input hook — orchestrates the push-to-talk pipeline.
+ *
+ * Wires together: global hotkey registration, Rust audio capture (via Tauri
+ * commands), vocabulary hint assembly, and STT transcription. The resulting
+ * transcript is pushed into the coaching pipeline as a query event.
+ *
+ * Flow:
+ * 1. On mount, registers a global hotkey for push-to-talk
+ * 2. Keydown → calls Rust `start_recording` command
+ * 3. Keyup → calls Rust `stop_recording` to get WAV bytes
+ * 4. Assembles vocab hints from current game state (match champions + static hard words)
+ * 5. Sends audio + hints to STT provider (Whisper API)
+ * 6. Pushes transcript into playerIntent$ as { type: "query", text }
+ * 7. Emits debug events at each stage for the debug panel
+ *
+ * Audio capture happens in Rust (via cpal) rather than the webview because:
+ * - It works regardless of window focus (game can be fullscreen)
+ * - No webview permission issues (macOS/Linux getUserMedia bugs)
+ * - Global hotkey fires from Rust, keeping the pipeline in one process
+ *
+ * See docs/voice-input-research.md for the full architecture rationale.
+ */
+
+import { useState, useEffect, useCallback, useRef } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import type { SttProvider, SttResult } from "../lib/voice/stt-provider";
+import { buildVocabHints } from "../lib/voice/vocab-hints";
+import { playerIntent$, debugInput$, liveGameState$ } from "../lib/reactive";
+
+/** Default hotkey for push-to-talk.
+ *
+ * Numpad minus: easy to reach with the right hand, not used by League.
+ * Note: This only works on native Windows — WSL2 global hotkeys don't fire.
+ */
+const PUSH_TO_TALK_HOTKEY = "NumpadSubtract";
+
+export interface VoiceInputState {
+  isRecording: boolean;
+  isTranscribing: boolean;
+  lastTranscript: string | null;
+  lastLatencyMs: number | null;
+  error: string | null;
+}
+
+export interface UseVoiceInputResult extends VoiceInputState {
+  startRecording: () => Promise<void>;
+  stopAndTranscribe: () => Promise<void>;
+}
+
+export function useVoiceInput(
+  provider: SttProvider | null
+): UseVoiceInputResult {
+  const [state, setState] = useState<VoiceInputState>({
+    isRecording: false,
+    isTranscribing: false,
+    lastTranscript: null,
+    lastLatencyMs: null,
+    error: null,
+  });
+
+  const providerRef = useRef(provider);
+  providerRef.current = provider;
+
+  // Track recording state in a ref so the hotkey callback always sees current value.
+  // React state updates are async, but the hotkey handler fires synchronously
+  // from the Tauri plugin — without a ref we'd get stale closure values.
+  const isRecordingRef = useRef(false);
+
+  const stopAndTranscribe = useCallback(async () => {
+    try {
+      isRecordingRef.current = false;
+      setState((s) => ({ ...s, isRecording: false, isTranscribing: true }));
+
+      debugInput$.next({
+        source: "voice",
+        summary: "Recording stopped, transcribing...",
+      });
+
+      // Get WAV bytes from Rust
+      const wavBytes: number[] = await invoke("stop_recording");
+      const blob = new Blob([new Uint8Array(wavBytes)], { type: "audio/wav" });
+
+      // Parse the WAV header to get the actual sample rate and channel count.
+      // The device may record at 48kHz stereo (Windows default) rather than
+      // 16kHz mono, so we can't hardcode the bytes-per-second calculation.
+      // WAV header layout: bytes 24-27 = sample rate (u32 LE), 22-23 = channels (u16 LE)
+      const wavData = new Uint8Array(wavBytes);
+      const view = new DataView(wavData.buffer);
+      const sampleRate = view.getUint32(24, true);
+      const channels = view.getUint16(22, true);
+      const bitsPerSample = view.getUint16(34, true);
+      const bytesPerSecond = sampleRate * channels * (bitsPerSample / 8);
+      const pcmBytes = Math.max(0, wavBytes.length - 44);
+      const audioDurationSec =
+        bytesPerSecond > 0 ? pcmBytes / bytesPerSecond : 0;
+      debugInput$.next({
+        source: "voice",
+        summary: `Audio captured: ${audioDurationSec.toFixed(1)}s`,
+      });
+
+      if (!providerRef.current) {
+        throw new Error("No STT provider configured");
+      }
+
+      // Build vocab hints from current game state
+      const gameState = liveGameState$.getValue();
+      const championNames = gameState.players.map((p) => p.championName);
+      const hints = buildVocabHints(championNames);
+
+      debugInput$.next({
+        source: "voice",
+        summary: `Vocab hints: ${hints.length} words`,
+        detail: hints.join(", "),
+      });
+
+      // Transcribe
+      const result: SttResult = await providerRef.current.transcribe(
+        blob,
+        hints
+      );
+
+      debugInput$.next({
+        source: "voice",
+        summary: `Transcript (${result.latencyMs}ms): ${result.transcript}`,
+        detail: result.transcript,
+      });
+
+      setState((s) => ({
+        ...s,
+        isTranscribing: false,
+        lastTranscript: result.transcript,
+        lastLatencyMs: result.latencyMs,
+        error: null,
+      }));
+
+      // Feed transcript into the coaching pipeline
+      if (result.transcript.trim()) {
+        playerIntent$.next({ type: "query", text: result.transcript });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      debugInput$.next({
+        source: "voice",
+        summary: `Error: ${message}`,
+      });
+      setState((s) => ({
+        ...s,
+        isRecording: false,
+        isTranscribing: false,
+        error: message,
+      }));
+    }
+  }, []);
+
+  const startRecording = useCallback(async () => {
+    try {
+      isRecordingRef.current = true;
+      setState((s) => ({ ...s, isRecording: true, error: null }));
+      debugInput$.next({
+        source: "voice",
+        summary: "Recording started (hotkey held)",
+      });
+      await invoke("start_recording");
+    } catch (err) {
+      const message = err instanceof Error ? err.message : String(err);
+      isRecordingRef.current = false;
+      debugInput$.next({
+        source: "voice",
+        summary: `Recording error: ${message}`,
+      });
+      setState((s) => ({ ...s, isRecording: false, error: message }));
+    }
+  }, []);
+
+  // Stable refs for the hotkey handler — avoids re-registering on every render
+  const startRef = useRef(startRecording);
+  const stopRef = useRef(stopAndTranscribe);
+  startRef.current = startRecording;
+  stopRef.current = stopAndTranscribe;
+
+  useEffect(() => {
+    let cancelled = false;
+
+    async function registerHotkey() {
+      try {
+        // Dynamic import — the global-shortcut plugin is only available in
+        // the Tauri runtime, not in tests or browser dev mode
+        const { register, unregister, isRegistered } =
+          await import("@tauri-apps/plugin-global-shortcut");
+
+        // Guard against React strict mode double-mount: if the hotkey is
+        // already registered (from a previous mount that hasn't cleaned up
+        // yet), unregister it first before re-registering.
+        if (await isRegistered(PUSH_TO_TALK_HOTKEY)) {
+          await unregister(PUSH_TO_TALK_HOTKEY);
+        }
+
+        if (cancelled) return;
+
+        await register(PUSH_TO_TALK_HOTKEY, (event) => {
+          if (event.state === "Pressed" && !isRecordingRef.current) {
+            startRef.current();
+          } else if (event.state === "Released" && isRecordingRef.current) {
+            stopRef.current();
+          }
+        });
+
+        debugInput$.next({
+          source: "voice",
+          summary: `Push-to-talk registered: ${PUSH_TO_TALK_HOTKEY}`,
+        });
+      } catch (err) {
+        // Expected to fail in non-Tauri environments (tests, browser dev)
+        console.warn("Global shortcut registration failed:", err);
+        debugInput$.next({
+          source: "voice",
+          summary: `Hotkey registration failed: ${err instanceof Error ? err.message : String(err)}`,
+        });
+      }
+    }
+
+    registerHotkey();
+
+    return () => {
+      cancelled = true;
+      import("@tauri-apps/plugin-global-shortcut")
+        .then(({ unregister }) => unregister(PUSH_TO_TALK_HOTKEY))
+        .catch(() => {});
+    };
+  }, []);
+
+  return { ...state, startRecording, stopAndTranscribe };
+}
+
+export { type SttProvider } from "../lib/voice/stt-provider";

--- a/src/lib/reactive/streams.ts
+++ b/src/lib/reactive/streams.ts
@@ -44,7 +44,8 @@ export interface DebugInputEvent {
     | "ws-filtered"
     | "riot-api"
     | "lcu-rest"
-    | "initial-state";
+    | "initial-state"
+    | "voice";
   summary: string;
   detail?: string;
 }

--- a/src/lib/voice/stt-provider.test.ts
+++ b/src/lib/voice/stt-provider.test.ts
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { WhisperProvider } from "./stt-provider";
+
+// Mock the OpenAI SDK — we don't want to make real API calls in tests
+const mockCreate = vi.fn();
+
+vi.mock("openai", () => {
+  return {
+    default: class MockOpenAI {
+      audio = {
+        transcriptions: {
+          create: mockCreate,
+        },
+      };
+    },
+  };
+});
+
+describe("WhisperProvider", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns transcript from Whisper API response", async () => {
+    mockCreate.mockResolvedValue({ text: "should I build Rabadon's" });
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    const result = await provider.transcribe(audio, ["Rabadon's"]);
+
+    expect(result.transcript).toBe("should I build Rabadon's");
+  });
+
+  it("sends audio as a File with correct name and type", async () => {
+    mockCreate.mockResolvedValue({ text: "test" });
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    await provider.transcribe(audio, []);
+
+    expect(mockCreate).toHaveBeenCalledOnce();
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.file).toBeInstanceOf(File);
+    expect(callArgs.file.name).toBe("recording.wav");
+  });
+
+  it("formats vocab hints as a glossary in the prompt parameter", async () => {
+    mockCreate.mockResolvedValue({ text: "test" });
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    await provider.transcribe(audio, ["Aatrox", "Rabadon's", "Hextech"]);
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.prompt).toBe("Glossary: Aatrox, Rabadon's, Hextech");
+  });
+
+  it("omits prompt parameter when vocab hints are empty", async () => {
+    mockCreate.mockResolvedValue({ text: "test" });
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    await provider.transcribe(audio, []);
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.prompt).toBeUndefined();
+  });
+
+  it("uses whisper-1 model", async () => {
+    mockCreate.mockResolvedValue({ text: "test" });
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    await provider.transcribe(audio, []);
+
+    const callArgs = mockCreate.mock.calls[0][0];
+    expect(callArgs.model).toBe("whisper-1");
+  });
+
+  it("measures latency", async () => {
+    // Simulate a small delay
+    mockCreate.mockImplementation(
+      () =>
+        new Promise((resolve) =>
+          setTimeout(() => resolve({ text: "test" }), 50)
+        )
+    );
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+    const result = await provider.transcribe(audio, []);
+
+    expect(result.latencyMs).toBeGreaterThanOrEqual(40);
+    expect(result.latencyMs).toBeLessThan(500);
+  });
+
+  it("throws on API error", async () => {
+    mockCreate.mockRejectedValue(new Error("API rate limit exceeded"));
+
+    const provider = new WhisperProvider("test-api-key");
+    const audio = new Blob(["fake-audio"], { type: "audio/wav" });
+
+    await expect(provider.transcribe(audio, [])).rejects.toThrow(
+      "API rate limit exceeded"
+    );
+  });
+});

--- a/src/lib/voice/stt-provider.ts
+++ b/src/lib/voice/stt-provider.ts
@@ -1,0 +1,71 @@
+/**
+ * Speech-to-text provider interface and implementations.
+ *
+ * Abstracts the STT engine behind a simple interface so we can swap between
+ * providers without changing the voice input pipeline:
+ * - OpenAI Whisper API (current default — same API key as coaching LLM)
+ * - Deepgram Nova-3 (upgrade path — faster, larger vocab budget)
+ * - Local whisper.cpp (future — free, runs in Docker)
+ *
+ * The provider receives raw audio bytes and vocabulary hints, and returns
+ * a transcript string with latency measurement.
+ */
+
+import OpenAI from "openai";
+import { formatWhisperGlossary } from "./vocab-hints";
+
+export interface SttResult {
+  transcript: string;
+  /** Round-trip time for the STT API call in milliseconds */
+  latencyMs: number;
+}
+
+export interface SttProvider {
+  transcribe(audio: Blob, vocabHints: string[]): Promise<SttResult>;
+}
+
+/**
+ * OpenAI Whisper API implementation.
+ *
+ * Uses the same API key as the coaching LLM (GPT-5.4 mini), so no additional
+ * credentials are needed. Vocabulary hints are formatted as a glossary string
+ * in the `prompt` parameter — Whisper uses this to bias toward recognizing
+ * the specified terms.
+ *
+ * Whisper's prompt parameter is limited to 224 tokens. Our vocabulary hint
+ * list is ~188 tokens, fitting within this limit. See vocab-hints.ts for
+ * the full analysis of how we stay under budget.
+ */
+export class WhisperProvider implements SttProvider {
+  private client: OpenAI;
+
+  constructor(apiKey: string) {
+    this.client = new OpenAI({ apiKey, dangerouslyAllowBrowser: true });
+  }
+
+  async transcribe(audio: Blob, vocabHints: string[]): Promise<SttResult> {
+    // Wrap the Blob as a File — the OpenAI SDK expects a File object
+    // with a name so it can determine the content type for the multipart upload.
+    const file = new File([audio], "recording.wav", { type: "audio/wav" });
+
+    // Build the glossary prompt from vocab hints.
+    // When empty, we omit the prompt entirely rather than sending an empty string,
+    // since Whisper performs slightly better without a prompt than with an empty one.
+    const glossary = formatWhisperGlossary(vocabHints);
+
+    const start = performance.now();
+
+    const response = await this.client.audio.transcriptions.create({
+      file,
+      model: "whisper-1",
+      ...(glossary ? { prompt: glossary } : {}),
+    });
+
+    const latencyMs = Math.round(performance.now() - start);
+
+    return {
+      transcript: response.text,
+      latencyMs,
+    };
+  }
+}

--- a/src/lib/voice/vocab-hints.test.ts
+++ b/src/lib/voice/vocab-hints.test.ts
@@ -1,0 +1,134 @@
+import { describe, it, expect } from "vitest";
+import {
+  HARD_ITEM_WORDS,
+  HARD_AUGMENT_WORDS,
+  HARD_CHAMPION_NAMES,
+  buildVocabHints,
+  formatWhisperGlossary,
+} from "./vocab-hints";
+
+describe("HARD_ITEM_WORDS", () => {
+  it("contains known hard item words", () => {
+    // Fantasy proper nouns that STT consistently mangles
+    expect(HARD_ITEM_WORDS).toContain("Rabadon's");
+    expect(HARD_ITEM_WORDS).toContain("Zhonya's");
+    expect(HARD_ITEM_WORDS).toContain("Morellonomicon");
+    expect(HARD_ITEM_WORDS).toContain("Fimbulwinter");
+    expect(HARD_ITEM_WORDS).toContain("Hextech");
+    expect(HARD_ITEM_WORDS).toContain("Manamune");
+  });
+
+  it("excludes common English words", () => {
+    // These are real English words or common enough that STT handles them
+    expect(HARD_ITEM_WORDS).not.toContain("Chain");
+    expect(HARD_ITEM_WORDS).not.toContain("Vest");
+    expect(HARD_ITEM_WORDS).not.toContain("Sword");
+    expect(HARD_ITEM_WORDS).not.toContain("Hourglass");
+    expect(HARD_ITEM_WORDS).not.toContain("Deathcap");
+  });
+
+  it("has the expected count", () => {
+    expect(HARD_ITEM_WORDS.length).toBe(55);
+  });
+});
+
+describe("HARD_AUGMENT_WORDS", () => {
+  it("contains known hard augment words", () => {
+    expect(HARD_AUGMENT_WORDS).toContain("Droppybara");
+    expect(HARD_AUGMENT_WORDS).toContain("Minionmancer");
+    expect(HARD_AUGMENT_WORDS).toContain("Poro");
+    expect(HARD_AUGMENT_WORDS).toContain("Homeguard");
+    expect(HARD_AUGMENT_WORDS).toContain("Witchful");
+  });
+
+  it("deduplicates with items when combined via buildVocabHints", () => {
+    // Some words appear in both item and augment lists (Thornmail, Sheen, etc.).
+    // The static lists are allowed to overlap — deduplication happens in
+    // buildVocabHints() which combines them into a Set.
+    const hints = buildVocabHints([]);
+    const uniqueCount = new Set(hints).size;
+    expect(uniqueCount).toBe(hints.length);
+  });
+
+  it("excludes common English words", () => {
+    expect(HARD_AUGMENT_WORDS).not.toContain("Heavy");
+    expect(HARD_AUGMENT_WORDS).not.toContain("Hitter");
+    expect(HARD_AUGMENT_WORDS).not.toContain("Circle");
+    expect(HARD_AUGMENT_WORDS).not.toContain("Death");
+  });
+});
+
+describe("HARD_CHAMPION_NAMES", () => {
+  it("contains fantasy champion names", () => {
+    expect(HARD_CHAMPION_NAMES.has("Aatrox")).toBe(true);
+    expect(HARD_CHAMPION_NAMES.has("Vel'Koz")).toBe(true);
+    expect(HARD_CHAMPION_NAMES.has("Kha'Zix")).toBe(true);
+    expect(HARD_CHAMPION_NAMES.has("Heimerdinger")).toBe(true);
+  });
+
+  it("excludes common English names that STT handles", () => {
+    expect(HARD_CHAMPION_NAMES.has("Annie")).toBe(false);
+    expect(HARD_CHAMPION_NAMES.has("Diana")).toBe(false);
+    expect(HARD_CHAMPION_NAMES.has("Graves")).toBe(false);
+    expect(HARD_CHAMPION_NAMES.has("Vi")).toBe(false);
+    expect(HARD_CHAMPION_NAMES.has("Brand")).toBe(false);
+  });
+
+  it("has the expected count", () => {
+    expect(HARD_CHAMPION_NAMES.size).toBe(89);
+  });
+});
+
+describe("buildVocabHints", () => {
+  it("includes static item and augment words", () => {
+    const hints = buildVocabHints([]);
+    expect(hints).toContain("Rabadon's");
+    expect(hints).toContain("Morellonomicon");
+    expect(hints).toContain("Droppybara");
+  });
+
+  it("includes hard champion names from the match", () => {
+    const hints = buildVocabHints(["Aatrox", "Vel'Koz", "Annie"]);
+    expect(hints).toContain("Aatrox");
+    expect(hints).toContain("Vel'Koz");
+  });
+
+  it("excludes common English champion names from the match", () => {
+    // Annie is a common English name — STT doesn't need help with it
+    const hints = buildVocabHints(["Annie", "Diana", "Graves"]);
+    expect(hints).not.toContain("Annie");
+    expect(hints).not.toContain("Diana");
+    expect(hints).not.toContain("Graves");
+  });
+
+  it("deduplicates across all sources", () => {
+    const hints = buildVocabHints(["Kalista"]);
+    // "Kalista" could appear as champion and "Kalista's" in items —
+    // each unique string should appear only once
+    const uniqueCount = new Set(hints).size;
+    expect(uniqueCount).toBe(hints.length);
+  });
+
+  it("returns a non-empty array even with no match champions", () => {
+    const hints = buildVocabHints([]);
+    // Should still have item + augment hard words
+    expect(hints.length).toBeGreaterThan(0);
+  });
+});
+
+describe("formatWhisperGlossary", () => {
+  it("formats as a comma-separated glossary with prefix", () => {
+    const result = formatWhisperGlossary(["Aatrox", "Rabadon's", "Hextech"]);
+    expect(result).toBe("Glossary: Aatrox, Rabadon's, Hextech");
+  });
+
+  it("returns empty string for empty input", () => {
+    const result = formatWhisperGlossary([]);
+    expect(result).toBe("");
+  });
+
+  it("handles a single word", () => {
+    const result = formatWhisperGlossary(["Morellonomicon"]);
+    expect(result).toBe("Glossary: Morellonomicon");
+  });
+});

--- a/src/lib/voice/vocab-hints.ts
+++ b/src/lib/voice/vocab-hints.ts
@@ -1,0 +1,312 @@
+/**
+ * Vocabulary hint builder for STT (speech-to-text) engines.
+ *
+ * STT engines struggle with fantasy/invented words common in League of Legends
+ * (champion names, item names, augment names). Both Whisper and Deepgram support
+ * vocabulary hinting — a list of words the engine should bias toward recognizing.
+ *
+ * However, vocabulary hint budgets are limited:
+ * - Whisper: 224 tokens max in the `prompt` parameter
+ * - Deepgram: 500 tokens / 100 keyterms in the `keyterm` parameter
+ *
+ * To fit within these limits, we apply two optimizations:
+ *
+ * 1. **Send only hard words, not full names.** "Rabadon's Deathcap" becomes
+ *    just "Rabadon's" — "Deathcap" is common English that STT handles fine.
+ *    This roughly halves token usage for multi-word names.
+ *
+ * 2. **Scope champions to the current match.** All 89 hard champion words would
+ *    consume ~170 tokens alone. Since players almost exclusively discuss champions
+ *    in their current game, we send only the ~10 match champions' hard words (~18
+ *    tokens), freeing budget for items and augments.
+ *
+ * The combined output is ~188 tokens — fits Whisper's 224-token limit with margin.
+ *
+ * See docs/voice-input-research.md for the full analysis and word lists.
+ */
+
+/**
+ * Hard-to-transcribe words from ARAM-purchasable item names.
+ *
+ * These are fantasy proper nouns, invented compounds, and archaic English words
+ * that general-purpose STT engines consistently mangle. Common English words
+ * from item names (e.g., "Deathcap", "Hourglass", "Chain Vest") are excluded
+ * because STT handles them fine without hints.
+ *
+ * Selection criteria for inclusion:
+ * - Fantasy/invented words: Rabadon's, Guinsoo's, Morellonomicon
+ * - Game-specific compounds: Hextech, Chempunk, Chemtech
+ * - Archaic English uncommon in speech: Solari, Malmortius, Navori
+ * - Possessives of fantasy names: Zhonya's, Liandry's, Shurelya's
+ *
+ * Curated from 248 ARAM-purchasable items; 55 hard words identified.
+ */
+export const HARD_ITEM_WORDS: readonly string[] = [
+  "Actualizer",
+  "Anathema's",
+  "Atma's",
+  "Bami's",
+  "Bandleglass",
+  "Bandlepipes",
+  "Battlesong",
+  "Cappa",
+  "Caulfield's",
+  "Chempunk",
+  "Chemtech",
+  "Cryptbloom",
+  "Dawncore",
+  "Fiendhunter",
+  "Fimbulwinter",
+  "Guinsoo's",
+  "Heartsteel",
+  "Helia",
+  "Hexdrinker",
+  "Hexoptics",
+  "Hexplate",
+  "Hextech",
+  "Jak'Sho",
+  "Kaenic",
+  "Kalista's",
+  "Kindlegem",
+  "Liandry's",
+  "Luden's",
+  "Malmortius",
+  "Manamune",
+  "Morellonomicon",
+  "Muramana",
+  "Nashor's",
+  "Navori",
+  "Phreakish",
+  "Poro-Snax",
+  "Rabadon's",
+  "Rageblade",
+  "Randuin's",
+  "Riftmaker",
+  "Rookern",
+  "Runaan's",
+  "Rylai's",
+  "Serylda's",
+  "Shojin",
+  "Shurelya's",
+  "Solari",
+  "Statikk",
+  "Sterak's",
+  "Tal",
+  "Witchcap",
+  "Wooglet's",
+  "Youmuu's",
+  "Yun",
+  "Zhonya's",
+];
+
+/**
+ * Hard-to-transcribe words from Mayhem augment names.
+ *
+ * Augments are the primary use case for voice input — players must speak augment
+ * names since the Riot API doesn't expose which options are on screen. Most
+ * augment names are common English ("Heavy Hitter", "Circle of Death"), but
+ * ~44 contain game-specific or invented words.
+ *
+ * After deduplication with HARD_ITEM_WORDS (shared words like "Hextech",
+ * "Zhonya's", "Thornmail", "Witchcap", "Wooglet's", "Sheen", "Mikael's"),
+ * ~37 unique augment-only hard words remain.
+ *
+ * Selection criteria — same as items, plus:
+ * - Game jargon: Poro, Crit, Buff, Homeguard
+ * - Unusual casing indicating game puns: ADAPt, EscAPADe, ReEnergize
+ * - Invented compounds: Minionmancer, Marksmage, Nightstalking
+ */
+export const HARD_AUGMENT_WORDS: readonly string[] = [
+  "ADAPt",
+  "Brutalizer",
+  "Buff",
+  "Colossus",
+  "Crit",
+  "Dawnbringer's",
+  "Dropkick",
+  "Droppybara",
+  "Earthwake",
+  "Empyrean",
+  "EscAPADe",
+  "Fey",
+  "Firebrand",
+  "Flashbang",
+  "Goldrend",
+  "Goredrink",
+  "Homeguard",
+  "Icathia's",
+  "Immolate",
+  "Keystone",
+  "Marksmage",
+  "Mikael's",
+  "Minionmancer",
+  "Nightstalking",
+  "Omni",
+  "Popoffs",
+  "Poro",
+  "ReEnergize",
+  "Repulsor",
+  "Scopier",
+  "Scopiest",
+  "Sheen",
+  "Sneakerhead",
+  "Snowball",
+  "Thornmail",
+  "Transmute",
+  "Trueshot",
+  "Urf's",
+  "Windspeaker's",
+  "Witchful",
+];
+
+/**
+ * All champion names that STT engines struggle with.
+ *
+ * Used as a lookup set: when building per-match vocab hints, each match
+ * champion is checked against this set. Champions with common English names
+ * (Annie, Diana, Graves, Karma, etc.) are excluded — STT transcribes them fine.
+ *
+ * 89 of 172 champions have fantasy/invented names requiring hints.
+ * Multi-word champion names contribute individual hard words:
+ * e.g., "Lee Sin" — "Lee" is fine, "Sin" is fine, neither needs hinting.
+ * "Aurelion Sol" — "Aurelion" is fantasy (included), "Sol" is fine.
+ */
+export const HARD_CHAMPION_NAMES: ReadonlySet<string> = new Set([
+  "Aatrox",
+  "Ahri",
+  "Akali",
+  "Akshan",
+  "Alistar",
+  "Ambessa",
+  "Amumu",
+  "Anivia",
+  "Aphelios",
+  "Aurelion",
+  "Azir",
+  "Bel'Veth",
+  "Blitzcrank",
+  "Cassiopeia",
+  "Cho'Gath",
+  "Corki",
+  "Ezreal",
+  "Fiddlesticks",
+  "Fizz",
+  "Gangplank",
+  "Gnar",
+  "Gragas",
+  "Hecarim",
+  "Heimerdinger",
+  "Hwei",
+  "Illaoi",
+  "Jarvan",
+  "Jhin",
+  "K'Sante",
+  "Kai'Sa",
+  "Kalista",
+  "Karthus",
+  "Kassadin",
+  "Katarina",
+  "Kayn",
+  "Kennen",
+  "Kha'Zix",
+  "Kled",
+  "Kog'Maw",
+  "LeBlanc",
+  "Lillia",
+  "Lissandra",
+  "Malphite",
+  "Malzahar",
+  "Maokai",
+  "Milio",
+  "Mordekaiser",
+  "Mundo",
+  "Naafiri",
+  "Nidalee",
+  "Nilah",
+  "Orianna",
+  "Qiyana",
+  "Rakan",
+  "Rammus",
+  "Rek'Sai",
+  "Renekton",
+  "Rengar",
+  "Ryze",
+  "Sejuani",
+  "Seraphine",
+  "Shaco",
+  "Shyvana",
+  "Singed",
+  "Skarner",
+  "Soraka",
+  "Sylas",
+  "Tahm",
+  "Taliyah",
+  "Tristana",
+  "Tryndamere",
+  "Urgot",
+  "Veigar",
+  "Vel'Koz",
+  "Viego",
+  "Vladimir",
+  "Volibear",
+  "Wukong",
+  "Xayah",
+  "Xerath",
+  "Xin",
+  "Yasuo",
+  "Yone",
+  "Yunara",
+  "Yuumi",
+  "Zaahen",
+  "Ziggs",
+  "Zilean",
+  "Zyra",
+]);
+
+/**
+ * Build the vocabulary hint list for an STT transcription request.
+ *
+ * Combines static hard words (items + augments) with dynamic match-specific
+ * champion names. The result is a deduplicated array of individual words
+ * that STT engines should be biased toward recognizing.
+ *
+ * @param matchChampions - Names of all champions in the current match (up to 10)
+ * @returns Deduplicated array of hard words, typically ~100 entries / ~188 tokens
+ */
+export function buildVocabHints(matchChampions: string[]): string[] {
+  const hints = new Set<string>();
+
+  // Add all static hard words (items + augments)
+  for (const word of HARD_ITEM_WORDS) {
+    hints.add(word);
+  }
+  for (const word of HARD_AUGMENT_WORDS) {
+    hints.add(word);
+  }
+
+  // Add match-specific champion names, but only the hard ones.
+  // Champions like "Annie" or "Diana" are common English names that
+  // STT handles without help — no point wasting token budget on them.
+  for (const champion of matchChampions) {
+    if (HARD_CHAMPION_NAMES.has(champion)) {
+      hints.add(champion);
+    }
+  }
+
+  return [...hints];
+}
+
+/**
+ * Format vocab hints as a Whisper-compatible glossary prompt string.
+ *
+ * Whisper's `prompt` parameter works best as a comma-separated glossary.
+ * The format "Glossary: word1, word2, ..." is recommended by OpenAI's
+ * Whisper prompting guide for steering spelling of proper nouns.
+ *
+ * @param hints - Array of hard words from buildVocabHints()
+ * @returns Formatted glossary string for the Whisper prompt parameter
+ */
+export function formatWhisperGlossary(hints: string[]): string {
+  if (hints.length === 0) return "";
+  return `Glossary: ${hints.join(", ")}`;
+}


### PR DESCRIPTION
## Summary

- Rust-side audio capture via cpal + hound (runs independent of webview focus, works while game is fullscreen)
- OpenAI Whisper API integration behind a swappable `SttProvider` interface
- Curated vocabulary hint system: sends only hard-to-transcribe words (~188 tokens) to fit Whisper's 224-token prompt limit
- Push-to-talk via global hotkey (NumpadSubtract) with "Hold to Talk" button fallback
- Debug panel shows full voice pipeline: recording state, audio duration, vocab hints sent, transcript + latency
- 33 new tests (vocab-hints, stt-provider, useVoiceInput hook)

Resolves #4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added push-to-talk voice recording with automatic transcription
  * Added recording status indicator and "Hold to Talk" button to the interface
  * Improved transcription accuracy through context-aware vocabulary hints

* **Documentation**
  * Added comprehensive design specification and research documentation for the voice input feature

* **Tests**
  * Added thorough test coverage for voice input operations, transcription, and vocabulary hint generation

<!-- end of auto-generated comment: release notes by coderabbit.ai -->