### PR TITLE
Add KDA to coaching context and clean up prompt noise

### DIFF
--- a/src/lib/ai/context-assembler.test.ts
+++ b/src/lib/ai/context-assembler.test.ts
@@ -298,6 +298,12 @@ describe("assembleContext", () => {
     expect(result!.currentGold).toBe(2500);
   });
 
+  it("includes kills, deaths, and assists from active player", () => {
+    const result = assembleContext(createLiveGameState(), createGameData());
+    expect(result).not.toBeNull();
+    expect(result!.kda).toEqual({ kills: 5, deaths: 2, assists: 8 });
+  });
+
   it("falls back to empty description when item not in gameData", () => {
     const gameData = createGameData();
     gameData.items.clear();

--- a/src/lib/ai/context-assembler.test.ts
+++ b/src/lib/ai/context-assembler.test.ts
@@ -304,6 +304,46 @@ describe("assembleContext", () => {
     expect(result!.kda).toEqual({ kills: 5, deaths: 2, assists: 8 });
   });
 
+  it("filters Poro-Snax from player items", () => {
+    const gameState = createLiveGameState();
+    gameState.players[0].items = [
+      { id: 3089, name: "Rabadon's Deathcap" },
+      { id: 0, name: "Poro-Snax" },
+    ];
+    const result = assembleContext(gameState, createGameData());
+    expect(result).not.toBeNull();
+    expect(result!.currentItems.map((i) => i.name)).toEqual([
+      "Rabadon's Deathcap",
+    ]);
+  });
+
+  it("filters Poro-Snax from enemy items", () => {
+    const gameState = createLiveGameState();
+    gameState.players[2].items = [
+      { id: 3153, name: "Blade of the Ruined King" },
+      { id: 0, name: "Poro-Snax" },
+    ];
+    const result = assembleContext(gameState, createGameData());
+    expect(result).not.toBeNull();
+    const vayne = result!.enemyTeam.find((e) => e.champion === "Vayne");
+    expect(vayne!.items.map((i) => i.name)).toEqual([
+      "Blade of the Ruined King",
+    ]);
+  });
+
+  it("filters consumable items", () => {
+    const gameState = createLiveGameState();
+    gameState.players[0].items = [
+      { id: 3089, name: "Rabadon's Deathcap" },
+      { id: 2003, name: "Health Potion" },
+      { id: 2031, name: "Refillable Potion" },
+    ];
+    const result = assembleContext(gameState, createGameData());
+    expect(result!.currentItems.map((i) => i.name)).toEqual([
+      "Rabadon's Deathcap",
+    ]);
+  });
+
   it("falls back to empty description when item not in gameData", () => {
     const gameData = createGameData();
     gameData.items.clear();

--- a/src/lib/ai/context-assembler.ts
+++ b/src/lib/ai/context-assembler.ts
@@ -68,6 +68,11 @@ export function assembleContext(
     },
     currentItems,
     currentGold: activePlayer.currentGold,
+    kda: {
+      kills: activePlayerInfo?.kills ?? 0,
+      deaths: activePlayerInfo?.deaths ?? 0,
+      assists: activePlayerInfo?.assists ?? 0,
+    },
     currentAugments: [],
     teamAnalysis,
     augmentSets: gameData.augmentSets,

--- a/src/lib/ai/context-assembler.ts
+++ b/src/lib/ai/context-assembler.ts
@@ -24,10 +24,12 @@ export function assembleContext(
     : `${activePlayer.championName} (no ability data available)`;
 
   const currentItems = activePlayerInfo
-    ? activePlayerInfo.items.map((item) => ({
-        name: item.name,
-        description: gameData.items.get(item.id)?.description ?? "",
-      }))
+    ? activePlayerInfo.items
+        .filter((item) => !isNoiseItem(item.name))
+        .map((item) => ({
+          name: item.name,
+          description: gameData.items.get(item.id)?.description ?? "",
+        }))
     : [];
 
   const activeTeam = activePlayerInfo?.team ?? "ORDER";
@@ -36,10 +38,12 @@ export function assembleContext(
     .filter((p) => p.team !== activeTeam)
     .map((p) => ({
       champion: p.championName,
-      items: p.items.map((item) => ({
-        name: item.name,
-        description: gameData.items.get(item.id)?.description ?? "",
-      })),
+      items: p.items
+        .filter((item) => !isNoiseItem(item.name))
+        .map((item) => ({
+          name: item.name,
+          description: gameData.items.get(item.id)?.description ?? "",
+        })),
     }));
 
   const allyTeam = gameState.players
@@ -83,6 +87,18 @@ export function assembleContext(
     gameTime: gameState.gameTime,
     balanceOverrides,
   };
+}
+
+/** Items that add no information to the coaching context */
+const NOISE_ITEMS = new Set([
+  "poro-snax",
+  "health potion",
+  "refillable potion",
+  "corrupting potion",
+]);
+
+function isNoiseItem(name: string): boolean {
+  return NOISE_ITEMS.has(name.toLowerCase());
 }
 
 function formatAbilities(

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -14,6 +14,7 @@ function createContext(
         "Ranged (550) | Mage, Assassin | HP: 590 (+96/lvl) | AD: 53 (+3/lvl) | AS: 0.668 (+2%/lvl) | Armor: 23 (+4.7/lvl) | MR: 30 (+1.3/lvl) | Mana",
     },
     currentGold: 2500,
+    kda: { kills: 5, deaths: 2, assists: 8 },
     currentItems: [
       {
         name: "Rabadon's Deathcap",
@@ -150,6 +151,11 @@ describe("buildUserPrompt", () => {
     it("includes current gold in items section", () => {
       const prompt = buildUserPrompt(createContext(), generalQuery);
       expect(prompt).toContain("2500 gold available");
+    });
+
+    it("includes KDA in champion header", () => {
+      const prompt = buildUserPrompt(createContext(), generalQuery);
+      expect(prompt).toContain("5/2/8");
     });
 
     it("includes enemy items as names only", () => {

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -148,9 +148,11 @@ describe("buildUserPrompt", () => {
       expect(prompt).toContain("Massively increases Ability Power.");
     });
 
-    it("includes current gold in items section", () => {
-      const prompt = buildUserPrompt(createContext(), generalQuery);
-      expect(prompt).toContain("2500 gold available");
+    it("includes current gold as a whole number", () => {
+      const ctx = createContext({ currentGold: 712.17431640625 });
+      const prompt = buildUserPrompt(ctx, generalQuery);
+      expect(prompt).toContain("712 gold available");
+      expect(prompt).not.toContain("712.17");
     });
 
     it("includes KDA in champion header", () => {
@@ -182,6 +184,31 @@ describe("buildUserPrompt", () => {
     it("includes champion abilities", () => {
       const prompt = buildUserPrompt(createContext(), generalQuery);
       expect(prompt).toContain("Orb of Deception");
+    });
+
+    it("excludes 'I chose' confirmation exchanges from history", () => {
+      const query: CoachingQuery = {
+        question: "What should I build?",
+        history: [
+          {
+            question: "Goliath, Deft, or Escape Plan?",
+            answer: "Take Deft.",
+          },
+          {
+            question: "I chose Deft.",
+            answer: "Good. Lock it in.",
+          },
+          {
+            question: "What items next?",
+            answer: "Build Kraken Slayer.",
+          },
+        ],
+      };
+      const prompt = buildUserPrompt(createContext(), query);
+      expect(prompt).toContain("Take Deft");
+      expect(prompt).toContain("Build Kraken Slayer");
+      expect(prompt).not.toContain("I chose Deft");
+      expect(prompt).not.toContain("Good. Lock it in");
     });
 
     it("includes champion stat profile when present", () => {

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -69,7 +69,7 @@ export function buildUserPrompt(
   sections.push(`## Game Time: ${formatGameTime(context.gameTime)}`);
 
   sections.push(
-    `## Your Champion: ${context.champion.name} (Level ${context.champion.level})`
+    `## Your Champion: ${context.champion.name} (Level ${context.champion.level}, ${context.kda.kills}/${context.kda.deaths}/${context.kda.assists} KDA)`
   );
   if (context.champion.statProfile) {
     sections.push(`### Stat Profile\n${context.champion.statProfile}`);

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -90,11 +90,11 @@ export function buildUserPrompt(
         : `- ${item.name}`
     );
     sections.push(
-      `### Current Items (${context.currentGold} gold available)\n${itemLines.join("\n")}`
+      `### Current Items (${Math.floor(context.currentGold)} gold available)\n${itemLines.join("\n")}`
     );
   } else {
     sections.push(
-      `### Current Items (${context.currentGold} gold available)\nNone`
+      `### Current Items (${Math.floor(context.currentGold)} gold available)\nNone`
     );
   }
 
@@ -133,10 +133,15 @@ export function buildUserPrompt(
   }
 
   if (query.history && query.history.length > 0) {
-    sections.push("## Recent Conversation");
-    for (const exchange of query.history) {
-      sections.push(`**Player:** ${exchange.question}`);
-      sections.push(`**Coach:** ${exchange.answer}`);
+    const meaningful = query.history.filter(
+      (e) => !/^i (?:chose|picked|took|selected|went with) /i.test(e.question)
+    );
+    if (meaningful.length > 0) {
+      sections.push("## Recent Conversation");
+      for (const exchange of meaningful) {
+        sections.push(`**Player:** ${exchange.question}`);
+        sections.push(`**Coach:** ${exchange.answer}`);
+      }
     }
   }
 

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -29,6 +29,7 @@ export interface CoachingContext {
   };
   currentItems: CoachingItem[];
   currentGold: number;
+  kda: { kills: number; deaths: number; assists: number };
   currentAugments: CoachingItem[];
   enemyTeam: Array<{
     champion: string;

--- a/src/lib/data-ingest/sources/data-dragon.test.ts
+++ b/src/lib/data-ingest/sources/data-dragon.test.ts
@@ -142,6 +142,28 @@ describe("fetchItems", () => {
     expect(boots!.image).toContain("1001.png");
   });
 
+  it("inserts separators between stats in item descriptions", async () => {
+    mockFetch.mockResolvedValue(
+      jsonResponse({
+        data: {
+          "6672": {
+            name: "Kraken Slayer",
+            description:
+              "<mainText><stats><attention>30</attention> Attack Damage<br><attention>40%</attention> Attack Speed<br><attention>20%</attention> Critical Strike Chance</stats></mainText>",
+            gold: { base: 800, total: 3000, sell: 2100, purchasable: true },
+            image: { full: "6672.png" },
+          },
+        },
+      })
+    );
+
+    const items = await fetchItems("15.6.1");
+    const kraken = items.get(6672);
+    expect(kraken!.description).toContain("30 Attack Damage");
+    expect(kraken!.description).toContain("40% Attack Speed");
+    expect(kraken!.description).not.toMatch(/Damage\d/);
+  });
+
   it("handles items without from/into arrays", async () => {
     mockFetch.mockResolvedValue(
       jsonResponse({

--- a/src/lib/data-ingest/sources/data-dragon.ts
+++ b/src/lib/data-ingest/sources/data-dragon.ts
@@ -192,7 +192,16 @@ function cleanItemName(raw: string): string {
 }
 
 function stripHtml(html: string): string {
-  return html.replace(/<[^>]+>/g, "").trim();
+  return html
+    .replace(/<br\s*\/?>/gi, " | ")
+    .replace(/<[^>]+>/g, " ")
+    .replace(
+      /\b0%? (?:Attack Damage|Ability Power|Attack Speed|Critical Strike Chance|Health|Armor|Magic Resist|Mana|Move Speed|Ability Haste)\b/g,
+      ""
+    )
+    .replace(/ *\| *\| */g, " | ")
+    .replace(/ {2,}/g, " ")
+    .trim();
 }
 
 // Raw DDragon response types

--- a/src/lib/data-ingest/sources/data-dragon.ts
+++ b/src/lib/data-ingest/sources/data-dragon.ts
@@ -195,11 +195,6 @@ function stripHtml(html: string): string {
   return html
     .replace(/<br\s*\/?>/gi, " | ")
     .replace(/<[^>]+>/g, " ")
-    .replace(
-      /\b0%? (?:Attack Damage|Ability Power|Attack Speed|Critical Strike Chance|Health|Armor|Magic Resist|Mana|Move Speed|Ability Haste)\b/g,
-      ""
-    )
-    .replace(/ *\| *\| */g, " | ")
     .replace(/ {2,}/g, " ")
     .trim();
 }


### PR DESCRIPTION
## Summary

- Add player kills/deaths/assists to CoachingContext, rendered as KDA in champion header (e.g., "Yunara Level 16, 5/2/8 KDA")
- Round gold to integer (was showing 11 decimal places)
- Fix item description spacing — DDragon HTML tags stripped with proper separators instead of running stats together
- Filter Poro-Snax and consumables (Health Potion, Refillable Potion) from all item lists — zero information value
- Trim "I chose X" confirmation exchanges from conversation history — the chosen augment is already in Current Augments

Closes #50

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * AI coach now displays player KDA (kills/deaths/assists) in champion summaries
  * Gold amounts display as whole numbers for clarity
  * Item descriptions formatted with clearer separators between stats
  * Filtered unnecessary consumables and noise items from AI coaching context for more focused recommendations

<!-- end of auto-generated comment: release notes by coderabbit.ai -->