### PR TITLE
docs: augment detection research and ow-electron migration plan

### DIFF
--- a/docs/ow-electron-migration-plan.md
+++ b/docs/ow-electron-migration-plan.md
@@ -39,7 +39,14 @@ Scaffold an ow-electron project alongside the existing Vite + React frontend. Cr
 | `append_coaching_log`       | `fs.appendFileSync` via IPC                                                    |
 | `get_coaching_log_location` | `app.getPath('userData')` via IPC                                              |
 
-Reimplement `tauri-bridge.ts` as an `electron-bridge.ts` that uses `ipcRenderer.invoke` instead of Tauri `invoke`, exposing the same `TauriBridge` interface. The reactive engine, coaching engine, and all business logic remain untouched.
+Also preserve Tauri push-event semantics used by the bridge:
+
+| Tauri event channel | Electron equivalent                                                                |
+| ------------------- | ---------------------------------------------------------------------------------- |
+| `lcu-event`         | Main process forwards parsed WebSocket payloads to renderer via `webContents.send` |
+| `lcu-disconnect`    | Main process emits disconnect reason to renderer via `webContents.send`            |
+
+Reimplement `tauri-bridge.ts` as an `electron-bridge.ts` that uses `ipcRenderer.invoke` for request/response commands and `ipcRenderer.on` for push events, exposing the same `TauriBridge` interface. The reactive engine, coaching engine, and all business logic remain untouched.
 
 Wire up the Vite dev server to serve the renderer content in development (Electron loads `http://localhost:5173` in dev, built files in production).
 
@@ -47,6 +54,7 @@ Wire up the Vite dev server to serve the renderer content in development (Electr
 
 - [ ] ow-electron app scaffolded with `@overwolf/ow-electron` and project structure (main process, renderer, IPC handlers)
 - [ ] All 8 Tauri commands reimplemented and working through Electron IPC
+- [ ] `lcu-event` and `lcu-disconnect` push-event behavior preserved with Electron IPC
 - [ ] `TauriBridge` interface preserved — `electron-bridge.ts` is a drop-in replacement
 - [ ] LCU discovery, WebSocket connection, and Live Client Data polling work during a live game
 - [ ] Voice input works via `getUserMedia` while the app is unfocused and a game is running

--- a/docs/ow-electron-migration-plan.md
+++ b/docs/ow-electron-migration-plan.md
@@ -94,11 +94,13 @@ The existing desktop BrowserWindow remains available as a configuration/dashboar
 
 ### What to build
 
-Subscribe to Overwolf GEP `augments` and `picked_augment` events for League of Legends. Create a new observable in the reactive engine that emits augment offer data (the 3 offered augment names) and augment selection data (which augment the player picked, which slot).
+Subscribe to Overwolf GEP `augments` and `picked_augment` events for League of Legends. Create a dedicated GEP observable that emits augment offer data (the 3 offered augment names) and augment selection data (which augment the player picked, which slot). This GEP observable merges into the existing `manualInput$` stream using events shaped identically to manual augment events (type: `"augment"`), so all downstream logic (augment selection tracking, context assembly) works unchanged.
+
+When both GEP and voice/manual input are active, GEP takes precedence — if a GEP augment event arrives within a short time window of a voice input for the same augment offer, the voice input is deduplicated to avoid double-processing.
 
 Map GEP augment internal names (e.g., `TFT8_Augment_DefenderTrait`) to the app's augment data model (display names, descriptions, tiers, set membership). Update the coaching context assembler to include detected augment offers, enabling the coaching engine to recommend among the specific 3 options rather than giving generic tier advice.
 
-The manual augment picker and voice input ("I chose X") remain as fallback inputs. When GEP data is available, it takes precedence. When unavailable (vanilla Electron build, or GEP not reporting), the app falls back to manual methods.
+The manual augment picker and voice input ("I chose X") remain as fallback inputs. When GEP data is unavailable (vanilla Electron build, or GEP not reporting), the app falls back to manual methods.
 
 ### Acceptance criteria
 

--- a/docs/ow-electron-migration-plan.md
+++ b/docs/ow-electron-migration-plan.md
@@ -1,0 +1,131 @@
+# Plan: Tauri to Overwolf Electron Migration
+
+> Source: Issue #59 research (programmatic augment detection) led to the decision to migrate from Tauri to ow-electron for GEP access + in-game overlay capabilities.
+
+## Architectural decisions
+
+Durable decisions that apply across all phases:
+
+- **Runtime**: `@overwolf/ow-electron` replaces Tauri. The app is an Electron app with Overwolf APIs injected. Standard Electron APIs (BrowserWindow, IPC, globalShortcut) work as normal; Overwolf additions live under `app.overwolf.*`.
+- **Process model**: Electron main process (Node.js) replaces Tauri's Rust backend. Renderer process (Chromium) replaces Tauri's webview. The React frontend and RxJS reactive engine are unchanged.
+- **IPC pattern**: Tauri `invoke` commands become Electron `ipcMain.handle` / `ipcRenderer.invoke` calls. The `TauriBridge` interface is reimplemented as an `ElectronBridge` with the same shape, so the reactive engine doesn't know or care about the runtime.
+- **Data sources**: The reactive engine's observable-based architecture stays. GEP becomes a new observable input alongside LCU WebSocket, Live Client Data API, voice input, and manual input.
+- **Overlay windows**: Created via `overlayApi.createWindow()` (OSR windows composited into the game's DirectX pipeline). League of Legends uses "standard mode" (visible cursor), so overlays are interactive without mode switching.
+- **Hotkeys**: `overlay.hotkeys` API replaces the Windows `WH_KEYBOARD_LL` hook. Supports press/release events, passthrough control, and works during gameplay.
+- **Audio capture**: `getUserMedia` in the renderer with `backgroundThrottling: false` replaces Rust `cpal`. AudioWorklet for processing if timer throttling is an issue.
+- **Dual-build**: `@overwolf/electron-is-overwolf` enables feature-flagging. Vanilla Electron builds degrade gracefully (no GEP, no overlay, no Overwolf hotkeys).
+- **Overwolf packages**: `gep` and `overlay` declared in `package.json` under `overwolf.packages`.
+- **Distribution**: Self-hosted (not locked to Overwolf store). Requires own code-signing certificate. Overwolf approval process required for the app.
+- **Platform**: Windows-only for GEP/overlay features. Mac/Linux would require the vanilla Electron fallback path.
+
+---
+
+## Phase 1: Electron bootstrap — replace Tauri backend with Node.js
+
+**User stories**: As a user, I can launch the app on ow-electron and get the same coaching experience I had with the Tauri version — LCU connection, live game data, voice input, coaching responses, and coaching logs.
+
+### What to build
+
+Scaffold an ow-electron project alongside the existing Vite + React frontend. Create an Electron main process that reimplements all 8 Tauri Rust commands as Node.js equivalents:
+
+| Tauri command               | Electron equivalent                                                            |
+| --------------------------- | ------------------------------------------------------------------------------ |
+| `fetch_riot_api`            | `fetch` with custom HTTPS agent (`rejectUnauthorized: false`)                  |
+| `discover_lcu`              | `fs.readFileSync` + lockfile parsing (already in `lcu-monitor.ts`)             |
+| `fetch_lcu`                 | `fetch` with Basic auth header + TLS skip                                      |
+| `connect_lcu_websocket`     | `ws` package with `rejectUnauthorized: false` (already in `lcu-monitor.ts`)    |
+| `start_recording`           | `getUserMedia({ audio: true })` in renderer with `backgroundThrottling: false` |
+| `stop_recording`            | Stop MediaStream, encode to WAV, return bytes                                  |
+| `append_coaching_log`       | `fs.appendFileSync` via IPC                                                    |
+| `get_coaching_log_location` | `app.getPath('userData')` via IPC                                              |
+
+Reimplement `tauri-bridge.ts` as an `electron-bridge.ts` that uses `ipcRenderer.invoke` instead of Tauri `invoke`, exposing the same `TauriBridge` interface. The reactive engine, coaching engine, and all business logic remain untouched.
+
+Wire up the Vite dev server to serve the renderer content in development (Electron loads `http://localhost:5173` in dev, built files in production).
+
+### Acceptance criteria
+
+- [ ] ow-electron app scaffolded with `@overwolf/ow-electron` and project structure (main process, renderer, IPC handlers)
+- [ ] All 8 Tauri commands reimplemented and working through Electron IPC
+- [ ] `TauriBridge` interface preserved — `electron-bridge.ts` is a drop-in replacement
+- [ ] LCU discovery, WebSocket connection, and Live Client Data polling work during a live game
+- [ ] Voice input works via `getUserMedia` while the app is unfocused and a game is running
+- [ ] Coaching log writes to `app.getPath('userData')/coaching-logs/`
+- [ ] All existing TypeScript tests pass (Vitest suite)
+- [ ] App launches, connects to LCU, enters a game, and produces coaching responses end-to-end
+
+---
+
+## Phase 2: In-game overlay
+
+**User stories**: As a user, I can see coaching recommendations directly on top of League of Legends without needing a second monitor. I can use a hotkey to trigger voice input while the game has focus.
+
+### What to build
+
+Register League of Legends as a supported game with the overlay API. When the game launches, inject the overlay and create overlay windows for the coaching UI. The main coaching display renders as a click-through overlay (using `passThrough` mode) positioned in a non-intrusive screen region. An interactive settings/details panel can be toggled.
+
+Replace the Windows keyboard hook with `overlay.hotkeys` for push-to-talk. Register a configurable hotkey (default: numpad minus, matching the current binding) that emits press/release events. Wire these events into the existing voice input flow.
+
+The existing desktop BrowserWindow remains available as a configuration/dashboard surface. The overlay windows show the real-time coaching content during gameplay.
+
+### Acceptance criteria
+
+- [ ] Overlay renders on top of League of Legends during gameplay
+- [ ] Coaching tips appear as click-through overlay content that doesn't interfere with gameplay
+- [ ] Push-to-talk hotkey works via `overlay.hotkeys` while the game has focus
+- [ ] Voice input captured and transcribed successfully from in-game hotkey press
+- [ ] Overlay can be toggled between click-through (display) and interactive (clickable) modes
+- [ ] Desktop window still works for pre-game configuration and post-game review
+- [ ] Overlay windows are DPI-aware and positioned correctly at common resolutions
+
+---
+
+## Phase 3: GEP integration — programmatic augment detection
+
+**User stories**: As a user, when augment cards appear in ARAM Mayhem or Arena, the app automatically detects which augments are offered and provides targeted recommendations without requiring voice input or manual selection.
+
+### What to build
+
+Subscribe to Overwolf GEP `augments` and `picked_augment` events for League of Legends. Create a new observable in the reactive engine that emits augment offer data (the 3 offered augment names) and augment selection data (which augment the player picked, which slot).
+
+Map GEP augment internal names (e.g., `TFT8_Augment_DefenderTrait`) to the app's augment data model (display names, descriptions, tiers, set membership). Update the coaching context assembler to include detected augment offers, enabling the coaching engine to recommend among the specific 3 options rather than giving generic tier advice.
+
+The manual augment picker and voice input ("I chose X") remain as fallback inputs. When GEP data is available, it takes precedence. When unavailable (vanilla Electron build, or GEP not reporting), the app falls back to manual methods.
+
+### Acceptance criteria
+
+- [ ] GEP `augments` feature registered and events received during Mayhem/Arena games
+- [ ] Augment offer observable integrated into the reactive engine
+- [ ] GEP internal augment names mapped to the app's augment data model
+- [ ] Coaching context includes the specific 3 offered augments when GEP data is available
+- [ ] Coaching engine produces recommendations referencing the specific offered augments
+- [ ] `picked_augment` events update the augment selection state (replacing manual confirmation)
+- [ ] Manual augment picker and voice input still work as fallbacks when GEP is unavailable
+- [ ] Augment detection works for both ARAM Mayhem and Arena modes
+
+---
+
+## Phase 4: Dual-build support — vanilla Electron fallback
+
+**User stories**: As a user without Overwolf, I can run the app in standalone mode with voice-based augment input and a separate window (no overlay, no GEP). As a developer, I maintain one codebase with two build targets.
+
+### What to build
+
+Add `@overwolf/electron-is-overwolf` to detect the runtime at startup. Feature-flag all Overwolf-specific code paths: GEP subscription, overlay window creation, overlay hotkey registration. When running as vanilla Electron:
+
+- GEP observable emits nothing (silent no-op)
+- No overlay windows are created; the desktop BrowserWindow is the only UI
+- Global hotkey falls back to `uiohook-napi` (or is disabled with a user-facing message)
+- All other functionality (LCU connection, Live Client Data polling, voice input, coaching engine) works normally
+
+Add build scripts for both targets: `build:overwolf` (ow-electron-builder) and `build:standalone` (standard electron-builder). Both produce distributable installers.
+
+### Acceptance criteria
+
+- [ ] `electron-is-overwolf` correctly detects runtime in both build targets
+- [ ] Vanilla Electron build launches and works without any Overwolf dependencies
+- [ ] All non-Overwolf features work in vanilla build (LCU, Live Client Data, voice input, coaching)
+- [ ] ow-electron build includes all features (GEP, overlay, hotkeys)
+- [ ] No Overwolf API calls execute in vanilla Electron build (no runtime errors)
+- [ ] Both build targets produce installable artifacts
+- [ ] One codebase — no feature branches or separate directories for each target

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -45,6 +45,8 @@ The architecture is mode-agnostic — a shared recommendation engine handles any
 21. As a developer, I want the desktop shell to serve as a state machine visualizer during development so that I can see all data flowing through the app (Riot API data, parsed state, augments, context payloads, LLM responses) while playing my nightly games
 22. As a developer, I want each module to be independently testable so that I can validate behavior in isolation before integration
 23. As a developer, I want the model evaluation pipeline to borrow from the existing review-kit evaluation infrastructure so that I don't reinvent the funnel pattern
+24. As a player, I want the app to automatically detect which augments I'm being offered so that I get recommendations without having to speak or manually input my choices
+25. As a player, I want the app to work as an in-game overlay AND as a standalone window so that I can use it with or without a second monitor
 
 ## Implementation Decisions
 
@@ -71,10 +73,12 @@ The system is composed of the following modules. Dependencies are listed to clar
 **Desktop Shell**
 
 - Dependencies: none (can be built in parallel with data ingest)
-- The Tauri v2 wrapper providing global hotkey registration, always-on-top window management, system tray, and audio capture
+- Overwolf Electron (ow-electron) app providing global hotkey registration, in-game overlay, audio capture, and Overwolf GEP integration for augment detection
+- Originally built on Tauri v2; migrating to ow-electron for access to GEP (augment offer detection) and native in-game overlay rendering (see `docs/ow-electron-migration-plan.md`)
 - Built early as a development tool — starts as a state machine visualizer showing all data flowing through the app (Riot API data, parsed game state, augment entries, context payloads, LLM responses)
 - Each module's output becomes visible in the shell as it's built, enabling dogfooding during nightly games
 - The final UI is a polish layer over this foundation, not a separate build
+- Supports dual-build: ow-electron (full features) and vanilla Electron (degraded mode without GEP/overlay, for non-Windows platforms or users without Overwolf)
 
 **Mode Module (ARAM Mayhem first)**
 
@@ -139,20 +143,21 @@ The system is composed of the following modules. Dependencies are listed to clar
 ### Data Flow
 
 1. App launches → Data Ingest Pipeline serves from cache, kicks off background refresh
-2. Game detected → Game State Manager begins polling Riot Live Client Data API
-3. Player presses hotkey → Voice Input captures audio, transcribes, parses to structured intent
-4. Context Assembler pulls game state + intent + mode context + recent history → constructs payload
-5. Recommendation Engine builds prompt, calls LLM, parses response → structured recommendation
-6. Desktop Shell / UI displays recommendation
-7. Player confirms their choice via voice → Game State Manager updates tracked state (e.g., selected augment added)
+2. Game detected → Game State Manager begins polling Riot Live Client Data API; GEP registers for augment features
+3. Augment selection triggered → GEP fires `augments` event with the 3 offered augment names → coaching engine automatically provides recommendation via overlay
+4. Player presses hotkey → Voice Input captures audio, transcribes, parses to structured intent (for open-ended questions, item advice, or augment input when GEP unavailable)
+5. Context Assembler pulls game state + detected augments + intent + mode context + recent history → constructs payload
+6. Recommendation Engine builds prompt, calls LLM, parses response → structured recommendation
+7. In-game overlay displays recommendation (or desktop window if overlay unavailable)
+8. Player selects augment → GEP fires `picked_augment` event → Game State Manager updates tracked state automatically
 
 ### Key Technical Decisions
 
-- **TypeScript preferred** for all application code. Rust required only for the Tauri v2 backend surface (hotkeys, window management, audio capture).
-- **Desktop framework: Tauri v2.** Chosen for resource efficiency (~20-80MB idle vs Electron's ~100-300MB). Vite + React for the frontend webview.
+- **TypeScript preferred** for all application code. The Electron main process handles hotkeys (via `overlay.hotkeys`), window management, and audio capture (via `getUserMedia`).
+- **Desktop framework: Overwolf Electron (ow-electron).** Originally Tauri v2 (chosen for resource efficiency), migrating to ow-electron for access to Overwolf GEP (programmatic augment detection) and native in-game overlay rendering. The React/TypeScript frontend and RxJS reactive engine are unchanged. See `docs/research/augment-detection-research.md` for research findings and `docs/ow-electron-migration-plan.md` for the migration plan.
 - **pnpm** for package management. **Vitest** for unit/integration testing. **Vercel AI SDK** (`ai` package) for LLM calls.
 - **No throwaway infrastructure.** Modules are built with real data and real integrations from the start, not hardcoded placeholders that get replaced later.
-- **Riot Live Client Data API** is the primary source for game state. Voice input fills gaps (augments, any data not exposed by the API). The API uses HTTPS on localhost:2999 with a self-signed certificate.
+- **Riot Live Client Data API** is the primary source for game state. **Overwolf GEP** provides augment offer/selection detection during Mayhem and Arena modes. Voice input serves as a fallback when GEP is unavailable. The Live Client Data API uses HTTPS on localhost:2999 with a self-signed certificate.
 - **Local cache with background refresh** for game data. The app always has data immediately from the last fetch; new patch data is fetched on launch and merged in the background.
 - **App owns the conversation state**, not the LLM. Context is assembled fresh from tracked game state plus a rolling window of recent exchanges. This is abstracted behind an interface for future flexibility (persistent history, local LLMs).
 - **LLM model is determined by build-time evaluation**, not runtime selection. The evaluation pipeline borrows from review-kit's funnel pattern with Evalite integration.
@@ -192,7 +197,7 @@ The system is composed of the following modules. Dependencies are listed to clar
 - **Enemy cooldown tracking** — Prohibited by Riot policy.
 - **Brawl mode** — Riot has declared Brawl data completely off-limits for third-party products.
 - **Hosted web service / multi-user backend** — The app is local-only for now.
-- **Mobile app** — The POC and initial product are desktop-only. Mobile may be revisited if the desktop shell framework (Tauri) supports it.
+- **Mobile app** — The POC and initial product are desktop-only (Windows, due to Overwolf GEP/overlay being Windows-only). Vanilla Electron builds can run on Mac/Linux with degraded features (no GEP, no overlay).
 
 ## Further Notes
 
@@ -213,7 +218,7 @@ The system is composed of the following modules. Dependencies are listed to clar
 
 - Augment set tracking and set bonus progression in recommendations
 - TTS output for hands-free advice
-- In-game overlay via Overwolf or similar
+- In-game overlay via Overwolf Electron (ow-electron) — renders coaching UI directly on top of the game using standard mode (interactive cursor for MOBAs)
 - Cross-game memory (SQLite + FTS5 for structured game history, sqlite-vec or similar for semantic search if needed)
 - Multi-model evaluation with PickAI + Evalite pipeline
 - Additional mode modules (Arena, regular ARAM, Summoner's Rift)

--- a/docs/prd.md
+++ b/docs/prd.md
@@ -153,7 +153,7 @@ The system is composed of the following modules. Dependencies are listed to clar
 
 ### Key Technical Decisions
 
-- **TypeScript preferred** for all application code. The Electron main process handles hotkeys (via `overlay.hotkeys`), window management, and audio capture (via `getUserMedia`).
+- **TypeScript preferred** for all application code. The Electron main process handles hotkeys (via `overlay.hotkeys`) and window management; audio capture (`getUserMedia`) runs in the renderer process.
 - **Desktop framework: Overwolf Electron (ow-electron).** Originally Tauri v2 (chosen for resource efficiency), migrating to ow-electron for access to Overwolf GEP (programmatic augment detection) and native in-game overlay rendering. The React/TypeScript frontend and RxJS reactive engine are unchanged. See `docs/research/augment-detection-research.md` for research findings and `docs/ow-electron-migration-plan.md` for the migration plan.
 - **pnpm** for package management. **Vitest** for unit/integration testing. **Vercel AI SDK** (`ai` package) for LLM calls.
 - **No throwaway infrastructure.** Modules are built with real data and real integrations from the start, not hardcoded placeholders that get replaced later.

--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -43,7 +43,7 @@ The API uses a self-signed HTTPS certificate. The Tauri webview can't fetch it d
 
 **Not exposed:**
 
-- Augments (any mode) — requires voice/manual input. In ARAM Mayhem, augment selection happens at levels 1, 7, 11, and 15 (4 total per game), but only after the player returns to the Nexus at that level. The API exposes player level but not whether they're at the Nexus or have an augment offer pending. Note: your.gg appears to detect augment offers in real-time via an overlay — mechanism unknown (image recognition, undocumented API, game memory). Worth investigating.
+- Augments (any mode) — the Live Client Data API does not expose augment offers or selections. In ARAM Mayhem, augment selection happens at levels 1, 7, 11, and 15 (4 total per game), but only after the player returns to the Nexus at that level. The API exposes player level but not whether they're at the Nexus or have an augment offer pending. **Programmatic detection is possible via Overwolf GEP** — see `docs/research/augment-detection-research.md` for full findings. The app currently uses voice/manual input as a fallback; the migration to ow-electron (see `docs/ow-electron-migration-plan.md`) will add GEP-based detection.
 - Some augments auto-select a follow-up (e.g., Transmute: Chaos grants two random augments instead of one). This can happen once per game, meaning a player can end up with 5 augments total (4 chosen + 1 granted). The API doesn't expose these auto-selections, so the app needs a way to record the granted augment. The UI should distinguish between "chosen" slots (4 max) and a "granted" slot that appears as a result of choosing certain augments. With voice input, the user can report all augments received in one utterance.
 
 ### ARAM Mayhem augment re-roll mechanics
@@ -379,9 +379,11 @@ Events observed during a full ARAM Mayhem game session that don't fall into the 
 - `/riot-messaging-service/v1/message/teambuilder/v1/rerollInfoV1` — ARAM reroll info
 - `/riot-messaging-service/v1/message/teambuilder/v1/tbdGameDtoV1` — team builder game data
 
-#### Key finding: No in-game augment data from any source
+#### Key finding: No in-game augment data from LCU or Live Client Data API
 
-Confirmed by monitoring a full ARAM Mayhem game: no WebSocket event, REST endpoint, or inventory update exposes which augments a player selects during gameplay. The `AUGMENT` inventory type (`/lol-inventory/v2/inventory/AUGMENT`) contains cosmetic augment ownership (Arena augment skins), not in-game selections. In-game augment tracking requires manual input (UI picker or voice).
+Confirmed by monitoring a full ARAM Mayhem game: no LCU WebSocket event, LCU REST endpoint, or Live Client Data API endpoint exposes which augments a player is offered or selects during gameplay. The `AUGMENT` inventory type (`/lol-inventory/v2/inventory/AUGMENT`) contains cosmetic augment ownership (Arena augment skins), not in-game selections. The LCU WebSocket subscribes to `OnJsonApiEvent` (the broadest possible subscription) — augment events simply do not exist in this API. This is a fundamental limitation: the LCU is the client/launcher process, while augment selection happens in the game process.
+
+**However, Overwolf's Game Events Provider (GEP) does expose augment data** — see `docs/research/augment-detection-research.md` for the full investigation. GEP hooks into the game process via a Vanguard-whitelisted DLL and provides `augments` (the 3 offered choices) and `picked_augment` (which one was selected) events for both ARAM Mayhem and Arena modes.
 
 ### WSL2 access
 

--- a/docs/research/augment-detection-research.md
+++ b/docs/research/augment-detection-research.md
@@ -1,0 +1,273 @@
+# Augment Detection Research
+
+> Issue #59: Investigate programmatic augment offer detection
+
+## Summary
+
+Riot's official APIs (Live Client Data API, LCU WebSocket, LCU REST, Match-v5) do not expose augment offer or selection events during gameplay. The only sanctioned programmatic mechanism for detecting augments in real-time is **Overwolf's Game Events Provider (GEP)**, which hooks into the game process via a Vanguard-whitelisted DLL.
+
+This research led to the decision to migrate from Tauri to Overwolf Electron (`@overwolf/ow-electron`) — see `docs/ow-electron-migration-plan.md`.
+
+## What was investigated
+
+### 1. Riot Live Client Data API (localhost:2999)
+
+The complete endpoint list was audited against community documentation (stirante, MingweiSamuel's OpenAPI schema):
+
+| Endpoint                                | Augment data?              |
+| --------------------------------------- | -------------------------- |
+| `/liveclientdata/allgamedata`           | No                         |
+| `/liveclientdata/activeplayer`          | No                         |
+| `/liveclientdata/activeplayerabilities` | No                         |
+| `/liveclientdata/activeplayerrunes`     | No                         |
+| `/liveclientdata/playerlist`            | No                         |
+| `/liveclientdata/playeritems`           | No                         |
+| `/liveclientdata/playerscores`          | No                         |
+| `/liveclientdata/playersummonerspells`  | No                         |
+| `/liveclientdata/eventdata`             | No (kills/objectives only) |
+| `/liveclientdata/gamestats`             | No                         |
+
+No augment-related data appears in any endpoint. The schema has not been updated for Arena or Mayhem augment features.
+
+### 2. LCU WebSocket (WAMP 1.0)
+
+The LCU WebSocket was monitored during a full ARAM Mayhem game session using our `scripts/lcu-monitor.ts` tool. The monitor subscribes to `OnJsonApiEvent` (the broadest possible subscription — all JSON API events).
+
+**Finding:** No augment-related events fire during gameplay. The only "augment" endpoints in the LCU are cosmetic TFT augment-pillar skins:
+
+- `GET /lol-cosmetics/v1/inventories/{setName}/augment-pillars`
+- `PUT /lol-cosmetics/v1/selection/tft-augment-pillar`
+- `DELETE /lol-cosmetics/v1/selection/tft-augment-pillar`
+
+**Why:** The LCU is the League Client (lobby/launcher) process, which is separate from the game process. During gameplay (InProgress phase), the LCU provides phase transitions and client-level events, but the actual in-game state (including augment selection screens) happens inside the game process, which the LCU cannot see.
+
+### 3. Riot Match-v5 API (post-game)
+
+- After a game ends, Match-v5 includes `PlayerAugment1` through `PlayerAugment4` fields with augment IDs
+- However, **Mayhem matches return 403** (confirmed via Riot developer-relations issue #1109) — Riot treats Mayhem match data as private
+- Augment metadata (names, descriptions, icons) is available from CommunityDragon: `https://raw.communitydragon.org/{version}/cdragon/arena/en_us.json`
+- This provides historical augment data for analysis but not real-time detection
+
+### 4. SkinSpotlights Live Events API
+
+An undocumented API that was enabled via `game.cfg`, supporting events like `OnKill`, `OnDamage`, etc. **Removed as of patch 14.1.** Only worked in spectator/replay mode, never in live gameplay. Never had augment events even when it worked.
+
+### 5. Overwolf Game Events Provider (GEP)
+
+**This is the key finding.** Overwolf GEP exposes augment events for both ARAM Mayhem and Arena modes since GEP version 299.0.
+
+#### Available events
+
+**`augments`** (category: `me`) — List of available augments offered to the player (the 3 choices):
+
+```json
+{
+  "augment_1": { "name": "TFT8_Augment_DefenderTrait" },
+  "augment_2": { "name": "TFT7_Augment_PandorasBench" },
+  "augment_3": { "name": "TFT6_Augment_SecondWind1" }
+}
+```
+
+**`picked_augment`** (category: `me`) — Which augment the player selected, with slot tracking:
+
+```json
+{
+  "slot_1": { "name": "TFT9_Augment_CyberneticBulk3" },
+  "slot_2": { "name": "TFT9_Augment_SettTheBoss" },
+  "slot_3": { "name": "" }
+}
+```
+
+#### How GEP works
+
+GEP uses DLLs (`gep_lolarena.dll`, `gep_lolarenaext.dll`) that run alongside the game process. These are whitelisted by Vanguard through a partnership between Overwolf and Riot. This is NOT a public API — you must build an Overwolf app to access the data.
+
+#### API usage in ow-electron
+
+```typescript
+// Declare needed packages in package.json
+{ "overwolf": { "packages": ["gep", "overlay"] } }
+
+// Subscribe to augment features
+app.overwolf.packages.gep.setRequiredFeatures(['augments']);
+
+// Listen for augment offers
+app.overwolf.packages.gep.on('new-info-update', (e, gameId, ...args) => {
+  // args contains augment offer/pick data
+});
+
+// Listen for augment selection events
+app.overwolf.packages.gep.on('new-game-event', (e, gameId, ...args) => {
+  // args contains game event data
+});
+```
+
+#### GEP changelog (augment-related entries)
+
+Multiple fixes and improvements have been made to augment detection:
+
+- "Added support for multiple augment selection"
+- "Split between augments and items, created `item_select` info update"
+- Multiple fixes to `picked_augment` event accuracy (Dec 2023+)
+- Multiple fixes to `augment` event timing and data completeness
+
+### 6. Augment name mapping
+
+GEP uses internal augment names (e.g., `TFT8_Augment_DefenderTrait`) that need to be mapped to our augment data model (display names, descriptions, tiers, set membership). This mapping will use CommunityDragon's `cherry-augments.json` which contains both internal IDs/names and display names.
+
+## How other tools detect augments
+
+### Blitz.gg
+
+- **Platform:** Overwolf app
+- **Augment overlays:** Explicit ARAM Mayhem and Arena augment overlays that show tier ratings during augment selection
+- **Mechanism:** Overwolf GEP (confirmed — they state they do not read or write memory)
+
+### OP.GG Desktop
+
+- **Platform:** Overwolf app
+- **Has:** "Augment Tier" overlay showing tier of augments that fit the current champion
+- **Mechanism:** Overwolf GEP
+
+### your.gg
+
+- **Platform:** Standalone desktop app (not Overwolf)
+- **Behavior observed:** 1-2 second delay before overlay appears, inconsistent coverage (overlay on 1 of 3 stat anvils but not others)
+- **Mechanism:** Unknown. The delay and inconsistency pattern is more consistent with OCR/screen capture than API-based detection, but could also be Overwolf GEP with latency. Their site says the app "connects to your League of Legends Client" (LCU language).
+- **Acquired by Gen.G** (May 2024) — may have elevated Riot API access through partnership
+
+### TFT Augment Overlay (open source)
+
+- **Repository:** `github.com/arunthiruma588/tft-augment-overlay`
+- **Mechanism:** OCR via pytesseract + python-image-search + pillow
+- **Limitations:** Only supports 1920x1080, resolution-dependent, fragile
+- **Confirms:** No standard API exists for TFT augment detection either
+
+## Approaches evaluated for Champ Sage
+
+| Approach                  | Detects specific augments?              | Reliability                                   | Effort                                | ToS risk                                           |
+| ------------------------- | --------------------------------------- | --------------------------------------------- | ------------------------------------- | -------------------------------------------------- |
+| **Overwolf GEP**          | Yes (exact names)                       | High                                          | High (requires ow-electron migration) | None (sanctioned)                                  |
+| **Screen capture + OCR**  | Yes (if recognition works)              | Medium (resolution-dependent, can miss cards) | Medium                                | Low (gray area)                                    |
+| **Level-based heuristic** | No (only knows WHEN to expect an offer) | Low                                           | Low (already built)                   | None                                               |
+| **Memory reading**        | Yes                                     | High                                          | Medium                                | **Prohibited** (blocked by Vanguard, violates ToS) |
+
+**Decision:** Migrate to ow-electron for GEP access. OCR reserved as backup plan. See `docs/ow-electron-migration-plan.md` for the migration plan.
+
+## Riot policy compliance
+
+### What's allowed
+
+- Build recommendations, item suggestions, champion select assistance
+- Overlays that "highlight decisions and give multiple choices to help players make good decisions"
+- Apps that pull data through official APIs
+- Premium app versions (if a free version exists)
+- Products that "increase, not decrease, the diversity of game decisions"
+
+### What's prohibited
+
+- Tracking enemy summoner spell cooldowns or ability cooldowns
+- Ultimate timers (explicitly banned March 2025)
+- Notifications that "dictate player action" (e.g., "go gank top lane")
+- Power spike alerts (e.g., "X champion has hit level 6")
+- De-anonymizing players in Ranked Solo/Duo champ select
+- Custom ranking systems, MMR/ELO calculators
+- In-game overlay advertisements (banned May 2025)
+- Overlays that mimic Riot's UI
+- **ALL Brawl-related data** — explicitly prohibited for third-party use
+- Memory reading (blocked by Vanguard)
+- **Augment win rate display** is specifically prohibited: "Products cannot display win rates for Augments or Arena Mode items." However, popularity/pick rate is allowed.
+
+### What Champ Sage does (contextual reasoning, not win rates)
+
+Champ Sage provides contextual coaching recommendations ("given your build and the enemy team, this augment synergizes best") rather than statistical win rates ("this augment has a 58% win rate"). This aligns with Riot's allowance of tools that "highlight decisions and give multiple choices" without "dictating player action."
+
+### Vanguard anti-cheat
+
+- Kernel-level anti-cheat (Ring 0), live on LoL since April 2024
+- **No allowlist exists** — no exceptions for any developer
+- Memory reading is blocked; apps must adapt or be blocked
+- LCU API, Live Client Data API, and Overwolf GEP continue to work
+- Overwolf's GEP DLL is not "whitelisted" per se — Riot says there is no allowlist — but it does work alongside Vanguard, likely due to how GEP hooks into the game process
+
+### Registration requirement
+
+All products serving League players must be registered on the Riot Developer Portal, regardless of whether they use official APIs. This applies to Champ Sage. URL: `https://developer.riotgames.com/policies/general`
+
+### Key policy sources
+
+- General policies: `https://developer.riotgames.com/policies/general` (updated March 2025)
+- Vanguard FAQ: `https://www.riotgames.com/en/DevRel/vanguard-faq`
+- Vanguard DevRel: `https://support-developer.riotgames.com/hc/en-us/articles/28021427366163-Vanguard`
+- API Terms: `https://support-developer.riotgames.com/hc/en-us/articles/22698917218323-API-Terms-and-Conditions`
+- Overwolf compliance: `https://dev.overwolf.com/ow-native/guides/game-compliance/riot-games/`
+
+## Overwolf Electron (ow-electron) technical details
+
+### What it is
+
+A closed-source fork of Electron.js (`@overwolf/ow-electron`) that adds Overwolf's proprietary APIs. Drop-in replacement for the `electron` npm package. Current version: 39.6.0 (March 2026).
+
+### Packages
+
+- `@overwolf/ow-electron` — replaces `electron`
+- `@overwolf/ow-electron-builder` — replaces `electron-builder`
+- `@overwolf/ow-electron-packages-types` — TypeScript types
+- `@overwolf/electron-is-overwolf` — runtime detection for dual-build support
+
+### Available Overwolf API modules
+
+| Module     | Purpose                                                                   |
+| ---------- | ------------------------------------------------------------------------- |
+| `overlay`  | In-game overlay windows (standard mode for MOBAs, exclusive mode for FPS) |
+| `gep`      | Game Events Provider — real-time game data                                |
+| `recorder` | Audio/video recording (beta)                                              |
+| `crn`      | Content Recommendation Notifications                                      |
+| `utility`  | Game launch/exit detection, installed games scanning                      |
+
+### Overlay for League of Legends
+
+League uses **standard mode** — the mouse cursor is visible during gameplay, so overlay windows are interactive without mode switching. Overlay windows support:
+
+- `passThrough` — display-only, clicks pass through to the game
+- `noPassThrough` — interactive, clicks handled by the overlay
+- `passThroughAndNotify` — clicks pass through AND the overlay is notified
+- DPI awareness, game-bounds constraint, dragging
+
+### Global hotkeys
+
+`overlay.hotkeys` API replaces `WH_KEYBOARD_LL`. Works during gameplay:
+
+- `register(hotKey, callback)` — callback receives `(hotKey, state)` where state is `"pressed"` or `"released"`
+- Supports modifiers (ctrl, alt, shift, meta, custom)
+- `passthrough` option: if `true`, key reaches both overlay and game
+
+### Audio capture
+
+`getUserMedia` works in Electron with `backgroundThrottling: false` on the BrowserWindow. The audio stream continues capturing when the window is unfocused or minimized. For timer-sensitive processing, use AudioWorklet (runs on a separate thread, not subject to background throttling).
+
+### Dual-build support
+
+`@overwolf/electron-is-overwolf` detects the runtime at startup. Feature-flag Overwolf code paths so the same codebase can run as vanilla Electron without Overwolf features. Standard Electron builds degrade to the current behavior (voice input, manual augment picker, separate window).
+
+### Distribution
+
+- Self-hosted distribution is allowed — not locked to the Overwolf store
+- Requires own code-signing certificate
+- Overwolf provides optional CDN, installer, and auto-updater
+- Requires Overwolf approval process (submit app idea, QA review, DevRel manager assigned)
+
+### Revenue sharing (if using Overwolf monetization)
+
+| Model                 | Split (developer / Overwolf) |
+| --------------------- | ---------------------------- |
+| Ads                   | 70/30                        |
+| Subscriptions (Tebex) | 85/15                        |
+
+Not required — the app can be free or use its own payment system.
+
+### Platform limitations
+
+- GEP and overlay are **Windows-only** currently
+- Mac/Linux support for GEP/overlay is "in development" (only ads work cross-platform)
+- Vanilla Electron builds work cross-platform but without Overwolf features


### PR DESCRIPTION
## Summary

- Comprehensive research into how augment offers can be detected programmatically during Mayhem/Arena games (issue #59)
- Overwolf GEP confirmed as the only sanctioned mechanism — Blitz.gg and OP.GG use it
- Created 4-phase migration plan from Tauri to ow-electron (`docs/ow-electron-migration-plan.md`)
- Full research documented in `docs/research/augment-detection-research.md`
- Updated PRD and technical reference to reflect findings

Closes #59

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Added a multi-phase migration plan moving the desktop shell to Overwolf Electron, covering phased rollout, IPC parity, overlay, hotkeys, audio capture, and acceptance criteria
  * Documented automatic augment detection via Overwolf Game Events Provider (GEP) and how it feeds recommendations
  * Updated product spec for in-game overlay and standalone window modes, platform constraints, and dual-build fallback behavior
  * Consolidated augment-detection research and clarified data-source availability and mapping approach
<!-- end of auto-generated comment: release notes by coderabbit.ai -->