### PR TITLE
fix: show meaningful details in debug panel App Observables

### DIFF
--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,8 +1,12 @@
 import { useState, useEffect, useRef } from "react";
 import { skip, distinctUntilChanged, map } from "rxjs/operators";
 import { detailedDiff } from "deep-object-diff";
-import { formatGameTime } from "../lib/format";
 import { hasGameStateChangedMeaningfully } from "../lib/reactive/debug-filters";
+import {
+  summarizeLifecycleEvent,
+  summarizeLiveGameState,
+  summarizeUserInput,
+} from "../lib/reactive/debug-summarizers";
 import {
   gameLifecycle$,
   liveGameState$,
@@ -10,12 +14,7 @@ import {
   notifications$,
   debugInput$,
 } from "../lib/reactive";
-import type {
-  GameLifecycleEvent,
-  LiveGameState,
-  UserInputEvent,
-  DebugInputEvent,
-} from "../lib/reactive";
+import type { DebugInputEvent, LiveGameState } from "../lib/reactive";
 
 interface LogEntry {
   id: number;
@@ -29,23 +28,6 @@ let nextId = 0;
 
 function formatTime(): string {
   return new Date().toLocaleTimeString("en-US", { hour12: false });
-}
-
-function summarizeLifecycleEvent(event: GameLifecycleEvent): {
-  summary: string;
-} {
-  switch (event.type) {
-    case "connection":
-      return { summary: event.connected ? "Connected" : "Disconnected" };
-    case "phase":
-      return { summary: `Phase: ${event.phase}` };
-    case "lobby":
-      return { summary: "Lobby update" };
-    case "matchmaking":
-      return { summary: "Matchmaking update" };
-    case "session":
-      return { summary: "Session update" };
-  }
 }
 
 /** Compute a compact diff string between two objects. Returns undefined if empty. */
@@ -109,27 +91,6 @@ function computeDiff(
   formatObj("~updated", d.updated);
 
   return parts.length > 0 ? parts.join("\n") : undefined;
-}
-
-function summarizeLiveGameState(state: LiveGameState): string {
-  if (!state.activePlayer) {
-    if (state.champSelect != null) return "Champ select active";
-    if (state.eogStats) return `EOG: ${state.eogStats.isWin ? "WIN" : "LOSS"}`;
-    return "Default (no data)";
-  }
-  const parts = [
-    state.activePlayer.championName,
-    `Lv${state.activePlayer.level}`,
-    formatGameTime(state.gameTime),
-  ];
-  if (state.gameMode) parts.push(state.gameMode);
-  if (state.players.length > 0) parts.push(`${state.players.length}p`);
-  return parts.join(" | ");
-}
-
-function summarizeUserInput(event: UserInputEvent): string {
-  if (event.type === "augment") return `Augment: ${event.augment.name}`;
-  return `Query: "${event.text}"`;
 }
 
 const INPUT_COLORS: Record<string, string> = {
@@ -226,7 +187,7 @@ function startSubscriptions(): void {
 
   // Output log entries — skip(1) to avoid BehaviorSubject replay
   gameLifecycle$.pipe(skip(1)).subscribe((event) => {
-    const { summary } = summarizeLifecycleEvent(event);
+    const summary = summarizeLifecycleEvent(event);
     let detail: string | undefined;
 
     if (

--- a/src/lib/reactive/debug-summarizers.test.ts
+++ b/src/lib/reactive/debug-summarizers.test.ts
@@ -1,0 +1,234 @@
+import { describe, it, expect } from "vitest";
+import {
+  summarizeLifecycleEvent,
+  summarizeLiveGameState,
+  summarizeUserInput,
+} from "./debug-summarizers";
+import type {
+  GameLifecycleEvent,
+  LiveGameState,
+  UserInputEvent,
+} from "./types";
+import type { ActivePlayer } from "../game-state/types";
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function createDefaultLiveGameState(
+  overrides: Partial<LiveGameState> = {}
+): LiveGameState {
+  return {
+    activePlayer: null,
+    players: [],
+    gameMode: "",
+    lcuGameMode: "",
+    gameTime: 0,
+    champSelect: null,
+    eogStats: null,
+    ...overrides,
+  };
+}
+
+function createActivePlayer(
+  overrides: Partial<ActivePlayer> = {}
+): ActivePlayer {
+  return {
+    championName: "Ahri",
+    level: 6,
+    currentGold: 1500,
+    runes: {
+      keystone: "Dark Harvest",
+      primaryTree: "Domination",
+      secondaryTree: "Sorcery",
+    },
+    stats: {
+      abilityPower: 0,
+      armor: 30,
+      attackDamage: 50,
+      attackSpeed: 0.625,
+      abilityHaste: 0,
+      critChance: 0,
+      magicResist: 30,
+      moveSpeed: 330,
+      maxHealth: 1000,
+      currentHealth: 1000,
+    },
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// summarizeLifecycleEvent
+// ---------------------------------------------------------------------------
+
+describe("summarizeLifecycleEvent", () => {
+  it("shows Connected/Disconnected for connection events", () => {
+    expect(
+      summarizeLifecycleEvent({ type: "connection", connected: true })
+    ).toBe("Connected");
+    expect(
+      summarizeLifecycleEvent({ type: "connection", connected: false })
+    ).toBe("Disconnected");
+  });
+
+  it("shows the phase name for phase events", () => {
+    expect(
+      summarizeLifecycleEvent({ type: "phase", phase: "ChampSelect" })
+    ).toBe("Phase: ChampSelect");
+  });
+
+  // --- Lobby ---
+
+  it("shows game mode for lobby events", () => {
+    const event: GameLifecycleEvent = {
+      type: "lobby",
+      data: { gameConfig: { gameMode: "CLASSIC" } },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe("Lobby: CLASSIC");
+  });
+
+  it("shows game mode and member count for lobby events with members", () => {
+    const event: GameLifecycleEvent = {
+      type: "lobby",
+      data: {
+        gameConfig: { gameMode: "ARAM" },
+        members: [{}, {}, {}],
+      },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe("Lobby: ARAM, 3 members");
+  });
+
+  it("falls back to generic lobby summary when data is missing", () => {
+    const event: GameLifecycleEvent = { type: "lobby", data: {} };
+    expect(summarizeLifecycleEvent(event)).toBe("Lobby update");
+  });
+
+  it("handles null lobby data gracefully", () => {
+    const event: GameLifecycleEvent = { type: "lobby", data: null };
+    expect(summarizeLifecycleEvent(event)).toBe("Lobby update");
+  });
+
+  // --- Session ---
+
+  it("shows phase for session events", () => {
+    const event: GameLifecycleEvent = {
+      type: "session",
+      data: { phase: "InProgress" },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe("Session: InProgress");
+  });
+
+  it("shows phase and game mode for session events", () => {
+    const event: GameLifecycleEvent = {
+      type: "session",
+      data: {
+        phase: "ChampSelect",
+        gameData: { queue: { gameMode: "ARAM" } },
+      },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe("Session: ChampSelect, ARAM");
+  });
+
+  it("falls back to generic session summary when data is missing", () => {
+    const event: GameLifecycleEvent = { type: "session", data: {} };
+    expect(summarizeLifecycleEvent(event)).toBe("Session update");
+  });
+
+  // --- Matchmaking ---
+
+  it("shows search state for matchmaking events", () => {
+    const event: GameLifecycleEvent = {
+      type: "matchmaking",
+      data: { searchState: "Searching" },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe("Matchmaking: Searching");
+  });
+
+  it("shows search state and estimated time for matchmaking events", () => {
+    const event: GameLifecycleEvent = {
+      type: "matchmaking",
+      data: { searchState: "Searching", estimatedQueueTime: 90 },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe(
+      "Matchmaking: Searching, est. 1:30"
+    );
+  });
+
+  it("falls back to generic matchmaking summary when data is missing", () => {
+    const event: GameLifecycleEvent = { type: "matchmaking", data: {} };
+    expect(summarizeLifecycleEvent(event)).toBe("Matchmaking update");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeLiveGameState
+// ---------------------------------------------------------------------------
+
+describe("summarizeLiveGameState", () => {
+  it("returns default text when no data", () => {
+    expect(summarizeLiveGameState(createDefaultLiveGameState())).toBe(
+      "Default (no data)"
+    );
+  });
+
+  it("indicates champ select active", () => {
+    expect(
+      summarizeLiveGameState(
+        createDefaultLiveGameState({ champSelect: { myTeam: [] } })
+      )
+    ).toBe("Champ select active");
+  });
+
+  it("shows EOG win/loss", () => {
+    const eogStats = {
+      gameId: "123",
+      gameLength: 1200,
+      gameMode: "ARAM",
+      isWin: true,
+      championId: 103,
+      items: [3089],
+    };
+    expect(
+      summarizeLiveGameState(createDefaultLiveGameState({ eogStats }))
+    ).toBe("EOG: WIN");
+  });
+
+  it("shows champion, level, time, mode, and player count", () => {
+    const state = createDefaultLiveGameState({
+      activePlayer: createActivePlayer({
+        championName: "Ahri",
+        level: 6,
+      }),
+      gameTime: 305,
+      gameMode: "ARAM",
+      players: [{} as never, {} as never, {} as never],
+    });
+    expect(summarizeLiveGameState(state)).toBe("Ahri | Lv6 | 5:05 | ARAM | 3p");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// summarizeUserInput
+// ---------------------------------------------------------------------------
+
+describe("summarizeUserInput", () => {
+  it("shows augment name", () => {
+    const event: UserInputEvent = {
+      type: "augment",
+      augment: {
+        name: "Blade Waltz",
+        description: "desc",
+        tier: "Gold",
+        sets: [],
+        mode: "mayhem",
+      },
+    };
+    expect(summarizeUserInput(event)).toBe("Augment: Blade Waltz");
+  });
+
+  it("shows query text", () => {
+    const event: UserInputEvent = { type: "query", text: "how do I play Ahri" };
+    expect(summarizeUserInput(event)).toBe('Query: "how do I play Ahri"');
+  });
+});

--- a/src/lib/reactive/debug-summarizers.ts
+++ b/src/lib/reactive/debug-summarizers.ts
@@ -1,0 +1,88 @@
+import type {
+  GameLifecycleEvent,
+  LiveGameState,
+  UserInputEvent,
+} from "./types";
+import { formatGameTime } from "../format";
+
+// Safe accessor for unknown nested data from LCU payloads
+function get(obj: unknown, ...path: string[]): unknown {
+  let current = obj;
+  for (const key of path) {
+    if (current == null || typeof current !== "object") return undefined;
+    current = (current as Record<string, unknown>)[key];
+  }
+  return current;
+}
+
+/** Summarize a lifecycle event into a human-readable one-liner for the debug panel. */
+export function summarizeLifecycleEvent(event: GameLifecycleEvent): string {
+  switch (event.type) {
+    case "connection":
+      return event.connected ? "Connected" : "Disconnected";
+    case "phase":
+      return `Phase: ${event.phase}`;
+    case "lobby":
+      return summarizeLobby(event.data);
+    case "matchmaking":
+      return summarizeMatchmaking(event.data);
+    case "session":
+      return summarizeSession(event.data);
+  }
+}
+
+function summarizeLobby(data: unknown): string {
+  const gameMode = get(data, "gameConfig", "gameMode");
+  if (typeof gameMode !== "string") return "Lobby update";
+
+  const members = get(data, "members");
+  if (Array.isArray(members) && members.length > 0) {
+    return `Lobby: ${gameMode}, ${members.length} members`;
+  }
+  return `Lobby: ${gameMode}`;
+}
+
+function summarizeSession(data: unknown): string {
+  const phase = get(data, "phase");
+  if (typeof phase !== "string") return "Session update";
+
+  const gameMode = get(data, "gameData", "queue", "gameMode");
+  if (typeof gameMode === "string") {
+    return `Session: ${phase}, ${gameMode}`;
+  }
+  return `Session: ${phase}`;
+}
+
+function summarizeMatchmaking(data: unknown): string {
+  const searchState = get(data, "searchState");
+  if (typeof searchState !== "string") return "Matchmaking update";
+
+  const estimatedTime = get(data, "estimatedQueueTime");
+  if (typeof estimatedTime === "number" && estimatedTime > 0) {
+    return `Matchmaking: ${searchState}, est. ${formatGameTime(estimatedTime)}`;
+  }
+  return `Matchmaking: ${searchState}`;
+}
+
+/** Summarize live game state into a compact one-liner. */
+export function summarizeLiveGameState(state: LiveGameState): string {
+  if (!state.activePlayer) {
+    if (state.champSelect != null) return "Champ select active";
+    if (state.eogStats) return `EOG: ${state.eogStats.isWin ? "WIN" : "LOSS"}`;
+    return "Default (no data)";
+  }
+  const parts = [
+    state.activePlayer.championName,
+    `Lv${state.activePlayer.level}`,
+    formatGameTime(state.gameTime),
+  ];
+  if (state.gameMode) parts.push(state.gameMode);
+  if (state.players.length > 0) parts.push(`${state.players.length}p`);
+  return parts.join(" | ");
+}
+
+/** Summarize a user input event. */
+export function summarizeUserInput(event: UserInputEvent): string {
+  if (event.type === "augment") return `Augment: ${event.augment.name}`;
+  return `Query: "${event.text}"`;
+}


### PR DESCRIPTION
## Summary
- Extracted debug summarizer functions from DebugPanel.tsx into a testable module (`debug-summarizers.ts`)
- Lifecycle event summaries now show actual data instead of generic labels:
  - Lobby: `Lobby: ARAM, 3 members` instead of `Lobby update`
  - Session: `Session: ChampSelect, ARAM` instead of `Session update`
  - Matchmaking: `Matchmaking: Searching, est. 1:30` instead of `Matchmaking update`
- Falls back to generic text when LCU data fields aren't present
- 18 tests covering all summarizer functions

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Refactor**
  * Reorganized debug summary generation logic into a dedicated module for improved code maintainability and reusability.

* **Tests**
  * Added comprehensive test coverage for debug summary generation functions, validating output for lifecycle events, live game state, and user input scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->