### PR TITLE
Include current gold in coaching context for item recommendations

### DIFF
--- a/src/lib/ai/context-assembler.test.ts
+++ b/src/lib/ai/context-assembler.test.ts
@@ -292,6 +292,12 @@ describe("assembleContext", () => {
     ]);
   });
 
+  it("includes current gold from active player", () => {
+    const result = assembleContext(createLiveGameState(), createGameData());
+    expect(result).not.toBeNull();
+    expect(result!.currentGold).toBe(2500);
+  });
+
   it("falls back to empty description when item not in gameData", () => {
     const gameData = createGameData();
     gameData.items.clear();

--- a/src/lib/ai/context-assembler.ts
+++ b/src/lib/ai/context-assembler.ts
@@ -67,6 +67,7 @@ export function assembleContext(
       statProfile,
     },
     currentItems,
+    currentGold: activePlayer.currentGold,
     currentAugments: [],
     teamAnalysis,
     augmentSets: gameData.augmentSets,

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -13,6 +13,7 @@ function createContext(
       statProfile:
         "Ranged (550) | Mage, Assassin | HP: 590 (+96/lvl) | AD: 53 (+3/lvl) | AS: 0.668 (+2%/lvl) | Armor: 23 (+4.7/lvl) | MR: 30 (+1.3/lvl) | Mana",
     },
+    currentGold: 2500,
     currentItems: [
       {
         name: "Rabadon's Deathcap",
@@ -144,6 +145,11 @@ describe("buildUserPrompt", () => {
       const prompt = buildUserPrompt(createContext(), generalQuery);
       expect(prompt).toContain("Rabadon's Deathcap");
       expect(prompt).toContain("Massively increases Ability Power.");
+    });
+
+    it("includes current gold in items section", () => {
+      const prompt = buildUserPrompt(createContext(), generalQuery);
+      expect(prompt).toContain("2500 gold available");
     });
 
     it("includes enemy items as names only", () => {

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -87,9 +87,13 @@ export function buildUserPrompt(
         ? `- ${item.name}: ${item.description}`
         : `- ${item.name}`
     );
-    sections.push(`### Current Items\n${itemLines.join("\n")}`);
+    sections.push(
+      `### Current Items (${context.currentGold} gold available)\n${itemLines.join("\n")}`
+    );
   } else {
-    sections.push("### Current Items\nNone");
+    sections.push(
+      `### Current Items (${context.currentGold} gold available)\nNone`
+    );
   }
 
   if (context.currentAugments.length > 0) {

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -28,6 +28,7 @@ export interface CoachingContext {
     statProfile: string | null;
   };
   currentItems: CoachingItem[];
+  currentGold: number;
   currentAugments: CoachingItem[];
   enemyTeam: Array<{
     champion: string;


### PR DESCRIPTION
## Summary

- Add `currentGold` to `CoachingContext`, populated from the Live Client Data API's `activePlayer.currentGold`
- Display gold alongside current items in the coaching prompt: `### Current Items (2500 gold available)`
- The model can now factor in available gold when recommending item purchases (e.g., "you have 1200g, buy Chain Vest" vs "save for BF Sword")

Most of the item recommendation functionality was already completed in PR #44 (coaching engine). This PR addresses the one missing piece: gold availability wasn't being passed to the model.

Closes #12

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The coaching assistant now displays your available gold alongside the “Current Items” section, even when you have no items, improving clarity for purchase decisions.

* **Tests**
  * Added tests to ensure the correct gold amount is captured and shown in the coaching prompts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->