### PR TITLE
Fix debug panel noise and WebSocket reconnection

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -149,7 +149,7 @@ const OUTPUT_COLORS: Record<string, string> = {
   notification: "#f87171",
 };
 
-const MAX_LOG_ENTRIES = 100;
+const MAX_LOG_ENTRIES = 200;
 
 function formatBufferAsText(entries: LogEntry[]): string {
   return entries

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from "react";
 import { skip, distinctUntilChanged, map } from "rxjs/operators";
 import { detailedDiff } from "deep-object-diff";
 import { formatGameTime } from "../lib/format";
+import { hasGameStateChangedMeaningfully } from "../lib/reactive/debug-filters";
 import {
   gameLifecycle$,
   liveGameState$,
@@ -261,17 +262,7 @@ function startSubscriptions(): void {
   liveGameState$
     .pipe(
       skip(1),
-      // Deduplicate on meaningful state changes (not game time ticking)
-      distinctUntilChanged((a, b) => {
-        if (a.activePlayer?.championName !== b.activePlayer?.championName)
-          return false;
-        if (a.activePlayer?.level !== b.activePlayer?.level) return false;
-        if (a.players.length !== b.players.length) return false;
-        if (a.gameMode !== b.gameMode) return false;
-        if ((a.champSelect != null) !== (b.champSelect != null)) return false;
-        if ((a.eogStats != null) !== (b.eogStats != null)) return false;
-        return true;
-      }),
+      distinctUntilChanged((a, b) => !hasGameStateChangedMeaningfully(a, b)),
       map((state) => summarizeLiveGameState(state))
     )
     .subscribe((summary) => {

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,5 +1,5 @@
 import { useState, useEffect, useRef } from "react";
-import { skip } from "rxjs/operators";
+import { skip, distinctUntilChanged, map } from "rxjs/operators";
 import { detailedDiff } from "deep-object-diff";
 import { formatGameTime } from "../lib/format";
 import {
@@ -239,17 +239,36 @@ function startSubscriptions(): void {
         event.data != null && typeof event.data === "object"
           ? (event.data as Record<string, unknown>)
           : null;
+
+      // Suppress matchmaking ticks that only update timeInQueue
+      if (
+        event.type === "matchmaking" &&
+        detail &&
+        /^~updated:\n\s+timeInQueue: \d+$/.test(detail.trim())
+      ) {
+        return;
+      }
+
+      // Truncate JWT tokens in diffs — they're unreadable noise
+      if (detail) {
+        detail = detail.replace(/eyJ[A-Za-z0-9_-]{50,}/g, "[JWT token]");
+      }
     }
 
     pushOutput("lifecycle", summary, detail);
   });
 
-  liveGameState$.pipe(skip(1)).subscribe((state) => {
-    const summary = summarizeLiveGameState(state);
-    if (summary !== "Default (no data)") {
-      pushOutput("liveGame", summary);
-    }
-  });
+  liveGameState$
+    .pipe(
+      skip(1),
+      map((state) => summarizeLiveGameState(state)),
+      distinctUntilChanged()
+    )
+    .subscribe((summary) => {
+      if (summary !== "Default (no data)") {
+        pushOutput("liveGame", summary);
+      }
+    });
 
   userInput$.subscribe((event) => {
     pushOutput("userInput", summarizeUserInput(event));

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -252,7 +252,10 @@ function startSubscriptions(): void {
 
       // Truncate JWT tokens in diffs — they're unreadable noise
       if (detail) {
-        detail = detail.replace(/eyJ[A-Za-z0-9_-]{50,}/g, "[JWT token]");
+        detail = detail.replace(
+          /\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
+          "[JWT token]"
+        );
       }
     }
 

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -261,8 +261,18 @@ function startSubscriptions(): void {
   liveGameState$
     .pipe(
       skip(1),
-      map((state) => summarizeLiveGameState(state)),
-      distinctUntilChanged()
+      // Deduplicate on meaningful state changes (not game time ticking)
+      distinctUntilChanged((a, b) => {
+        if (a.activePlayer?.championName !== b.activePlayer?.championName)
+          return false;
+        if (a.activePlayer?.level !== b.activePlayer?.level) return false;
+        if (a.players.length !== b.players.length) return false;
+        if (a.gameMode !== b.gameMode) return false;
+        if ((a.champSelect != null) !== (b.champSelect != null)) return false;
+        if ((a.eogStats != null) !== (b.eogStats != null)) return false;
+        return true;
+      }),
+      map((state) => summarizeLiveGameState(state))
     )
     .subscribe((summary) => {
       if (summary !== "Default (no data)") {

--- a/src/lib/reactive/debug-filters.test.ts
+++ b/src/lib/reactive/debug-filters.test.ts
@@ -3,7 +3,10 @@ import {
   isDebugWorthy,
   shouldLogPollStatus,
   describeEvent,
+  hasGameStateChangedMeaningfully,
 } from "./debug-filters";
+import type { LiveGameState } from "./types";
+import { createDefaultLiveGameState } from "./streams";
 
 describe("isDebugWorthy", () => {
   it("allows gameflow phase events", () => {
@@ -118,5 +121,84 @@ describe("shouldLogPollStatus", () => {
 
   it("logs when status changes from CONNECTION_FAILED to LOADING", () => {
     expect(shouldLogPollStatus("LOADING", "CONNECTION_FAILED")).toBe(true);
+  });
+});
+
+describe("hasGameStateChangedMeaningfully", () => {
+  function makeState(overrides: Partial<LiveGameState> = {}): LiveGameState {
+    return { ...createDefaultLiveGameState(), ...overrides };
+  }
+
+  it("detects champion change", () => {
+    const a = makeState({
+      activePlayer: { championName: "Ahri" } as LiveGameState["activePlayer"],
+    });
+    const b = makeState({
+      activePlayer: { championName: "Jinx" } as LiveGameState["activePlayer"],
+    });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("detects level change", () => {
+    const a = makeState({
+      activePlayer: {
+        championName: "Ahri",
+        level: 5,
+      } as LiveGameState["activePlayer"],
+    });
+    const b = makeState({
+      activePlayer: {
+        championName: "Ahri",
+        level: 6,
+      } as LiveGameState["activePlayer"],
+    });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("detects player count change", () => {
+    const a = makeState({
+      players: [{ championName: "Ahri" }] as LiveGameState["players"],
+    });
+    const b = makeState({ players: [] });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("detects game mode change", () => {
+    const a = makeState({ gameMode: "ARAM" });
+    const b = makeState({ gameMode: "KIWI" });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("detects champ select appearing", () => {
+    const a = makeState({ champSelect: null });
+    const b = makeState({ champSelect: { some: "data" } as unknown });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("detects end-of-game stats appearing", () => {
+    const a = makeState({ eogStats: null });
+    const b = makeState({
+      eogStats: {
+        gameId: "1",
+        gameLength: 600,
+        gameMode: "ARAM",
+        isWin: true,
+        championId: 1,
+        items: [],
+      },
+    });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(true);
+  });
+
+  it("ignores game time changes", () => {
+    const a = makeState({ gameTime: 100 });
+    const b = makeState({ gameTime: 102 });
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(false);
+  });
+
+  it("ignores identical states", () => {
+    const a = makeState();
+    const b = makeState();
+    expect(hasGameStateChangedMeaningfully(a, b)).toBe(false);
   });
 });

--- a/src/lib/reactive/debug-filters.test.ts
+++ b/src/lib/reactive/debug-filters.test.ts
@@ -1,0 +1,122 @@
+import { describe, it, expect } from "vitest";
+import {
+  isDebugWorthy,
+  shouldLogPollStatus,
+  describeEvent,
+} from "./debug-filters";
+
+describe("isDebugWorthy", () => {
+  it("allows gameflow phase events", () => {
+    expect(isDebugWorthy("/lol-gameflow/v1/gameflow-phase")).toBe(true);
+  });
+
+  it("allows gameflow session events", () => {
+    expect(isDebugWorthy("/lol-gameflow/v1/session")).toBe(true);
+  });
+
+  it("allows champ select session events", () => {
+    expect(isDebugWorthy("/lol-champ-select/v1/session")).toBe(true);
+  });
+
+  it("filters out grid-champions noise", () => {
+    expect(isDebugWorthy("/lol-champ-select/v1/grid-champions/143")).toBe(
+      false
+    );
+  });
+
+  it("filters out skin-carousel noise", () => {
+    expect(isDebugWorthy("/lol-champ-select/v1/skin-carousel-skins")).toBe(
+      false
+    );
+  });
+
+  it("filters out matchmaking search ticks", () => {
+    expect(isDebugWorthy("/lol-matchmaking/v1/search")).toBe(false);
+  });
+
+  it("filters out settings updates", () => {
+    expect(isDebugWorthy("/lol-settings/v1/account/champ-select")).toBe(false);
+  });
+
+  it("filters out hovercard updates", () => {
+    expect(isDebugWorthy("/lol-hovercard/v1/friend-info/some-uuid")).toBe(
+      false
+    );
+  });
+
+  it("filters out lobby-team-builder noise", () => {
+    expect(
+      isDebugWorthy(
+        "/lol-lobby-team-builder/champ-select/v1/pickable-champion-ids"
+      )
+    ).toBe(false);
+  });
+
+  it("filters out summoner individual updates", () => {
+    expect(isDebugWorthy("/lol-champ-select/v1/summoners/3")).toBe(false);
+  });
+});
+
+describe("describeEvent", () => {
+  it("describes gameflow phase updates", () => {
+    expect(
+      describeEvent("Update", "/lol-gameflow/v1/gameflow-phase")
+    ).toContain("Gameflow phase");
+  });
+
+  it("describes game session updates", () => {
+    expect(describeEvent("Update", "/lol-gameflow/v1/session")).toContain(
+      "Game session"
+    );
+  });
+
+  it("describes champ select ending", () => {
+    expect(describeEvent("Delete", "/lol-champ-select/v1/session")).toBe(
+      "Champion Select ended"
+    );
+  });
+
+  it("describes champ select updates", () => {
+    expect(describeEvent("Update", "/lol-champ-select/v1/session")).toBe(
+      "Champion Select updated"
+    );
+  });
+
+  it("describes league session token", () => {
+    expect(
+      describeEvent("Update", "/lol-league-session/v1/league-session-token")
+    ).toContain("League session token");
+  });
+
+  it("falls back to raw event for unknown URIs", () => {
+    expect(describeEvent("Update", "/unknown/path")).toBe(
+      "Update /unknown/path"
+    );
+  });
+});
+
+describe("shouldLogPollStatus", () => {
+  it("logs the first status", () => {
+    expect(shouldLogPollStatus("LOADING", null)).toBe(true);
+  });
+
+  it("suppresses repeated LOADING status", () => {
+    expect(shouldLogPollStatus("LOADING", "LOADING")).toBe(false);
+  });
+
+  it("logs when status changes from LOADING to OK", () => {
+    expect(shouldLogPollStatus("OK", "LOADING")).toBe(true);
+  });
+
+  it("logs when status changes from OK to LOADING", () => {
+    expect(shouldLogPollStatus("LOADING", "OK")).toBe(true);
+  });
+
+  it("suppresses repeated OK status", () => {
+    expect(shouldLogPollStatus("OK", "OK")).toBe(false);
+  });
+
+  it("logs when status changes from CONNECTION_FAILED to LOADING", () => {
+    expect(shouldLogPollStatus("LOADING", "CONNECTION_FAILED")).toBe(true);
+  });
+});

--- a/src/lib/reactive/debug-filters.ts
+++ b/src/lib/reactive/debug-filters.ts
@@ -47,3 +47,23 @@ export function shouldLogPollStatus(
 ): boolean {
   return current !== previous;
 }
+
+/**
+ * Deduplicate rapid-fire WebSocket debug events.
+ * The LCU often sends 3-4 events for the same URI within milliseconds.
+ * This tracks the last logged URI+timestamp and suppresses duplicates
+ * within a short window.
+ */
+const DEDUP_WINDOW_MS = 500;
+let lastLoggedUri = "";
+let lastLoggedTime = 0;
+
+export function shouldLogWebSocketEvent(uri: string): boolean {
+  const now = Date.now();
+  if (uri === lastLoggedUri && now - lastLoggedTime < DEDUP_WINDOW_MS) {
+    return false;
+  }
+  lastLoggedUri = uri;
+  lastLoggedTime = now;
+  return true;
+}

--- a/src/lib/reactive/debug-filters.ts
+++ b/src/lib/reactive/debug-filters.ts
@@ -1,0 +1,49 @@
+/**
+ * Debug panel filtering utilities.
+ * Controls which events show up in the debug panel to reduce noise,
+ * and translates raw URIs into human-readable descriptions.
+ */
+
+/**
+ * Allowlist of WebSocket URI prefixes worth showing in the debug panel.
+ * Everything else is filtered out. To add a new event type, add a prefix
+ * here and optionally add a human-readable label in describeEvent().
+ */
+const DEBUG_WORTHY_PREFIXES = [
+  "/lol-gameflow/v1/gameflow-phase",
+  "/lol-gameflow/v1/session",
+  "/lol-champ-select/v1/session",
+  "/lol-league-session/",
+];
+
+/** Check if a WebSocket event URI is worth showing in the debug panel */
+export function isDebugWorthy(uri: string): boolean {
+  return DEBUG_WORTHY_PREFIXES.some((prefix) => uri.startsWith(prefix));
+}
+
+/** Translate a raw WebSocket event into a human-readable debug summary */
+export function describeEvent(eventType: string, uri: string): string {
+  if (uri === "/lol-gameflow/v1/gameflow-phase") {
+    return `Gameflow phase ${eventType.toLowerCase()}d`;
+  }
+  if (uri === "/lol-gameflow/v1/session") {
+    return `Game session ${eventType.toLowerCase()}d`;
+  }
+  if (uri === "/lol-champ-select/v1/session") {
+    return eventType === "Delete"
+      ? "Champion Select ended"
+      : "Champion Select updated";
+  }
+  if (uri.startsWith("/lol-league-session/")) {
+    return "League session token updated";
+  }
+  return `${eventType} ${uri}`;
+}
+
+/** Check if a poll status change should be logged (deduplicates repeated statuses) */
+export function shouldLogPollStatus(
+  current: string,
+  previous: string | null
+): boolean {
+  return current !== previous;
+}

--- a/src/lib/reactive/debug-filters.ts
+++ b/src/lib/reactive/debug-filters.ts
@@ -80,7 +80,7 @@ function gameStateFingerprint(state: LiveGameState): string {
     state.activePlayer?.championName ?? "",
     state.activePlayer?.level ?? 0,
     state.players.length,
-    state.gameMode,
+    state.lcuGameMode || state.gameMode,
     state.champSelect != null ? "cs" : "",
     state.eogStats != null ? "eog" : "",
   ].join("|");

--- a/src/lib/reactive/debug-filters.ts
+++ b/src/lib/reactive/debug-filters.ts
@@ -3,6 +3,7 @@
  * Controls which events show up in the debug panel to reduce noise,
  * and translates raw URIs into human-readable descriptions.
  */
+import type { LiveGameState } from "./types";
 
 /**
  * Allowlist of WebSocket URI prefixes worth showing in the debug panel.
@@ -66,4 +67,32 @@ export function shouldLogWebSocketEvent(uri: string): boolean {
   lastLoggedUri = uri;
   lastLoggedTime = now;
   return true;
+}
+
+/**
+ * Extract a fingerprint of the game state fields worth logging about.
+ * Changes to fields NOT in this fingerprint (like gameTime) are ignored.
+ *
+ * To add a new meaningful field, just add it to the fingerprint string.
+ */
+function gameStateFingerprint(state: LiveGameState): string {
+  return [
+    state.activePlayer?.championName ?? "",
+    state.activePlayer?.level ?? 0,
+    state.players.length,
+    state.gameMode,
+    state.champSelect != null ? "cs" : "",
+    state.eogStats != null ? "eog" : "",
+  ].join("|");
+}
+
+/**
+ * Check if two LiveGameState snapshots differ in a way worth logging.
+ * Ignores high-frequency changes like game time ticking every 2 seconds.
+ */
+export function hasGameStateChangedMeaningfully(
+  prev: LiveGameState,
+  next: LiveGameState
+): boolean {
+  return gameStateFingerprint(prev) !== gameStateFingerprint(next);
 }

--- a/src/lib/reactive/engine.test.ts
+++ b/src/lib/reactive/engine.test.ts
@@ -287,6 +287,25 @@ describe("ReactiveEngine", () => {
       expect(bridge.connectLcuWebSocket).toHaveBeenCalledWith(12345, "secret");
     });
 
+    it("retries WebSocket connection after failure", async () => {
+      bridge.setLcuAvailable(12345, "secret");
+
+      // First connection attempt fails
+      (bridge.connectLcuWebSocket as Mock).mockRejectedValueOnce(
+        new Error("Connection refused")
+      );
+
+      engine.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(bridge.connectLcuWebSocket).toHaveBeenCalledTimes(1);
+
+      // After retry delay (3s = next discovery tick), should retry
+      await vi.advanceTimersByTimeAsync(3000);
+
+      expect(bridge.connectLcuWebSocket).toHaveBeenCalledTimes(2);
+    });
+
     it("fetches initial phase via REST on connect", async () => {
       bridge.setLcuAvailable(12345, "secret");
       bridge.setFetchLcuResponse("None");

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -32,6 +32,7 @@ import { formatGameTime } from "../format";
 import {
   isDebugWorthy,
   shouldLogPollStatus,
+  shouldLogWebSocketEvent,
   describeEvent,
 } from "./debug-filters";
 
@@ -153,12 +154,19 @@ export class ReactiveEngine {
     // Push connection events to gameLifecycle$ and track credentials
     this.subscription.add(
       lcuConnection$.subscribe((status) => {
-        debugInput$.next({
-          source: "discovery",
-          summary: status.connected
-            ? `LCU found — port ${status.port}`
-            : "LCU not found",
-        });
+        // Only log discovery when connection status or port actually changes
+        // (not on retry seq bumps — those just re-trigger WebSocket connection)
+        const isNewDiscovery =
+          this.currentPort !== status.port ||
+          (status.connected && this.currentPort === 0);
+        if (isNewDiscovery || !status.connected) {
+          debugInput$.next({
+            source: "discovery",
+            summary: status.connected
+              ? `LCU found — port ${status.port}`
+              : "LCU not found",
+          });
+        }
         if (status.connected) {
           this.currentPort = status.port;
           this.currentToken = status.token;
@@ -188,9 +196,12 @@ export class ReactiveEngine {
               let unlisten: (() => void) | null = null;
               let unlistenDisconnect: (() => void) | null = null;
 
+              const isRetry = this.wsRetrySeq > 0;
               debugInput$.next({
                 source: "websocket",
-                summary: `Connecting WebSocket to port ${creds.port}...`,
+                summary: isRetry
+                  ? `Retrying WebSocket connection... (attempt ${this.wsRetrySeq + 1})`
+                  : `Connecting WebSocket to port ${creds.port}...`,
               });
 
               Promise.all([
@@ -241,7 +252,7 @@ export class ReactiveEngine {
     // Layer 3: WebSocket event splits
     this.subscription.add(
       this.wsEvents$.subscribe((evt) => {
-        if (isDebugWorthy(evt.uri)) {
+        if (isDebugWorthy(evt.uri) && shouldLogWebSocketEvent(evt.uri)) {
           debugInput$.next({
             source: "websocket",
             summary: describeEvent(evt.event_type, evt.uri),

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -109,6 +109,9 @@ export class ReactiveEngine {
   // LCU game mode (KIWI for Mayhem, CLASSIC for SR, CHERRY for Arena)
   private lcuGameMode = "";
 
+  // Incremented on WebSocket failure to force discovery re-emit
+  private wsRetrySeq = 0;
+
   // Error recovery state for Live Client Data polling
   private consecutiveFailures = 0;
   private lastPollStatus: string | null = null;
@@ -127,12 +130,22 @@ export class ReactiveEngine {
       startWith(0),
       switchMap(() =>
         this.bridge.discoverLcu().then(
-          (creds) => ({ connected: true as const, ...creds }),
-          () => ({ connected: false as const, port: 0, token: "" })
+          (creds) => ({
+            connected: true as const,
+            ...creds,
+            seq: this.wsRetrySeq,
+          }),
+          () => ({
+            connected: false as const,
+            port: 0,
+            token: "",
+            seq: this.wsRetrySeq,
+          })
         )
       ),
       distinctUntilChanged(
-        (a, b) => a.connected === b.connected && a.port === b.port
+        (a, b) =>
+          a.connected === b.connected && a.port === b.port && a.seq === b.seq
       ),
       share()
     );
@@ -210,7 +223,9 @@ export class ReactiveEngine {
                     source: "websocket",
                     summary: `WebSocket connection FAILED: ${err instanceof Error ? err.message : String(err)}`,
                   });
-                  // Don't error the subscriber — let discovery retry
+                  // Bump retry seq so the next discovery tick re-emits
+                  // and triggers a new connection attempt
+                  this.wsRetrySeq++;
                 });
 
               return () => {

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -213,6 +213,7 @@ export class ReactiveEngine {
                     source: "websocket",
                     summary: `WebSocket disconnected: ${event.reason}`,
                   });
+                  this.wsRetrySeq++;
                 }),
                 this.bridge.connectLcuWebSocket(creds.port, creds.token),
               ])

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -29,6 +29,11 @@ import { normalizeGameState } from "../game-state/normalize";
 import type { TauriBridge, LcuEventPayload } from "./tauri-bridge";
 import type { GameflowPhase, LiveGameState, EogStats } from "./types";
 import { formatGameTime } from "../format";
+import {
+  isDebugWorthy,
+  shouldLogPollStatus,
+  describeEvent,
+} from "./debug-filters";
 
 const DISCOVERY_INTERVAL_MS = 3000;
 const POLL_INTERVAL_MS = 2000;
@@ -106,6 +111,7 @@ export class ReactiveEngine {
 
   // Error recovery state for Live Client Data polling
   private consecutiveFailures = 0;
+  private lastPollStatus: string | null = null;
   private backoffMs = POLL_INTERVAL_MS;
   private notified = false;
 
@@ -218,16 +224,12 @@ export class ReactiveEngine {
     );
 
     // Layer 3: WebSocket event splits
-    // Log non-noise WebSocket events only
     this.subscription.add(
       this.wsEvents$.subscribe((evt) => {
-        const isNoise = NOISE_PREFIXES.some((prefix) =>
-          evt.uri.startsWith(prefix)
-        );
-        if (!isNoise) {
+        if (isDebugWorthy(evt.uri)) {
           debugInput$.next({
             source: "websocket",
-            summary: `${evt.event_type} ${evt.uri}`,
+            summary: describeEvent(evt.event_type, evt.uri),
           });
         }
       })
@@ -314,6 +316,7 @@ export class ReactiveEngine {
             if (phase !== "InProgress") {
               liveGameState$.next(createDefaultLiveGameState());
               this.lcuGameMode = "";
+              this.lastPollStatus = null;
 
               // Clear any active error notification when leaving InProgress
               if (this.notified) {
@@ -479,17 +482,28 @@ export class ReactiveEngine {
             (json) => {
               const raw: unknown = JSON.parse(json);
               const normalized = normalizeGameState(raw);
-              debugInput$.next({
-                source: "riot-api",
-                summary: `Poll OK — ${normalized.gameMode} ${formatGameTime(normalized.gameTime)} ${normalized.players.length}p`,
-              });
+              const status = `OK — ${normalized.gameMode} ${formatGameTime(normalized.gameTime)} ${normalized.players.length}p`;
+              if (shouldLogPollStatus("OK", this.lastPollStatus)) {
+                debugInput$.next({
+                  source: "riot-api",
+                  summary: `Poll ${status}`,
+                });
+              }
+              this.lastPollStatus = "OK";
               return { success: true as const, data: normalized };
             },
             (err) => {
-              debugInput$.next({
-                source: "riot-api",
-                summary: `Poll failed — ${err instanceof Error ? err.message : String(err)}`,
-              });
+              const errMsg = err instanceof Error ? err.message : String(err);
+              const status = errMsg.includes("LOADING")
+                ? "LOADING"
+                : "CONNECTION_FAILED";
+              if (shouldLogPollStatus(status, this.lastPollStatus)) {
+                debugInput$.next({
+                  source: "riot-api",
+                  summary: `Poll failed — ${errMsg}`,
+                });
+              }
+              this.lastPollStatus = status;
               return { success: false as const, data: null };
             }
           )


### PR DESCRIPTION
## Summary

- Replace WebSocket event denylist with allowlist — only 4 event types shown in debug panel (gameflow phase, game session, champ select session, league session)
- Translate raw WebSocket URIs into human-readable labels ("Champion Select updated" instead of "Update /lol-champ-select/v1/session")
- Deduplicate rapid-fire WebSocket events (LCU sends 3-4 events for the same URI within milliseconds)
- Deduplicate Riot API poll status — LOADING/CONNECTION_FAILED only logs once on transition, not every 2 seconds
- Suppress liveGame poll ticks — only log when champion, level, player count, or game mode changes (not game time)
- Suppress matchmaking timeInQueue ticks and truncate JWT tokens in lifecycle diffs
- Retry WebSocket connection on failure via discovery re-emit (3-second retry, no backoff)
- Double debug panel buffer from 100 to 200 entries
- Extract all filtering logic into tested debug-filters.ts module (30 tests)

Closes #39, closes #40, closes #41, closes #42

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  - Enhanced connection resilience with automatic WebSocket retry mechanism for failed connections.
  - Improved debug logging with smarter event filtering to reduce noisy entries and better identify meaningful state changes.
  - Increased debug log capacity for larger input/output buffers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->