### PR TITLE
Unify game mode constants with documentation

### DIFF
--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -118,11 +118,11 @@ Available at the `PreEndOfGame` phase transition (immediately when the nexus die
 
 | Display name    | Live Client Data API `gameMode` | LCU `gameMode` |
 | --------------- | ------------------------------- | -------------- |
-| ARAM Mayhem     | `ARAM`                          | `KIWI`         |
+| ARAM Mayhem     | `KIWI`                          | `KIWI`         |
 | Summoner's Rift | `CLASSIC`                       | `CLASSIC`      |
 | Arena           | `CHERRY`                        | `CHERRY`       |
 
-The Live Client Data API and LCU use different mode strings for ARAM Mayhem. Mode detection must handle both: `ARAM` for live game state, `KIWI` for LCU/post-game data.
+Both sources return the same mode string for all tested modes. The `GAME_MODE_ARAM` ("ARAM") fallback in mode detection exists for defensive compatibility — earlier versions of the API reportedly returned "ARAM" for Mayhem, though current testing (patch 15.6) consistently shows "KIWI". Constants are defined in `src/lib/mode/types.ts`.
 
 ### WebSocket (real-time events)
 

--- a/docs/technical-reference.md
+++ b/docs/technical-reference.md
@@ -116,13 +116,14 @@ Available at the `PreEndOfGame` phase transition (immediately when the nexus die
 
 ### Game mode internal names
 
-| Display name    | Live Client Data API `gameMode` | LCU `gameMode` |
-| --------------- | ------------------------------- | -------------- |
-| ARAM Mayhem     | `KIWI`                          | `KIWI`         |
-| Summoner's Rift | `CLASSIC`                       | `CLASSIC`      |
-| Arena           | `CHERRY`                        | `CHERRY`       |
+| Display name    | Live Client Data API `gameMode` | LCU `gameMode` | Constant           |
+| --------------- | ------------------------------- | -------------- | ------------------ |
+| ARAM Mayhem     | `KIWI`                          | `KIWI`         | `GAME_MODE_MAYHEM` |
+| Regular ARAM    | `ARAM` (assumed, untested)      | `ARAM`         | `GAME_MODE_ARAM`   |
+| Summoner's Rift | `CLASSIC`                       | `CLASSIC`      | —                  |
+| Arena           | `CHERRY`                        | `CHERRY`       | `GAME_MODE_ARENA`  |
 
-Both sources return the same mode string for all tested modes. The `GAME_MODE_ARAM` ("ARAM") fallback in mode detection exists for defensive compatibility — earlier versions of the API reportedly returned "ARAM" for Mayhem, though current testing (patch 15.6) consistently shows "KIWI". Constants are defined in `src/lib/mode/types.ts`.
+Both sources return the same mode string for all tested modes. Regular ARAM has not been tested in-game yet — the `GAME_MODE_ARAM` ("ARAM") value is assumed from documentation and used as a fallback in mode detection. ARAM Mayhem consistently returns "KIWI" (tested patch 15.6). Constants are defined in `src/lib/mode/types.ts`.
 
 ### WebSocket (real-time events)
 

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,6 +1,6 @@
 import type { CoachingContext, CoachingQuery } from "./types";
 import { formatGameTime } from "../format";
-import { LCU_MODE_MAYHEM } from "../mode/types";
+import { GAME_MODE_MAYHEM, GAME_MODE_ARAM } from "../mode/types";
 
 export function buildSystemPrompt(context: {
   gameMode: string;
@@ -27,7 +27,9 @@ export function buildSystemPrompt(context: {
   ];
 
   const isMayhem =
-    context.lcuGameMode === LCU_MODE_MAYHEM || context.gameMode === "ARAM";
+    context.lcuGameMode === GAME_MODE_MAYHEM ||
+    context.gameMode === GAME_MODE_MAYHEM ||
+    context.gameMode === GAME_MODE_ARAM;
   if (isMayhem) {
     sections.push(
       "",
@@ -61,7 +63,7 @@ export function buildUserPrompt(
 
   const modeLabel =
     context.lcuGameMode && context.lcuGameMode !== context.gameMode
-      ? `${context.gameMode} — ${context.lcuGameMode === LCU_MODE_MAYHEM ? "Mayhem (KIWI)" : context.lcuGameMode}`
+      ? `${context.gameMode} — ${context.lcuGameMode === GAME_MODE_MAYHEM ? "Mayhem (KIWI)" : context.lcuGameMode}`
       : context.gameMode;
   sections.push(`## Game Mode: ${modeLabel}`);
   sections.push(`## Game Time: ${formatGameTime(context.gameTime)}`);

--- a/src/lib/mode/aram-mayhem.ts
+++ b/src/lib/mode/aram-mayhem.ts
@@ -7,7 +7,7 @@ import type {
   PlayerModeContext,
   TeamComposition,
 } from "./types";
-import { LCU_MODE_MAYHEM } from "./types";
+import { GAME_MODE_MAYHEM, GAME_MODE_ARAM } from "./types";
 
 export const aramMayhemMode: GameMode = {
   id: "aram-mayhem",
@@ -16,7 +16,7 @@ export const aramMayhemMode: GameMode = {
   augmentSelectionLevels: [1, 7, 11, 15],
 
   matches(gameMode: string): boolean {
-    return gameMode === "ARAM" || gameMode === LCU_MODE_MAYHEM;
+    return gameMode === GAME_MODE_MAYHEM || gameMode === GAME_MODE_ARAM;
   },
 
   buildContext(gameState: GameState, gameData: LoadedGameData): ModeContext {

--- a/src/lib/mode/index.ts
+++ b/src/lib/mode/index.ts
@@ -9,6 +9,7 @@ export type {
   SetProgress,
   TeamComposition,
 } from "./types";
+export { GAME_MODE_MAYHEM, GAME_MODE_ARAM, GAME_MODE_ARENA } from "./types";
 export { createModeRegistry } from "./registry";
 export { aramMayhemMode } from "./aram-mayhem";
 export { buildEffectiveGameState } from "./effective-state";

--- a/src/lib/mode/types.ts
+++ b/src/lib/mode/types.ts
@@ -6,8 +6,23 @@ import type {
   Item,
 } from "../data-ingest/types";
 
-/** LCU game mode string for ARAM Mayhem (Live Client API returns this instead of "ARAM") */
-export const LCU_MODE_MAYHEM = "KIWI";
+/**
+ * Game mode constants.
+ *
+ * Mode strings come from two sources:
+ * - **Live Client Data API** (`gameData.gameMode` via port 2999): returns the
+ *   internal mode string. For ARAM Mayhem this is "KIWI", not "ARAM".
+ * - **LCU WebSocket** (`gameData.queue.gameMode` in session events): returns
+ *   the same internal mode string ("KIWI" for Mayhem, "CHERRY" for Arena).
+ *
+ * The `lcuGameMode` field in LiveGameState is set from the LCU WebSocket
+ * session, while `gameMode` comes from the Live Client Data API. For Mayhem
+ * games, both return "KIWI". The "ARAM" fallback in mode detection exists
+ * for defensive compatibility in case Riot changes the string in a future patch.
+ */
+export const GAME_MODE_MAYHEM = "KIWI";
+export const GAME_MODE_ARAM = "ARAM";
+export const GAME_MODE_ARENA = "CHERRY";
 import type {
   ActivePlayerRunes,
   ActivePlayerStats,


### PR DESCRIPTION
## Summary

- Replace scattered `"KIWI"` and `"ARAM"` string literals with named constants: `GAME_MODE_MAYHEM`, `GAME_MODE_ARAM`, `GAME_MODE_ARENA`
- Document when each mode string is available, which API returns it, and why the ARAM fallback exists
- Fix incorrect technical reference (previously said Live Client API returns "ARAM" for Mayhem — it returns "KIWI")
- Add regular ARAM to the game mode table (untested, noted as assumed)
- Export constants from mode index for easy importing

Closes #48

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated game mode reference documentation with clarified mappings for ARAM variants and tested compatibility across game data sources.

* **Refactor**
  * Consolidated game mode detection logic for improved consistency and reliability across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->