### PR TITLE
feat: structured logging system with electron-log (#53)

### DIFF
--- a/docs/reference/logging-design.md
+++ b/docs/reference/logging-design.md
@@ -1,0 +1,186 @@
+# Structured Logging System Design
+
+Design document for issue #53. Captures decisions made during the design exploration session.
+
+## Problem
+
+Logging in Champ Sage is ad-hoc and fragmented: 36 `debugInput$.next()` calls feed a UI-only debug panel, 25 scattered `console.*` calls go nowhere persistent, and two separate IPC-based log files (coaching, GEP) use different formats. There's no way to configure log verbosity, no consistent format, and no simple way for a non-technical user to collect and share diagnostic logs.
+
+## Core Requirements
+
+### Must-have
+
+- Single structured log file (NDJSON) covering all modules and both Electron processes
+- Module-tagged, leveled log entries with type-enforced module tags
+- File menu for setting log level (error / warn / info / debug / trace) with "Open Log Folder" item
+- Log level persisted across restarts, default `info`
+- Time-based log rotation (one file per day), auto-prune files older than 5 days
+- Full migration: all `debugInput$.next()`, `console.*`, and ad-hoc `logToFile` calls replaced
+- App version + log level logged as first entry in every session
+- Pretty console output in dev
+
+### Nice-to-have (deferred)
+
+- Per-module log level filtering (achievable later via electron-log hook system)
+- Debug panel rewrite or removal (separate follow-up)
+
+## Key Decisions
+
+| Decision                 | Choice                      | Rationale                                                                            |
+| ------------------------ | --------------------------- | ------------------------------------------------------------------------------------ |
+| Library                  | electron-log                | Purpose-built for Electron; handles main/renderer IPC, file rotation, scoped loggers |
+| Log format (file)        | NDJSON                      | Parseable by scripts, jq, and LLMs; unambiguous field extraction                     |
+| Log format (console)     | Pretty text                 | Human-readable for dev; electron-log default                                         |
+| Single vs multiple files | One primary log file        | GEP raw payloads move to trace level; separate GEP log eliminated                    |
+| Log rotation             | Time-based, daily files     | File name tells you the date; 5-day auto-prune on startup                            |
+| Level configuration      | File menu with persistence  | Zero friction for non-technical users; env var not required                          |
+| Default level            | info                        | Produces a useful diagnostic log without user action                                 |
+| Module tags              | Type-enforced union         | Prevents typos that would silently break grep-based diagnosis                        |
+| Debug panel              | Stays as-is for now         | Removed in a follow-up PR; `debugInput$` stops being fed                             |
+| Process field            | Include `main` / `renderer` | Single file, need to distinguish origin                                              |
+
+## Module Taxonomy
+
+| Tag                  | Scope                                                 |
+| -------------------- | ----------------------------------------------------- |
+| `app`                | Startup, shutdown, initialization, overlay lifecycle  |
+| `engine`             | LCU discovery, WebSocket, polling, error recovery     |
+| `game-state`         | Live game state processing                            |
+| `coaching:reactive`  | User-initiated LLM queries and responses              |
+| `coaching:proactive` | GEP-triggered auto-coaching                           |
+| `gep`                | GEP bridge, augment detection, raw event processing   |
+| `voice`              | Audio capture, STT transcription, hotkey registration |
+| `data-ingest`        | Static data pipeline (champions, items, augments)     |
+| `ui`                 | UI-level events worth logging                         |
+| `ipc`                | Electron main/renderer IPC                            |
+
+## Migration Audit
+
+Full migration — no `debugInput$.next()`, `console.*`, or ad-hoc `logToFile` calls remain after implementation. Each existing call site was evaluated individually.
+
+### engine.ts (12 debugInput$ calls) — module: engine
+
+| Current call                              | Verdict                    | Level | Reasoning                                                    |
+| ----------------------------------------- | -------------------------- | ----- | ------------------------------------------------------------ |
+| LCU found/not found                       | Keep                       | info  | Connection state is the session story                        |
+| WebSocket connecting/retrying             | Keep                       | info  | Connectivity is critical diagnostic info                     |
+| WebSocket connected                       | Keep                       | info  | "                                                            |
+| WebSocket disconnected                    | Keep                       | warn  | Something went wrong, app is recovering                      |
+| WebSocket connection FAILED               | Keep                       | error | Hard failure                                                 |
+| WebSocket event (debug-worthy)            | Keep                       | debug | Internal mechanics, only when diagnosing                     |
+| Initial state: phase fetched              | Keep                       | debug | Useful for diagnosing "app joined mid-game"                  |
+| Initial state: session fetched            | Keep, lose the JSON detail | debug | Full session JSON is trace at best                           |
+| Initial state: phase/session fetch failed | Keep                       | warn  | Recoverable failure                                          |
+| Poll OK status                            | Keep                       | debug | Per-tick noise at info, useful for diagnosing polling issues |
+| Poll failed                               | Keep                       | warn  | Recoverable failure                                          |
+
+### gep-bridge.ts (4 debugInput$ + 2 GEP log IPC calls) — module: gep
+
+| Current call                            | Verdict | Level | Reasoning                            |
+| --------------------------------------- | ------- | ----- | ------------------------------------ |
+| GEP bridge initialized                  | Keep    | info  | Lifecycle event                      |
+| Augment offer detected                  | Keep    | info  | Core feature event                   |
+| Augment picked                          | Keep    | info  | "                                    |
+| Failed to parse augment offer           | Keep    | error | Data corruption, needs investigation |
+| Raw GEP info update (was separate file) | Keep    | trace | Raw payload, only for deep debugging |
+| Raw GEP game event (was separate file)  | Keep    | trace | "                                    |
+
+### useVoiceInput.ts (13 debugInput$ calls) — module: voice
+
+| Current call                          | Verdict | Level | Reasoning                                       |
+| ------------------------------------- | ------- | ----- | ----------------------------------------------- |
+| Push-to-talk hotkey registered        | Keep    | info  | Lifecycle — confirms voice is wired up          |
+| Hotkey pressed/released (keyboard)    | Remove  | —     | Redundant with recording started/stopped        |
+| Overlay hotkey pressed/released       | Remove  | —     | Redundant with recording started/stopped        |
+| Recording started                     | Keep    | info  | Voice pipeline event                            |
+| Recording stopped, transcribing       | Keep    | info  | "                                               |
+| Audio captured (duration)             | Keep    | debug | Implementation detail, useful for STT diagnosis |
+| Vocab hints                           | Remove  | —     | Never useful in practice                        |
+| Transcript result                     | Keep    | info  | Core feature event                              |
+| Voice error                           | Keep    | error | Something broke                                 |
+| Recording error                       | Keep    | error | "                                               |
+| Voice transcript received by coaching | Remove  | —     | Redundant — coaching module logs the query      |
+
+### CoachingInput.tsx (6 debugInput$ + 2 console.\*) — module: coaching:reactive / coaching:proactive
+
+| Current call                 | Verdict                    | Level | Reasoning                                           |
+| ---------------------------- | -------------------------- | ----- | --------------------------------------------------- |
+| Coaching skipped (reason)    | Keep                       | warn  | Tells you why coaching didn't fire                  |
+| Augment selected via text    | Keep                       | info  | Build tracking                                      |
+| Coaching query submitted     | Keep                       | info  | Core feature event                                  |
+| console.warn skipped         | Merge into logger          | warn  | Already the right level                             |
+| console.error coaching error | Merge into logger          | error | Already the right level                             |
+| console.warn no API key      | Keep                       | warn  | Important for "friend can't get coaching" diagnosis |
+| GEP auto-query submitted     | Keep as coaching:proactive | info  | Distinguishes trigger source                        |
+| GEP augment added to build   | Keep as coaching:proactive | info  | Build tracking                                      |
+
+### recommendation-engine.ts (3 logToFile calls) — module: coaching:reactive or coaching:proactive
+
+| Current call                              | Verdict     | Level                                            | Reasoning                                           |
+| ----------------------------------------- | ----------- | ------------------------------------------------ | --------------------------------------------------- |
+| Coaching request (model, champion, items) | Keep, split | info for summary, trace for full prompts         | Summary is session story; full prompts are firehose |
+| Response (timing, tokens, answer)         | Keep, split | info for timing+summary, trace for full response | Same split                                          |
+| Error                                     | Keep        | error                                            | Critical diagnostic                                 |
+
+### App.tsx (2 debugInput$ + 4 console.\*) — module: app
+
+| Current call                            | Verdict | Level | Reasoning                              |
+| --------------------------------------- | ------- | ----- | -------------------------------------- |
+| Game detected (mode, players, augments) | Keep    | info  | Session story                          |
+| Mode detection                          | Remove  | —     | Redundant with game detected           |
+| console.log STT provider selected       | Keep    | info  | Which voice path is active             |
+| console.warn no STT provider            | Keep    | warn  | Explains why voice doesn't work        |
+| console.warn GEP bridge init failed     | Keep    | warn  | Explains why auto-augment doesn't work |
+
+### electron/main.ts (18 console.\*) — module: app / engine / gep
+
+| Current call                     | Verdict | Level      | Module |
+| -------------------------------- | ------- | ---------- | ------ |
+| ow-electron vs vanilla detection | Keep    | info       | app    |
+| Log file paths                   | Keep    | info       | app    |
+| Overwolf package ready           | Keep    | info       | app    |
+| Overlay registered               | Keep    | info       | app    |
+| Game launched                    | Keep    | info       | app    |
+| Game is elevated (can't inject)  | Keep    | error      | app    |
+| Overlay injected                 | Keep    | info       | app    |
+| Overlay active                   | Keep    | info       | app    |
+| Game exited                      | Keep    | info       | app    |
+| Overlay injection error          | Keep    | error      | app    |
+| Hotkey registered                | Keep    | info       | voice  |
+| GEP: League detected             | Keep    | info       | gep    |
+| GEP: Features set                | Keep    | debug      | gep    |
+| GEP: Features failed + retry     | Keep    | warn/error | gep    |
+| GEP: Features set on retry       | Keep    | info       | gep    |
+| GEP: League exited               | Keep    | info       | gep    |
+| GEP error                        | Keep    | error      | gep    |
+| GEP initialized                  | Keep    | info       | gep    |
+| Overlay API not available        | Keep    | warn       | app    |
+| GEP API not available            | Keep    | warn       | gep    |
+
+### New log points to add
+
+| What                                          | Level | Module             | Why                                                  |
+| --------------------------------------------- | ----- | ------------------ | ---------------------------------------------------- |
+| App version + log level on startup            | info  | app                | First line of every log — essential for diagnosis    |
+| Log level changed                             | info  | app                | Explains verbosity change mid-file                   |
+| Data ingest completed (counts, version)       | info  | data-ingest        | Confirms static data loaded                          |
+| Data ingest failed                            | error | data-ingest        | Currently silent                                     |
+| Context assembly result                       | debug | coaching:reactive  | Fills gap between "query submitted" and "LLM called" |
+| Context assembly returned null                | warn  | coaching:reactive  | Explains why a query produced nothing                |
+| Abort signal fired (stale coaching cancelled) | debug | coaching:proactive | Confirms cancellation worked                         |
+| WebSocket cleanup on game exit                | debug | engine             | Currently silent but diagnostically useful           |
+
+### Migration totals
+
+- 36 `debugInput$.next()` calls become ~28 logger calls (8 removed as redundant)
+- 25 `console.*` calls become ~20 logger calls
+- ~8 new log points added for identified gaps
+- Separate GEP log file eliminated
+- Coaching log file replaced by unified logger
+
+## Constraints
+
+- electron-log does not support per-scope log levels natively; the hook system provides an escape hatch when needed
+- Renderer cannot write to filesystem directly; all file I/O goes through electron-log's IPC transport
+- Summoner names must never appear in logs (Riot compliance)
+- API keys and tokens must be redacted

--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -142,6 +142,8 @@ Available during the ChampSelect phase. Fires on every change (pick, ban, timer 
 
 **Champion ID resolution:** The LCU uses numeric champion keys (e.g., 136 = Aurelion Sol, 497 = Rakan). These map to `Champion.key` in our DDragon data ingest. Use `resolveChampionName()` from `src/lib/data-ingest/champion-id-map.ts` for reverse lookup.
 
+### End-of-game stats (`/lol-end-of-game/v1/eog-stats-block`)
+
 Available at the `PreEndOfGame` phase transition (immediately when the nexus dies — ~20 seconds before `EndOfGame`).
 
 **What it provides:**

--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -101,7 +101,46 @@ None → Lobby → Matchmaking → ReadyCheck → ChampSelect → InProgress →
 - **EndOfGame**: Post-game screen showing stats/honor. Stats still available.
 - Returns to **Lobby** when the player exits the post-game screen.
 
-### End-of-game stats (`/lol-end-of-game/v1/eog-stats-block`)
+### Champ select session (`/lol-champ-select/v1/session`)
+
+Available during the ChampSelect phase. Fires on every change (pick, ban, timer tick, trade). Captured from Practice Tool on 2026-03-29.
+
+**Key fields:**
+
+- `localPlayerCellId` — numeric cell ID identifying the local player (0-indexed)
+- `myTeam[]` — array of allied player objects:
+  - `cellId` — position in the draft (0-indexed)
+  - `championId` — numeric champion key (0 = not yet picked). Maps to `Champion.key` in our data ingest.
+  - `championPickIntent` — numeric champion key the player is hovering before lock-in (0 = none)
+  - `assignedPosition` — role string: `"top"`, `"jungle"`, `"middle"`, `"bottom"`, `"utility"`, or `""` (empty in ARAM/Arena)
+  - `gameName` — Riot ID game name (only populated for the local player; empty for teammates in ranked)
+  - `tagLine` — Riot ID tagline
+  - `spell1Id`, `spell2Id` — summoner spell IDs (4=Flash, 12=Teleport, 14=Ignite, 11=Smite, 21=Barrier, etc.)
+  - `selectedSkinId` — skin ID (championId \* 1000 + skin number)
+  - `team` — team number (1 = blue/ORDER, 2 = red/CHAOS)
+  - `isHumanoid` — boolean (false for the local player in Practice Tool, true for bots that simulate humans)
+  - `nameVisibilityType` — `"VISIBLE"` or `"HIDDEN"` (hidden for enemy team in ranked)
+  - `puuid` — player UUID
+- `theirTeam[]` — same structure as `myTeam[]`, for the enemy team. Champion IDs are 0 in modes where enemy picks are hidden during champ select.
+- `bans` — `{ myTeamBans: number[], theirTeamBans: number[], numBans: number }`
+- `benchChampions[]` — array of available bench champions (ARAM trade pool)
+- `benchEnabled` — boolean (true in ARAM)
+- `actions[][]` — nested array of pick/ban actions:
+  - `actorCellId` — which player is acting
+  - `championId` — champion being picked/banned
+  - `completed` — boolean (true = locked in)
+  - `isInProgress` — boolean (true = currently this player's turn)
+  - `type` — `"pick"` or `"ban"`
+- `timer` — current phase timer:
+  - `phase` — `"BAN_PICK"`, `"FINALIZATION"`, `"GAME_STARTING"`, or `""`
+  - `adjustedTimeLeftInPhase` — milliseconds remaining
+  - `totalTimeInPhase` — total milliseconds for this phase
+- `isCustomGame` — boolean
+- `queueId` — numeric queue ID (e.g., 3140 for Practice Tool)
+- `trades[]` — available trade offers between teammates
+- `gameId` — numeric game ID
+
+**Champion ID resolution:** The LCU uses numeric champion keys (e.g., 136 = Aurelion Sol, 497 = Rakan). These map to `Champion.key` in our DDragon data ingest. Use `resolveChampionName()` from `src/lib/data-ingest/champion-id-map.ts` for reverse lookup.
 
 Available at the `PreEndOfGame` phase transition (immediately when the nexus dies — ~20 seconds before `EndOfGame`).
 

--- a/electron/logger.ts
+++ b/electron/logger.ts
@@ -1,0 +1,191 @@
+/**
+ * Main process logger setup.
+ *
+ * Configures electron-log with:
+ * - NDJSON file transport (one file per day, 5-day retention)
+ * - Pretty console transport for dev
+ * - Persisted log level via electron-store or simple JSON file
+ *
+ * Must be called before any other electron-log usage in the main process.
+ */
+
+import log from "electron-log/main";
+import { app } from "electron";
+import { readdirSync, unlinkSync, readFileSync, writeFileSync } from "node:fs";
+import { join, basename } from "node:path";
+
+type LogLevel = "error" | "warn" | "info" | "debug" | "silly";
+
+/** Maps our user-facing level names to electron-log levels */
+const LEVEL_MAP: Record<string, LogLevel> = {
+  error: "error",
+  warn: "warn",
+  info: "info",
+  debug: "debug",
+  trace: "silly",
+};
+
+const LOG_RETENTION_DAYS = 5;
+const LOG_FILENAME_PATTERN = /^champ-sage-\d{4}-\d{2}-\d{2}\.log$/;
+
+// ---------------------------------------------------------------------------
+// Log level persistence
+// ---------------------------------------------------------------------------
+
+function getSettingsPath(): string {
+  return join(app.getPath("userData"), "log-settings.json");
+}
+
+export function loadLogLevel(): string {
+  try {
+    const raw = readFileSync(getSettingsPath(), "utf-8");
+    const settings = JSON.parse(raw) as { level?: string };
+    if (settings.level && settings.level in LEVEL_MAP) {
+      return settings.level;
+    }
+  } catch {
+    // No settings file or invalid — use default
+  }
+  return "info";
+}
+
+export function saveLogLevel(level: string): void {
+  writeFileSync(getSettingsPath(), JSON.stringify({ level }), "utf-8");
+}
+
+// ---------------------------------------------------------------------------
+// NDJSON formatter
+// ---------------------------------------------------------------------------
+
+function ndjsonFormat(params: {
+  data: unknown[];
+  level: string;
+  message: {
+    date?: Date;
+    scope?: string;
+    variables?: { processType?: string };
+  };
+}): unknown[] {
+  const { data, level, message } = params;
+
+  const parts: string[] = [];
+  let metadata: Record<string, unknown> | undefined;
+
+  for (const item of data) {
+    if (typeof item === "string") {
+      parts.push(item);
+    } else if (item instanceof Error) {
+      parts.push(item.message);
+      if (item.stack) {
+        metadata = { ...metadata, stack: item.stack };
+      }
+    } else if (typeof item === "object" && item !== null) {
+      metadata = { ...metadata, ...(item as Record<string, unknown>) };
+    } else {
+      parts.push(String(item));
+    }
+  }
+
+  const entry: Record<string, unknown> = {
+    time: (message.date ?? new Date()).toISOString(),
+    level,
+    ...(message.scope ? { scope: message.scope } : {}),
+    process:
+      message.variables?.processType === "renderer" ? "renderer" : "main",
+    msg: parts.join(" "),
+    ...(metadata ? metadata : {}),
+  };
+
+  return [JSON.stringify(entry)];
+}
+
+// ---------------------------------------------------------------------------
+// Log file pruning
+// ---------------------------------------------------------------------------
+
+function pruneOldLogs(logsDir: string): void {
+  const cutoff = Date.now() - LOG_RETENTION_DAYS * 24 * 60 * 60 * 1000;
+
+  try {
+    for (const file of readdirSync(logsDir)) {
+      if (!LOG_FILENAME_PATTERN.test(file)) continue;
+
+      // Extract date from filename: champ-sage-YYYY-MM-DD.log
+      const dateStr = file.slice("champ-sage-".length, -".log".length);
+      const fileDate = new Date(dateStr + "T00:00:00Z").getTime();
+
+      if (fileDate && fileDate < cutoff) {
+        try {
+          unlinkSync(join(logsDir, file));
+        } catch {
+          // Best effort — file may be locked
+        }
+      }
+    }
+  } catch {
+    // Logs directory may not exist yet
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+export function initLogger(): void {
+  // Initialize electron-log IPC for renderer → main communication
+  log.initialize();
+
+  // NDJSON format for the file transport
+  log.transports.file.format = ndjsonFormat as unknown as string;
+
+  // Daily log files — use electron-log's built-in path resolution,
+  // only override the filename to include today's date
+  log.transports.file.fileName = `champ-sage-${new Date().toISOString().slice(0, 10)}.log`;
+
+  // Disable size-based rotation (we use time-based via filename)
+  log.transports.file.maxSize = 0;
+
+  // Set log levels from persisted setting
+  const level = loadLogLevel();
+  const electronLevel = LEVEL_MAP[level] ?? "info";
+  log.transports.file.level = electronLevel;
+  log.transports.console.level = electronLevel;
+
+  // Prune old log files from the directory electron-log resolved
+  const logFile = log.transports.file.getFile();
+  if (logFile?.path) {
+    const resolvedDir = join(logFile.path, "..");
+    pruneOldLogs(resolvedDir);
+  }
+
+  // Log the session start
+  const appLog = log.scope("app");
+  const version = app.getVersion();
+  appLog.info(
+    `Champ Sage v${version} starting — log level: ${level}, log file: ${logFile?.path ?? "unknown"}`
+  );
+}
+
+/** Change the active log level at runtime (called from menu) */
+export function setLogLevel(level: string): void {
+  const electronLevel = LEVEL_MAP[level];
+  if (!electronLevel) return;
+
+  log.transports.file.level = electronLevel;
+  log.transports.console.level = electronLevel;
+  saveLogLevel(level);
+
+  const appLog = log.scope("app");
+  appLog.info(`Log level changed to: ${level}`);
+}
+
+/** Get the directory containing log files */
+export function getLogsDir(): string {
+  const logFile = log.transports.file.getFile();
+  if (logFile?.path) {
+    return join(logFile.path, "..");
+  }
+  return join(app.getPath("userData"), "logs");
+}
+
+export { log };

--- a/electron/main.ts
+++ b/electron/main.ts
@@ -1,7 +1,20 @@
-import { app as electronApp, BrowserWindow, ipcMain } from "electron";
-import { readFileSync, appendFileSync, mkdirSync } from "node:fs";
+import {
+  app as electronApp,
+  BrowserWindow,
+  ipcMain,
+  Menu,
+  shell,
+} from "electron";
+import { readFileSync } from "node:fs";
 import { join } from "node:path";
 import WebSocket from "ws";
+import {
+  initLogger,
+  setLogLevel,
+  getLogsDir,
+  log,
+  loadLogLevel,
+} from "./logger";
 
 const app = electronApp;
 
@@ -11,16 +24,6 @@ const app = electronApp;
 // When running under vanilla Electron, this property doesn't exist.
 const owApp: any =
   "overwolf" in (electronApp as any) ? (electronApp as any) : null;
-
-if (owApp) {
-  console.log(
-    "[champ-sage] Running as ow-electron (Overwolf features available)"
-  );
-} else {
-  console.log(
-    "[champ-sage] Running as vanilla Electron (no Overwolf features)"
-  );
-}
 
 // League of Legends game IDs
 const LOL_GAME_ID = 5426;
@@ -64,37 +67,6 @@ function parseLockfile(content: string): LcuCredentials {
 
 function lcuBasicAuth(token: string): string {
   return `Basic ${Buffer.from(`riot:${token}`).toString("base64")}`;
-}
-
-// ---------------------------------------------------------------------------
-// Coaching log
-// ---------------------------------------------------------------------------
-
-let coachingLogPath: string | null = null;
-let gepLogPath: string | null = null;
-
-function initLogs(): void {
-  const logsDir = join(app.getPath("userData"), "coaching-logs");
-  mkdirSync(logsDir, { recursive: true });
-  const timestamp = new Date().toISOString().replace(/[:.]/g, "-").slice(0, 19);
-  coachingLogPath = join(logsDir, `coaching-${timestamp}.log`);
-  gepLogPath = join(logsDir, `gep-${timestamp}.log`);
-  console.log(`[champ-sage] Coaching log: ${coachingLogPath}`);
-  console.log(`[champ-sage] GEP log: ${gepLogPath}`);
-}
-
-function getCoachingLogPath(): string {
-  if (!coachingLogPath) {
-    initLogs();
-  }
-  return coachingLogPath!;
-}
-
-function getGepLogPath(): string {
-  if (!gepLogPath) {
-    initLogs();
-  }
-  return gepLogPath!;
 }
 
 // ---------------------------------------------------------------------------
@@ -278,25 +250,6 @@ function registerIpcHandlers(): void {
       });
     })
   );
-
-  ipcMain.handle("append_coaching_log", async (_event, text: string) => {
-    const path = getCoachingLogPath();
-    appendFileSync(path, text + "\n");
-  });
-
-  ipcMain.handle("get_coaching_log_location", async () => {
-    return getCoachingLogPath();
-  });
-
-  // GEP event logging — separate log file for raw GEP data
-  ipcMain.handle("append_gep_log", async (_event, text: string) => {
-    const path = getGepLogPath();
-    appendFileSync(path, text + "\n");
-  });
-
-  ipcMain.handle("get_gep_log_location", async () => {
-    return getGepLogPath();
-  });
 }
 
 // ---------------------------------------------------------------------------
@@ -342,6 +295,10 @@ function createMainWindow(): BrowserWindow {
 // and the separate desktop window only.
 // ---------------------------------------------------------------------------
 
+const appLog = log.scope("app");
+const gepLog = log.scope("gep");
+const voiceLog = log.scope("voice");
+
 let gepInitialized = false;
 let overlayInitialized = false;
 
@@ -350,11 +307,8 @@ function initOverwolfFeatures(): void {
 
   const packages = owApp.overwolf.packages;
 
-  // Wait for each package to be ready
-  packages.on("ready", (e, packageName: string, version: string) => {
-    console.log(
-      `[champ-sage] Overwolf package ready: ${packageName} v${version}`
-    );
+  packages.on("ready", (e: unknown, packageName: string, version: string) => {
+    appLog.info(`Overwolf package ready: ${packageName} v${version}`);
 
     if (packageName === "overlay" && !overlayInitialized) {
       overlayInitialized = true;
@@ -374,74 +328,59 @@ function initOverlay(): void {
 
   const overlayApi = (owApp.overwolf.packages as any).overlay;
   if (!overlayApi) {
-    console.warn("[champ-sage] Overlay API not available");
+    appLog.warn("Overlay API not available");
     return;
   }
 
-  // Register League of Legends for overlay injection
   overlayApi.registerGames({ gamesIds: [LOL_GAME_ID] });
-  console.log("[champ-sage] Overlay registered for League of Legends");
+  appLog.info("Overlay registered for League of Legends");
 
-  // When League launches, inject the overlay
   overlayApi.on("game-launched", (event: any, gameInfo: any) => {
-    console.log(
-      `[champ-sage] Game launched: ${gameInfo.name} (id: ${gameInfo.id})`
-    );
+    appLog.info(`Game launched: ${gameInfo.name} (id: ${gameInfo.id})`);
 
     if (gameInfo.processInfo?.isElevated) {
-      console.warn("[champ-sage] Game is elevated — cannot inject overlay");
+      appLog.error("Game is elevated — cannot inject overlay");
       event.dismiss();
       return;
     }
 
     event.inject();
-    console.log("[champ-sage] Overlay injected");
+    appLog.info("Overlay injected");
   });
 
   overlayApi.on("game-injected", (gameInfo: any) => {
-    console.log(`[champ-sage] Overlay active in ${gameInfo.name}`);
+    appLog.info(`Overlay active in ${gameInfo.name}`);
     sendToAllWindows("overlay-status", { active: true, game: gameInfo.name });
 
-    // Register push-to-talk hotkey now that overlay is active
     registerOverlayHotkey(overlayApi);
   });
 
   overlayApi.on("game-exit", (gameInfo: any, wasInjected: boolean) => {
-    // Proactively close the LCU WebSocket before the client shuts down
-    // to avoid the noisy CloseEvent dump from the ws library
     cleanupWebSocket();
-
-    console.log(
-      `[champ-sage] Game exited: ${gameInfo.name} (was injected: ${wasInjected})`
-    );
+    appLog.info(`Game exited: ${gameInfo.name} (was injected: ${wasInjected})`);
     sendToAllWindows("overlay-status", { active: false, game: gameInfo.name });
   });
 
-  overlayApi.on("game-injection-error", (gameInfo: any, error: string) => {
-    console.error(`[champ-sage] Overlay injection error: ${error}`);
+  overlayApi.on("game-injection-error", (_gameInfo: any, error: string) => {
+    appLog.error(`Overlay injection error: ${error}`);
   });
 }
 
 function registerOverlayHotkey(overlayApi: any): void {
-  // NumpadSubtract (keyCode 109) — hold-to-talk
-  // passthrough: true so the key also reaches the game (numpad minus isn't
-  // used by League, so this is safe)
   overlayApi.hotkeys.register(
     {
       name: "push-to-talk",
       keyCode: 109, // VK_SUBTRACT (numpad minus)
       passthrough: true,
     },
-    (hotkey: any, state: "pressed" | "released") => {
+    (_hotkey: any, state: "pressed" | "released") => {
       sendToAllWindows("hotkey-event", {
         state: state === "pressed" ? "Pressed" : "Released",
       });
     }
   );
 
-  console.log(
-    "[champ-sage] Overlay hotkey registered: NumpadSubtract (hold-to-talk)"
-  );
+  voiceLog.info("Overlay hotkey registered: NumpadSubtract (hold-to-talk)");
 }
 
 // --- GEP (Game Events Provider) ---
@@ -451,17 +390,16 @@ function initGep(): void {
 
   const gepApi = owApp.overwolf.packages.gep;
   if (!gepApi) {
-    console.warn("[champ-sage] GEP API not available");
+    gepLog.warn("GEP API not available");
     return;
   }
 
-  // When League is detected, enable GEP and subscribe to augment features
   gepApi.on(
     "game-detected",
-    (e: any, gameId: number, name: string, gameInfo: any) => {
+    (e: any, gameId: number, _name: string, gameInfo: any) => {
       if (gameId !== LOL_GAME_ID) return;
 
-      console.log(`[champ-sage] GEP: League detected (pid: ${gameInfo.pid})`);
+      gepLog.info(`League detected (pid: ${gameInfo.pid})`);
       e.enable();
 
       const requiredFeatures = ["augments"];
@@ -469,59 +407,111 @@ function initGep(): void {
       gepApi
         .setRequiredFeatures(gameId, requiredFeatures)
         .then(() => {
-          console.log(
-            `[champ-sage] GEP: Required features set (${requiredFeatures.join(", ")})`
+          gepLog.debug(
+            `Required features set (${requiredFeatures.join(", ")})`
           );
         })
         .catch((err: Error) => {
-          console.error(
-            "[champ-sage] GEP: Failed to set required features:",
-            err.message
-          );
-          // Retry after a delay — GEP docs say this can fail initially
+          gepLog.warn("Failed to set required features:", err.message);
           setTimeout(() => {
             gepApi
               .setRequiredFeatures(gameId, requiredFeatures)
-              .then(() =>
-                console.log("[champ-sage] GEP: Features set on retry")
-              )
+              .then(() => gepLog.info("Features set on retry"))
               .catch((err2: Error) =>
-                console.error(
-                  "[champ-sage] GEP: Retry also failed:",
-                  err2.message
-                )
+                gepLog.error("Retry also failed:", err2.message)
               );
           }, 3000);
         });
     }
   );
 
-  // Forward all info updates to the renderer — dedup happens there via RxJS
-  gepApi.on("new-info-update", (e: any, gameId: number, ...args: any[]) => {
+  gepApi.on("new-info-update", (_e: any, gameId: number, ...args: any[]) => {
     if (gameId !== LOL_GAME_ID) return;
     const update = args[0];
     if (!update) return;
     sendToAllWindows("gep-info-update", update);
   });
 
-  // Forward all game events to the renderer
-  gepApi.on("new-game-event", (e: any, gameId: number, ...args: any[]) => {
+  gepApi.on("new-game-event", (_e: any, gameId: number, ...args: any[]) => {
     if (gameId !== LOL_GAME_ID) return;
     sendToAllWindows("gep-game-event", args[0]);
   });
 
   // @ts-ignore — game-exit is undocumented but works
-  gepApi.on("game-exit", (e: any, gameId: number) => {
+  gepApi.on("game-exit", (_e: any, gameId: number) => {
     if (gameId !== LOL_GAME_ID) return;
-    console.log("[champ-sage] GEP: League exited");
+    gepLog.info("League exited");
   });
 
-  gepApi.on("error", (e: any, gameId: number, error: any) => {
+  gepApi.on("error", (_e: any, gameId: number, error: any) => {
     if (gameId !== LOL_GAME_ID) return;
-    console.error("[champ-sage] GEP error:", error);
+    gepLog.error("GEP error:", error);
   });
 
-  console.log("[champ-sage] GEP initialized, waiting for League to launch...");
+  gepLog.info("GEP initialized, waiting for League to launch...");
+}
+
+// ---------------------------------------------------------------------------
+// Application menu with log level control
+// ---------------------------------------------------------------------------
+
+function buildAppMenu(): void {
+  const currentLevel = loadLogLevel();
+  const levels = ["error", "warn", "info", "debug", "trace"] as const;
+
+  const template: Electron.MenuItemConstructorOptions[] = [
+    {
+      label: "File",
+      submenu: [
+        {
+          label: "Log Level",
+          submenu: levels.map((level) => ({
+            label: level.charAt(0).toUpperCase() + level.slice(1),
+            type: "radio" as const,
+            checked: level === currentLevel,
+            click: () => {
+              setLogLevel(level);
+              // Rebuild menu to update radio state
+              buildAppMenu();
+            },
+          })),
+        },
+        {
+          label: "Open Log Folder",
+          click: () => shell.openPath(getLogsDir()),
+        },
+        { type: "separator" },
+        { role: "quit" },
+      ],
+    },
+    {
+      label: "Edit",
+      submenu: [
+        { role: "undo" },
+        { role: "redo" },
+        { type: "separator" },
+        { role: "cut" },
+        { role: "copy" },
+        { role: "paste" },
+        { role: "selectAll" },
+      ],
+    },
+    {
+      label: "View",
+      submenu: [
+        { role: "reload" },
+        { role: "forceReload" },
+        { role: "toggleDevTools" },
+        { type: "separator" },
+        { role: "resetZoom" },
+        { role: "zoomIn" },
+        { role: "zoomOut" },
+        { role: "togglefullscreen" },
+      ],
+    },
+  ];
+
+  Menu.setApplicationMenu(Menu.buildFromTemplate(template));
 }
 
 // ---------------------------------------------------------------------------
@@ -529,9 +519,17 @@ function initGep(): void {
 // ---------------------------------------------------------------------------
 
 app.whenReady().then(() => {
+  initLogger();
   registerIpcHandlers();
-  initLogs();
+  buildAppMenu();
   createMainWindow();
+
+  appLog.info(
+    owApp
+      ? "Running as ow-electron (Overwolf features available)"
+      : "Running as vanilla Electron (no Overwolf features)"
+  );
+
   initOverwolfFeatures();
 
   app.on("activate", () => {

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -1,10 +1,13 @@
 import { contextBridge, ipcRenderer } from "electron";
 
+// electron-log preload — sets up IPC bridge for renderer → main log transport
+import "electron-log/preload";
+
 /**
  * Preload script — exposes a safe IPC bridge to the renderer.
  *
  * Channels:
- * - invoke: request/response commands (LCU, coaching log)
+ * - invoke: request/response commands (LCU discovery, fetch)
  * - onLcuEvent/onLcuDisconnect: LCU WebSocket push events
  * - onHotkeyEvent: push-to-talk hotkey (renderer keydown/keyup in Phase 1,
  *   overlay.hotkeys in ow-electron)

--- a/electron/tsup.config.ts
+++ b/electron/tsup.config.ts
@@ -10,7 +10,7 @@ export default defineConfig([
     sourcemap: true,
     clean: true,
     external: ["electron"],
-    noExternal: ["ws"],
+    noExternal: ["ws", "electron-log"],
   },
   {
     entry: { preload: "electron/preload.ts" },
@@ -20,5 +20,6 @@ export default defineConfig([
     target: "node18",
     sourcemap: true,
     external: ["electron"],
+    noExternal: ["electron-log"],
   },
 ]);

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@openrouter/ai-sdk-provider": "^2.3.3",
     "ai": "^6.0.134",
     "deep-object-diff": "^1.1.9",
+    "electron-log": "^5.4.3",
     "luaparse": "^0.3.1",
     "openai": "^6.32.0",
     "react": "^19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -19,6 +19,9 @@ importers:
       deep-object-diff:
         specifier: ^1.1.9
         version: 1.1.9
+      electron-log:
+        specifier: ^5.4.3
+        version: 5.4.3
       luaparse:
         specifier: ^0.3.1
         version: 0.3.1
@@ -2297,6 +2300,13 @@ packages:
       {
         integrity: sha512-kXhajX6DzdIQcTlctVTKoG1oO39JhWcTG0lH7ZEJ4FzPaKJy7KFNfNJUd5BoEmLjv5GlrRZpEOYnniD+LcwNJA==,
       }
+
+  electron-log@5.4.3:
+    resolution:
+      {
+        integrity: sha512-sOUsM3LjZdugatazSQ/XTyNcw8dfvH1SYhXWiJyfYodAAKOZdHs0txPiLDXFzOZbhXgAgshQkshH2ccq0feyLQ==,
+      }
+    engines: { node: ">= 14" }
 
   electron-publish@26.8.1:
     resolution:
@@ -6654,6 +6664,8 @@ snapshots:
     transitivePeerDependencies:
       - dmg-builder
       - supports-color
+
+  electron-log@5.4.3: {}
 
   electron-publish@26.8.1:
     dependencies:

--- a/src/App.css
+++ b/src/App.css
@@ -837,22 +837,6 @@ button.augment-card {
   border-color: #666;
 }
 
-.debug-two-columns {
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 0.75rem;
-  flex: 1;
-  min-height: 0;
-}
-
-.debug-column {
-  display: flex;
-  flex-direction: column;
-  gap: 0.4rem;
-  min-width: 0;
-  min-height: 0;
-}
-
 .debug-source-legend {
   display: flex;
   flex-wrap: wrap;
@@ -876,19 +860,6 @@ button.augment-card {
 
 .debug-stream-name {
   color: #aaa;
-}
-
-.debug-noise-toggle {
-  font-size: 0.85em;
-  color: #666;
-  cursor: pointer;
-  display: flex;
-  align-items: center;
-  gap: 0.25em;
-}
-
-.debug-noise-toggle input {
-  cursor: pointer;
 }
 
 .debug-log {
@@ -919,10 +890,6 @@ button.augment-card {
   align-items: baseline;
 }
 
-.debug-log-entry.expandable {
-  cursor: pointer;
-}
-
 .debug-log-entry:hover {
   background-color: #1a1a1a;
 }
@@ -940,19 +907,6 @@ button.augment-card {
 
 .debug-log-summary {
   color: #ccc;
-}
-
-.debug-log-detail {
-  width: 100%;
-  margin: 0.25em 0 0.5em;
-  padding: 0.5em;
-  background-color: #1a1a1a;
-  border-radius: 0.1875rem;
-  color: #888;
-  font-size: 0.9em;
-  overflow-x: auto;
-  white-space: pre-wrap;
-  word-break: break-all;
 }
 
 /* Coaching display */

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -6,12 +6,11 @@ import { useLiveGameState } from "./hooks/useLiveGameState";
 import { useUserInput } from "./hooks/useUserInput";
 import { useVoiceInput } from "./hooks/useVoiceInput";
 import { useZoom } from "./hooks/useZoom";
-import {
-  initializeReactiveEngine,
-  debugInput$,
-  userInput$,
-} from "./lib/reactive";
+import { initializeReactiveEngine, userInput$ } from "./lib/reactive";
 import type { ReactiveEngine } from "./lib/reactive";
+import { getLogger } from "./lib/logger";
+
+const appLog = getLogger("app");
 import {
   WhisperProvider,
   LocalWhisperProvider,
@@ -46,7 +45,7 @@ function App() {
         gepCleanupRef.current = initGepBridge();
       })
       .catch((err) => {
-        console.warn("[app] Failed to initialize GEP bridge", err);
+        appLog.warn("Failed to initialize GEP bridge", err);
       });
 
     return () => {
@@ -71,18 +70,18 @@ function App() {
       | string
       | undefined;
     if (localUrl) {
-      console.log("[app] Using local Whisper provider:", localUrl);
+      appLog.info(`Using local Whisper provider: ${localUrl}`);
       return new LocalWhisperProvider(localUrl);
     }
 
     const apiKey = import.meta.env.VITE_OPENAI_API_KEY as string | undefined;
     if (!apiKey) {
-      console.warn(
-        "[app] No STT provider available (no VITE_LOCAL_WHISPER_URL or VITE_OPENAI_API_KEY)"
+      appLog.warn(
+        "No STT provider available (no VITE_LOCAL_WHISPER_URL or VITE_OPENAI_API_KEY)"
       );
       return null;
     }
-    console.log("[app] Using OpenAI Whisper provider");
+    appLog.info("Using OpenAI Whisper provider");
     return new WhisperProvider(apiKey);
   }, []);
 
@@ -98,12 +97,10 @@ function App() {
     const championNames = liveGame.players.map((p) => p.championName);
     ensureAbilities(data, championNames, data.version).catch(() => {});
 
-    // Log game detection info for debugging
     const detectedMode = registry.detect(liveGame.gameMode);
-    debugInput$.next({
-      source: "discovery",
-      summary: `Game detected: ${liveGame.gameMode} | mode: ${detectedMode?.displayName ?? "none"} | players: ${championNames.join(", ")} | augments in data: ${data.augments.size}`,
-    });
+    appLog.info(
+      `Game detected: ${liveGame.gameMode} | mode: ${detectedMode?.displayName ?? "none"} | players: ${championNames.length} | augments in data: ${data.augments.size}`
+    );
   }, [data, liveGame.players]);
 
   const prevPhaseRef = useRef<string | null>(null);
@@ -168,11 +165,6 @@ function App() {
     const mode = gameState.gameMode;
     if (mode === prevGameModeRef.current) return;
     prevGameModeRef.current = mode;
-    const detectedMode = registry.detect(mode);
-    debugInput$.next({
-      source: "discovery",
-      summary: `Mode detection: gameMode="${mode}" → ${detectedMode ? detectedMode.displayName : "none"} | augments: ${detectedMode ? (detectedMode.buildContext(gameState, data).modeAugments?.size ?? 0) : 0}`,
-    });
   }, [data, gameState]);
 
   const effectiveState = useMemo(() => {

--- a/src/components/CoachingInput.tsx
+++ b/src/components/CoachingInput.tsx
@@ -8,9 +8,13 @@ import type {
 } from "../lib/ai/types";
 import type { LoadedGameData } from "../lib/data-ingest";
 import { getCoachingResponse } from "../lib/ai/recommendation-engine";
-import { playerIntent$, manualInput$, debugInput$ } from "../lib/reactive";
+import { playerIntent$, manualInput$ } from "../lib/reactive";
 import { augmentOffer$, augmentPicked$ } from "../lib/reactive/gep-bridge";
 import { createAugmentCoachingController } from "../lib/ai/augment-coaching";
+import { getLogger } from "../lib/logger";
+
+const reactiveLog = getLogger("coaching:reactive");
+const proactiveLog = getLogger("coaching:proactive");
 
 interface CoachingInputProps {
   context: CoachingContext | null;
@@ -73,11 +77,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           : !apiKey
             ? "no API key"
             : "empty question";
-        console.warn("[coaching] SKIPPED:", reason);
-        debugInput$.next({
-          source: "llm",
-          summary: `Coaching skipped: ${reason}`,
-        });
+        reactiveLog.warn(`Coaching skipped: ${reason}`);
         return;
       }
 
@@ -106,10 +106,9 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           if (augmentData) {
             manualInput$.next({ type: "augment", augment: augmentData });
           }
-          debugInput$.next({
-            source: "llm",
-            summary: `Augment selected: ${newAugmentName} (total: ${chosenAugmentsRef.current.length + 1})`,
-          });
+          reactiveLog.info(
+            `Augment selected: ${newAugmentName} (total: ${chosenAugmentsRef.current.length + 1})`
+          );
         }
       }
 
@@ -129,21 +128,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
             : contextRef.current.currentAugments,
       };
 
-      debugInput$.next({
-        source: "llm",
-        summary: `Coaching query: "${question}"`,
-        detail:
-          [
-            augmentOptions
-              ? `Augment options matched: ${augmentOptions.map((a) => a.name).join(", ")}`
-              : null,
-            chosenAugmentsRef.current.length > 0
-              ? `Known augments: ${chosenAugmentsRef.current.map((a) => a.name).join(", ")}`
-              : null,
-          ]
-            .filter(Boolean)
-            .join("\n") || undefined,
-      });
+      reactiveLog.info(`Coaching query: "${question}"`);
 
       try {
         const response = await getCoachingResponse(
@@ -163,7 +148,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
         ]);
       } catch (err) {
         const msg = err instanceof Error ? err.message : "Request failed";
-        console.error("[coaching] ERROR:", msg);
+        reactiveLog.error(`Coaching error: ${msg}`);
         setError(msg);
       } finally {
         setLoading(false);
@@ -175,10 +160,6 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
   useEffect(() => {
     const sub = playerIntent$.subscribe((event) => {
       if (event.type === "query" && event.text.trim()) {
-        debugInput$.next({
-          source: "voice",
-          summary: `Voice transcript received by coaching: "${event.text}"`,
-        });
         submitQuestion(event.text);
       }
     });
@@ -194,10 +175,9 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
       {
         submitQuery: async (names, signal) => {
           const question = `I'm being offered these augments: ${names.join(", ")}. Which should I pick and which should I re-roll?`;
-          debugInput$.next({
-            source: "gep",
-            summary: `Auto-querying coaching for augment offer: ${names.join(", ")}`,
-          });
+          proactiveLog.info(
+            `Auto-querying coaching for augment offer: ${names.join(", ")}`
+          );
           await submitQuestion(question, { signal });
         },
         onPicked: (name) => {
@@ -215,10 +195,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           if (augmentData) {
             manualInput$.next({ type: "augment", augment: augmentData });
           }
-          debugInput$.next({
-            source: "gep",
-            summary: `Augment added to build: ${name}`,
-          });
+          proactiveLog.info(`Augment added to build: ${name}`);
         },
       }
     );
@@ -227,8 +204,8 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
   }, [submitQuestion]);
 
   if (!apiKey) {
-    console.warn(
-      "[coaching] No API key configured. Set VITE_OPENROUTER_API_KEY or VITE_OPENAI_API_KEY in .env"
+    reactiveLog.warn(
+      "No API key configured. Set VITE_OPENROUTER_API_KEY or VITE_OPENAI_API_KEY in .env"
     );
     return (
       <div className="coaching-display">

--- a/src/components/CoachingInput.tsx
+++ b/src/components/CoachingInput.tsx
@@ -102,12 +102,14 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
             (a) => a.name === newAugment.name
           );
           if (!alreadySelected) {
-            setChosenAugments((prev) => [...prev, newAugment]);
+            const next = [...chosenAugmentsRef.current, newAugment];
+            chosenAugmentsRef.current = next;
+            setChosenAugments(next);
             if (augmentData) {
               manualInput$.next({ type: "augment", augment: augmentData });
             }
             reactiveLog.info(
-              `Augment selected: ${newAugmentName} (total: ${chosenAugmentsRef.current.length + 1})`
+              `Augment selected: ${newAugmentName} (total: ${next.length})`
             );
           }
         }
@@ -191,7 +193,9 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
             description: augmentData?.description ?? "",
             sets: augmentData?.sets,
           };
-          setChosenAugments((prev) => [...prev, newAugment]);
+          const next = [...chosenAugmentsRef.current, newAugment];
+          chosenAugmentsRef.current = next;
+          setChosenAugments(next);
           if (augmentData) {
             manualInput$.next({ type: "augment", augment: augmentData });
           }

--- a/src/components/CoachingInput.tsx
+++ b/src/components/CoachingInput.tsx
@@ -98,17 +98,18 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
             description: augmentData?.description ?? "",
             sets: augmentData?.sets,
           };
-          setChosenAugments((prev) =>
-            prev.some((a) => a.name === newAugment.name)
-              ? prev
-              : [...prev, newAugment]
+          const alreadySelected = chosenAugmentsRef.current.some(
+            (a) => a.name === newAugment.name
           );
-          if (augmentData) {
-            manualInput$.next({ type: "augment", augment: augmentData });
+          if (!alreadySelected) {
+            setChosenAugments((prev) => [...prev, newAugment]);
+            if (augmentData) {
+              manualInput$.next({ type: "augment", augment: augmentData });
+            }
+            reactiveLog.info(
+              `Augment selected: ${newAugmentName} (total: ${chosenAugmentsRef.current.length + 1})`
+            );
           }
-          reactiveLog.info(
-            `Augment selected: ${newAugmentName} (total: ${chosenAugmentsRef.current.length + 1})`
-          );
         }
       }
 
@@ -181,6 +182,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           await submitQuestion(question, { signal });
         },
         onPicked: (name) => {
+          if (chosenAugmentsRef.current.some((a) => a.name === name)) return;
           const augmentData = gameDataRef.current.augments.get(
             name.toLowerCase()
           );
@@ -189,9 +191,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
             description: augmentData?.description ?? "",
             sets: augmentData?.sets,
           };
-          setChosenAugments((prev) =>
-            prev.some((a) => a.name === name) ? prev : [...prev, newAugment]
-          );
+          setChosenAugments((prev) => [...prev, newAugment]);
           if (augmentData) {
             manualInput$.next({ type: "augment", augment: augmentData });
           }
@@ -203,10 +203,15 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
     return () => ctrl.dispose();
   }, [submitQuestion]);
 
+  useEffect(() => {
+    if (!apiKey) {
+      reactiveLog.warn(
+        "No API key configured. Set VITE_OPENROUTER_API_KEY or VITE_OPENAI_API_KEY in .env"
+      );
+    }
+  }, [apiKey]);
+
   if (!apiKey) {
-    reactiveLog.warn(
-      "No API key configured. Set VITE_OPENROUTER_API_KEY or VITE_OPENAI_API_KEY in .env"
-    );
     return (
       <div className="coaching-display">
         <p className="entity-meta">

--- a/src/components/DebugPanel.tsx
+++ b/src/components/DebugPanel.tsx
@@ -1,6 +1,5 @@
 import { useState, useEffect, useRef } from "react";
 import { skip, distinctUntilChanged, map } from "rxjs/operators";
-import { detailedDiff } from "deep-object-diff";
 import { hasGameStateChangedMeaningfully } from "../lib/reactive/debug-filters";
 import {
   summarizeLifecycleEvent,
@@ -12,16 +11,14 @@ import {
   liveGameState$,
   userInput$,
   notifications$,
-  debugInput$,
 } from "../lib/reactive";
-import type { DebugInputEvent, LiveGameState } from "../lib/reactive";
+import type { LiveGameState } from "../lib/reactive";
 
 interface LogEntry {
   id: number;
   timestamp: string;
   stream: string;
   summary: string;
-  detail?: string;
 }
 
 let nextId = 0;
@@ -30,81 +27,7 @@ function formatTime(): string {
   return new Date().toLocaleTimeString("en-US", { hour12: false });
 }
 
-/** Compute a compact diff string between two objects. Returns undefined if empty. */
-function computeDiff(
-  prev: Record<string, unknown> | null,
-  next: unknown
-): string | undefined {
-  if (next == null || typeof next !== "object") return undefined;
-  const nextObj = next as Record<string, unknown>;
-  if (!prev) {
-    // First emission — show a compact summary of top-level keys
-    const keys = Object.keys(nextObj);
-    if (keys.length === 0) return undefined;
-    if (keys.length <= 6) {
-      return keys
-        .map((k) => {
-          const v = nextObj[k];
-          if (v == null) return `${k}: null`;
-          if (
-            typeof v === "string" ||
-            typeof v === "number" ||
-            typeof v === "boolean"
-          )
-            return `${k}: ${v}`;
-          if (Array.isArray(v)) return `${k}: [${v.length}]`;
-          return `${k}: {...}`;
-        })
-        .join("\n");
-    }
-    return `${keys.length} keys: ${keys.slice(0, 8).join(", ")}${keys.length > 8 ? "..." : ""}`;
-  }
-
-  const diff = detailedDiff(prev, nextObj);
-  const parts: string[] = [];
-
-  const formatObj = (label: string, obj: Record<string, unknown>) => {
-    const entries = Object.entries(obj);
-    if (entries.length === 0) return;
-    parts.push(
-      `${label}:\n${entries
-        .map(([k, v]) => {
-          if (v != null && typeof v === "object" && !Array.isArray(v)) {
-            // Nested changes — flatten one level
-            return Object.entries(v as Record<string, unknown>)
-              .map(([nk, nv]) => `  ${k}.${nk}: ${JSON.stringify(nv)}`)
-              .join("\n");
-          }
-          return `  ${k}: ${JSON.stringify(v)}`;
-        })
-        .join("\n")}`
-    );
-  };
-
-  const d = diff as {
-    added: Record<string, unknown>;
-    deleted: Record<string, unknown>;
-    updated: Record<string, unknown>;
-  };
-  formatObj("+added", d.added);
-  formatObj("-deleted", d.deleted);
-  formatObj("~updated", d.updated);
-
-  return parts.length > 0 ? parts.join("\n") : undefined;
-}
-
-const INPUT_COLORS: Record<string, string> = {
-  discovery: "#a78bfa",
-  websocket: "#6b7280",
-  "ws-filtered": "#818cf8",
-  "riot-api": "#34d399",
-  "lcu-rest": "#60a5fa",
-  "initial-state": "#fbbf24",
-  voice: "#ec4899",
-  llm: "#f472b6",
-};
-
-const OUTPUT_COLORS: Record<string, string> = {
+const STREAM_COLORS: Record<string, string> = {
   lifecycle: "#4ade80",
   liveGame: "#60a5fa",
   userInput: "#f59e0b",
@@ -115,112 +38,61 @@ const MAX_LOG_ENTRIES = 200;
 
 function formatBufferAsText(entries: LogEntry[]): string {
   return entries
-    .map((e) => {
-      let line = `[${e.timestamp}] [${e.stream}] ${e.summary}`;
-      if (e.detail) {
-        line += `\n${e.detail}`;
-      }
-      return line;
-    })
-    .join("\n\n");
+    .map((e) => `[${e.timestamp}] [${e.stream}] ${e.summary}`)
+    .join("\n");
 }
 
 function copyToClipboard(text: string): void {
   navigator.clipboard.writeText(text);
 }
 
-// ---- Module-level log buffers (persist across tab switches) ----
+// ---- Module-level log buffer (persists across tab switches) ----
 
-const inputBuffer: LogEntry[] = [];
-const outputBuffer: LogEntry[] = [];
-let bufferVersion = 0; // bumped on every write so React knows to re-render
+const logBuffer: LogEntry[] = [];
+let bufferVersion = 0;
 let subscriptionsStarted = false;
 
-function pushInput(stream: string, summary: string, detail?: string): void {
-  inputBuffer.push({
+function pushEntry(stream: string, summary: string): void {
+  // Deduplicate consecutive identical entries from the same stream —
+  // the LCU often sends multiple WebSocket events in quick succession
+  // with minor field differences that produce the same summary.
+  const prev = logBuffer[logBuffer.length - 1];
+  if (prev && prev.stream === stream && prev.summary === summary) return;
+
+  logBuffer.push({
     id: nextId++,
     timestamp: formatTime(),
     stream,
     summary,
-    detail,
   });
-  if (inputBuffer.length > MAX_LOG_ENTRIES) inputBuffer.shift();
+  if (logBuffer.length > MAX_LOG_ENTRIES) logBuffer.shift();
   bufferVersion++;
   notifyListeners();
 }
 
-function pushOutput(stream: string, summary: string, detail?: string): void {
-  outputBuffer.push({
-    id: nextId++,
-    timestamp: formatTime(),
-    stream,
-    summary,
-    detail,
-  });
-  if (outputBuffer.length > MAX_LOG_ENTRIES) outputBuffer.shift();
-  bufferVersion++;
-  notifyListeners();
-}
-
-// Listeners that the component registers to trigger re-renders
 type Listener = () => void;
 const listeners = new Set<Listener>();
 function notifyListeners() {
   for (const fn of listeners) fn();
 }
 
-// Track previous values for diff computation (persists across mounts)
-const prevValues: Record<string, Record<string, unknown> | null> = {
-  lobby: null,
-  matchmaking: null,
-  session: null,
-};
-
 function startSubscriptions(): void {
   if (subscriptionsStarted) return;
   subscriptionsStarted = true;
 
-  // Input stream
-  debugInput$.subscribe((event: DebugInputEvent) => {
-    pushInput(event.source, event.summary, event.detail);
-  });
-
-  // Output log entries — skip(1) to avoid BehaviorSubject replay
   gameLifecycle$.pipe(skip(1)).subscribe((event) => {
     const summary = summarizeLifecycleEvent(event);
-    let detail: string | undefined;
 
-    if (
-      event.type === "lobby" ||
-      event.type === "matchmaking" ||
-      event.type === "session"
-    ) {
-      const prev = prevValues[event.type];
-      detail = computeDiff(prev, event.data);
-      prevValues[event.type] =
-        event.data != null && typeof event.data === "object"
-          ? (event.data as Record<string, unknown>)
-          : null;
-
-      // Suppress matchmaking ticks that only update timeInQueue
-      if (
-        event.type === "matchmaking" &&
-        detail &&
-        /^~updated:\n\s+timeInQueue: \d+$/.test(detail.trim())
-      ) {
-        return;
-      }
-
-      // Truncate JWT tokens in diffs — they're unreadable noise
-      if (detail) {
-        detail = detail.replace(
-          /\beyJ[A-Za-z0-9_-]*\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g,
-          "[JWT token]"
-        );
+    // Suppress matchmaking ticks that only update timeInQueue
+    if (event.type === "matchmaking") {
+      const data = event.data as Record<string, unknown> | null;
+      if (data) {
+        const keys = Object.keys(data);
+        if (keys.length === 1 && keys[0] === "timeInQueue") return;
       }
     }
 
-    pushOutput("lifecycle", summary, detail);
+    pushEntry("lifecycle", summary);
   });
 
   liveGameState$
@@ -231,20 +103,16 @@ function startSubscriptions(): void {
     )
     .subscribe((summary) => {
       if (summary !== "Default (no data)") {
-        pushOutput("liveGame", summary);
+        pushEntry("liveGame", summary);
       }
     });
 
   userInput$.subscribe((event) => {
-    pushOutput("userInput", summarizeUserInput(event));
+    pushEntry("userInput", summarizeUserInput(event));
   });
 
   notifications$.subscribe((notif) => {
-    pushOutput(
-      "notification",
-      `[${notif.level}] ${notif.message}`,
-      `id: ${notif.id}`
-    );
+    pushEntry("notification", `[${notif.level}] ${notif.message}`);
   });
 }
 
@@ -252,26 +120,20 @@ startSubscriptions();
 
 export function DebugPanel() {
   const [, setRenderTick] = useState(0);
-  const [expandedId, setExpandedId] = useState<number | null>(null);
-  const [showNoise, setShowNoise] = useState(false);
   const [currentPhase, setCurrentPhase] = useState<string>("—");
   const [lcuConnected, setLcuConnected] = useState(false);
   const [pollingActive, setPollingActive] = useState(false);
   const [gameStateSnapshot, setGameStateSnapshot] =
     useState<LiveGameState | null>(null);
-  const inputLogEndRef = useRef<HTMLDivElement>(null);
-  const outputLogEndRef = useRef<HTMLDivElement>(null);
+  const logEndRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    // Re-render when buffers change
     const listener = () => setRenderTick((t) => t + 1);
     listeners.add(listener);
 
-    // Seed from output buffer history — the BehaviorSubject only holds the
-    // latest event which might be a session/lobby, not connection/phase.
-    // Scan the buffer for the most recent connection and phase events.
-    for (let i = outputBuffer.length - 1; i >= 0; i--) {
-      const entry = outputBuffer[i];
+    // Seed status from buffer history
+    for (let i = logBuffer.length - 1; i >= 0; i--) {
+      const entry = logBuffer[i];
       if (entry.stream === "lifecycle") {
         if (entry.summary === "Connected" || entry.summary === "Disconnected") {
           setLcuConnected(entry.summary === "Connected");
@@ -279,8 +141,8 @@ export function DebugPanel() {
         }
       }
     }
-    for (let i = outputBuffer.length - 1; i >= 0; i--) {
-      const entry = outputBuffer[i];
+    for (let i = logBuffer.length - 1; i >= 0; i--) {
+      const entry = logBuffer[i];
       if (entry.stream === "lifecycle" && entry.summary.startsWith("Phase: ")) {
         const phase = entry.summary.replace("Phase: ", "");
         setCurrentPhase(phase);
@@ -290,8 +152,6 @@ export function DebugPanel() {
     }
     setGameStateSnapshot(liveGameState$.getValue());
 
-    // Status card subscriptions — no skip(1) so BehaviorSubject replay
-    // catches us up, and subsequent events update in real time
     const subs = [
       gameLifecycle$.subscribe((event) => {
         if (event.type === "connection") setLcuConnected(event.connected);
@@ -300,7 +160,6 @@ export function DebugPanel() {
           setPollingActive(event.phase === "InProgress");
         }
       }),
-
       liveGameState$.subscribe((state) => {
         setGameStateSnapshot(state);
       }),
@@ -312,20 +171,9 @@ export function DebugPanel() {
     };
   }, []);
 
-  // Auto-scroll: always scroll to bottom after each render.
-  // Uses "instant" instead of "smooth" to avoid animation races
-  // when multiple entries arrive in quick succession.
   useEffect(() => {
-    inputLogEndRef.current?.scrollIntoView({ behavior: "instant" });
+    logEndRef.current?.scrollIntoView({ behavior: "instant" });
   });
-
-  useEffect(() => {
-    outputLogEndRef.current?.scrollIntoView({ behavior: "instant" });
-  });
-
-  const filteredInputLog = showNoise
-    ? inputBuffer
-    : inputBuffer.filter((e) => !e.summary.includes("[noise]"));
 
   return (
     <div className="debug-panel">
@@ -356,164 +204,61 @@ export function DebugPanel() {
         />
       </div>
 
-      <div className="debug-two-columns">
-        {/* Left column: Inputs */}
-        <div className="debug-column">
-          <div className="debug-section-title">
-            Data Source Inputs
-            <span className="debug-log-count">{filteredInputLog.length}</span>
-            <label className="debug-noise-toggle">
-              <input
-                type="checkbox"
-                checked={showNoise}
-                onChange={(e) => setShowNoise(e.target.checked)}
-              />
-              noise
-            </label>
-            {inputBuffer.length > 0 && (
-              <>
-                <button
-                  className="debug-clear-btn"
-                  onClick={() =>
-                    copyToClipboard(formatBufferAsText(inputBuffer))
-                  }
-                >
-                  Copy All
-                </button>
-                <button
-                  className="debug-clear-btn"
-                  onClick={() => {
-                    inputBuffer.length = 0;
-                    bufferVersion++;
-                    notifyListeners();
-                  }}
-                >
-                  Clear
-                </button>
-              </>
-            )}
-          </div>
-          <div className="debug-source-legend">
-            {Object.entries(INPUT_COLORS).map(([source, color]) => (
-              <span key={source} className="debug-stream-indicator">
-                <span
-                  className="debug-stream-dot"
-                  style={{ backgroundColor: color }}
-                />
-                <span className="debug-stream-name">{source}</span>
-              </span>
-            ))}
-          </div>
-          <div className="debug-log">
-            {filteredInputLog.length === 0 && (
-              <div className="debug-log-empty">
-                Waiting for data source events...
-              </div>
-            )}
-            {filteredInputLog.map((entry) => (
-              <LogEntryRow
-                key={entry.id}
-                entry={entry}
-                colors={INPUT_COLORS}
-                expandedId={expandedId}
-                onToggle={setExpandedId}
-              />
-            ))}
-            <div ref={inputLogEndRef} />
-          </div>
-        </div>
-
-        {/* Right column: App Observables */}
-        <div className="debug-column">
-          <div className="debug-section-title">
-            App Observables
-            <span className="debug-log-count">{outputBuffer.length}</span>
-            {outputBuffer.length > 0 && (
-              <>
-                <button
-                  className="debug-clear-btn"
-                  onClick={() =>
-                    copyToClipboard(formatBufferAsText(outputBuffer))
-                  }
-                >
-                  Copy All
-                </button>
-                <button
-                  className="debug-clear-btn"
-                  onClick={() => {
-                    outputBuffer.length = 0;
-                    bufferVersion++;
-                    notifyListeners();
-                  }}
-                >
-                  Clear
-                </button>
-              </>
-            )}
-          </div>
-          <div className="debug-source-legend">
-            {Object.entries(OUTPUT_COLORS).map(([stream, color]) => (
-              <span key={stream} className="debug-stream-indicator">
-                <span
-                  className="debug-stream-dot"
-                  style={{ backgroundColor: color }}
-                />
-                <span className="debug-stream-name">{stream}</span>
-              </span>
-            ))}
-          </div>
-          <div className="debug-log">
-            {outputBuffer.length === 0 && (
-              <div className="debug-log-empty">
-                Waiting for observable emissions...
-              </div>
-            )}
-            {outputBuffer.map((entry) => (
-              <LogEntryRow
-                key={entry.id}
-                entry={entry}
-                colors={OUTPUT_COLORS}
-                expandedId={expandedId}
-                onToggle={setExpandedId}
-              />
-            ))}
-            <div ref={outputLogEndRef} />
-          </div>
-        </div>
+      <div className="debug-section-title">
+        App Observables
+        <span className="debug-log-count">{logBuffer.length}</span>
+        {logBuffer.length > 0 && (
+          <>
+            <button
+              className="debug-clear-btn"
+              onClick={() => copyToClipboard(formatBufferAsText(logBuffer))}
+            >
+              Copy All
+            </button>
+            <button
+              className="debug-clear-btn"
+              onClick={() => {
+                logBuffer.length = 0;
+                bufferVersion++;
+                notifyListeners();
+              }}
+            >
+              Clear
+            </button>
+          </>
+        )}
       </div>
-    </div>
-  );
-}
-
-function LogEntryRow({
-  entry,
-  colors,
-  expandedId,
-  onToggle,
-}: {
-  entry: LogEntry;
-  colors: Record<string, string>;
-  expandedId: number | null;
-  onToggle: (id: number | null) => void;
-}) {
-  return (
-    <div
-      className={`debug-log-entry${entry.detail ? " expandable" : ""}`}
-      onClick={() =>
-        entry.detail && onToggle(expandedId === entry.id ? null : entry.id)
-      }
-    >
-      <span className="debug-log-time">{entry.timestamp}</span>
-      <span
-        className="debug-log-stream"
-        style={{ color: colors[entry.stream] ?? "#888" }}
-      >
-        {entry.stream}
-      </span>
-      <span className="debug-log-summary">{entry.summary}</span>
-      {expandedId === entry.id && entry.detail && (
-        <pre className="debug-log-detail">{entry.detail}</pre>
-      )}
+      <div className="debug-source-legend">
+        {Object.entries(STREAM_COLORS).map(([stream, color]) => (
+          <span key={stream} className="debug-stream-indicator">
+            <span
+              className="debug-stream-dot"
+              style={{ backgroundColor: color }}
+            />
+            <span className="debug-stream-name">{stream}</span>
+          </span>
+        ))}
+      </div>
+      <div className="debug-log">
+        {logBuffer.length === 0 && (
+          <div className="debug-log-empty">
+            Waiting for observable emissions...
+          </div>
+        )}
+        {logBuffer.map((entry) => (
+          <div key={entry.id} className="debug-log-entry">
+            <span className="debug-log-time">{entry.timestamp}</span>
+            <span
+              className="debug-log-stream"
+              style={{ color: STREAM_COLORS[entry.stream] ?? "#888" }}
+            >
+              {entry.stream}
+            </span>
+            <span className="debug-log-summary">{entry.summary}</span>
+          </div>
+        ))}
+        <div ref={logEndRef} />
+      </div>
     </div>
   );
 }

--- a/src/hooks/__tests__/useVoiceInput.test.ts
+++ b/src/hooks/__tests__/useVoiceInput.test.ts
@@ -2,7 +2,20 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useVoiceInput } from "../useVoiceInput";
 import type { SttProvider, SttResult } from "../../lib/voice/stt-provider";
-import { playerIntent$, debugInput$ } from "../../lib/reactive";
+import { playerIntent$ } from "../../lib/reactive";
+
+// Mock the logger — vi.hoisted runs before vi.mock hoisting
+const mockVoiceLog = vi.hoisted(() => ({
+  error: vi.fn(),
+  warn: vi.fn(),
+  info: vi.fn(),
+  debug: vi.fn(),
+  trace: vi.fn(),
+}));
+
+vi.mock("../../lib/logger", () => ({
+  getLogger: vi.fn(() => mockVoiceLog),
+}));
 
 // Mock the renderer-side audio recorder
 vi.mock("../../lib/audio/recorder", () => ({
@@ -154,11 +167,8 @@ describe("useVoiceInput", () => {
     sub.unsubscribe();
   });
 
-  it("emits debug events at each stage", async () => {
+  it("logs at each stage of the voice pipeline", async () => {
     const provider = createMockProvider();
-    const debugEvents: Array<{ source: string; summary: string }> = [];
-    const sub = debugInput$.subscribe((e) => debugEvents.push(e));
-
     const { result } = renderHook(() => useVoiceInput(provider));
 
     await act(async () => {
@@ -168,22 +178,17 @@ describe("useVoiceInput", () => {
       await result.current.stopAndTranscribe();
     });
 
-    const voiceEvents = debugEvents.filter((e) => e.source === "voice");
-    expect(voiceEvents.length).toBeGreaterThanOrEqual(4);
-    expect(
-      voiceEvents.some((e) => e.summary.includes("Recording started"))
-    ).toBe(true);
-    expect(
-      voiceEvents.some((e) => e.summary.includes("Recording stopped"))
-    ).toBe(true);
-    expect(voiceEvents.some((e) => e.summary.includes("Audio captured"))).toBe(
-      true
+    // Should have logged: recording started, recording stopped, audio captured (debug), transcript
+    expect(mockVoiceLog.info).toHaveBeenCalledWith("Recording started");
+    expect(mockVoiceLog.info).toHaveBeenCalledWith(
+      "Recording stopped, transcribing..."
     );
-    expect(voiceEvents.some((e) => e.summary.includes("Transcript"))).toBe(
-      true
+    expect(mockVoiceLog.info).toHaveBeenCalledWith(
+      expect.stringContaining("Transcript")
     );
-
-    sub.unsubscribe();
+    expect(mockVoiceLog.debug).toHaveBeenCalledWith(
+      expect.stringContaining("Audio captured")
+    );
   });
 
   it("handles recording errors gracefully", async () => {

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,5 +1,9 @@
 import { useState, useEffect, useCallback } from "react";
 import { loadGameData, type LoadedGameData } from "../lib/data-ingest";
+import { populateChampionIdMap } from "../lib/data-ingest/champion-id-map";
+import { getLogger } from "../lib/logger";
+
+const dataLog = getLogger("data-ingest");
 
 interface UseGameDataResult {
   data: LoadedGameData | null;
@@ -19,11 +23,17 @@ export function useGameData(): UseGameDataResult {
 
     loadGameData()
       .then((result) => {
+        populateChampionIdMap(result.champions);
+        dataLog.info(
+          `Data loaded: ${result.champions.size} champions, ${result.items.size} items, ${result.augments.size} augments (v${result.version})`
+        );
         setData(result);
         setLoading(false);
       })
       .catch((err) => {
-        setError(err instanceof Error ? err.message : String(err));
+        const msg = err instanceof Error ? err.message : String(err);
+        dataLog.error(`Data ingest failed: ${msg}`);
+        setError(msg);
         setLoading(false);
       });
   }, []);

--- a/src/hooks/useVoiceInput.ts
+++ b/src/hooks/useVoiceInput.ts
@@ -18,11 +18,14 @@
 import { useState, useEffect, useCallback, useRef } from "react";
 import type { SttProvider, SttResult } from "../lib/voice/stt-provider";
 import { buildVocabHints } from "../lib/voice/vocab-hints";
-import { playerIntent$, debugInput$, liveGameState$ } from "../lib/reactive";
+import { playerIntent$, liveGameState$ } from "../lib/reactive";
 import {
   startRecording as startAudioCapture,
   stopRecording as stopAudioCapture,
 } from "../lib/audio/recorder";
+import { getLogger } from "../lib/logger";
+
+const voiceLog = getLogger("voice");
 
 /** Default hotkey for push-to-talk.
  *
@@ -69,10 +72,7 @@ export function useVoiceInput(
       isRecordingRef.current = false;
       setState((s) => ({ ...s, isRecording: false, isTranscribing: true }));
 
-      debugInput$.next({
-        source: "voice",
-        summary: "Recording stopped, transcribing...",
-      });
+      voiceLog.info("Recording stopped, transcribing...");
 
       // Get WAV bytes from renderer-side audio capture
       const wavBytes = await stopAudioCapture();
@@ -91,10 +91,7 @@ export function useVoiceInput(
       const pcmBytes = Math.max(0, wavBytes.length - 44);
       const audioDurationSec =
         bytesPerSecond > 0 ? pcmBytes / bytesPerSecond : 0;
-      debugInput$.next({
-        source: "voice",
-        summary: `Audio captured: ${audioDurationSec.toFixed(1)}s`,
-      });
+      voiceLog.debug(`Audio captured: ${audioDurationSec.toFixed(1)}s`);
 
       if (!providerRef.current) {
         throw new Error("No STT provider configured");
@@ -105,23 +102,13 @@ export function useVoiceInput(
       const championNames = gameState.players.map((p) => p.championName);
       const hints = buildVocabHints(championNames);
 
-      debugInput$.next({
-        source: "voice",
-        summary: `Vocab hints: ${hints.length} words`,
-        detail: hints.join(", "),
-      });
-
       // Transcribe
       const result: SttResult = await providerRef.current.transcribe(
         blob,
         hints
       );
 
-      debugInput$.next({
-        source: "voice",
-        summary: `Transcript (${result.latencyMs}ms): ${result.transcript}`,
-        detail: result.transcript,
-      });
+      voiceLog.info(`Transcript (${result.latencyMs}ms): ${result.transcript}`);
 
       setState((s) => ({
         ...s,
@@ -137,10 +124,7 @@ export function useVoiceInput(
       }
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
-      debugInput$.next({
-        source: "voice",
-        summary: `Error: ${message}`,
-      });
+      voiceLog.error(`Transcription error: ${message}`);
       setState((s) => ({
         ...s,
         isRecording: false,
@@ -165,18 +149,12 @@ export function useVoiceInput(
 
       isRecordingRef.current = true;
       setState((s) => ({ ...s, isRecording: true, error: null }));
-      debugInput$.next({
-        source: "voice",
-        summary: "Recording started (hotkey held)",
-      });
+      voiceLog.info("Recording started");
       await startAudioCapture();
     } catch (err) {
       const message = err instanceof Error ? err.message : String(err);
       isRecordingRef.current = false;
-      debugInput$.next({
-        source: "voice",
-        summary: `Recording error: ${message}`,
-      });
+      voiceLog.error(`Recording error: ${message}`);
       setState((s) => ({ ...s, isRecording: false, error: message }));
     }
   }, []);
@@ -197,20 +175,12 @@ export function useVoiceInput(
       if (e.code !== PUSH_TO_TALK_HOTKEY) return;
       if (e.repeat) return;
       if (isRecordingRef.current) return;
-      debugInput$.next({
-        source: "voice",
-        summary: `Hotkey pressed: ${PUSH_TO_TALK_HOTKEY}`,
-      });
       startRef.current();
     };
 
     const handleKeyUp = (e: KeyboardEvent) => {
       if (e.code !== PUSH_TO_TALK_HOTKEY) return;
       if (!isRecordingRef.current) return;
-      debugInput$.next({
-        source: "voice",
-        summary: `Hotkey released: ${PUSH_TO_TALK_HOTKEY}`,
-      });
       stopRef.current();
     };
 
@@ -225,25 +195,16 @@ export function useVoiceInput(
       unlistenOverlayHotkey = api.onHotkeyEvent((payload) => {
         const { state } = payload as { state: string };
         if (state === "Pressed" && !isRecordingRef.current) {
-          debugInput$.next({
-            source: "voice",
-            summary: "Overlay hotkey pressed",
-          });
           startRef.current();
         } else if (state === "Released" && isRecordingRef.current) {
-          debugInput$.next({
-            source: "voice",
-            summary: "Overlay hotkey released",
-          });
           stopRef.current();
         }
       });
     }
 
-    debugInput$.next({
-      source: "voice",
-      summary: `Push-to-talk: ${PUSH_TO_TALK_HOTKEY} (keyboard + overlay hotkey)`,
-    });
+    voiceLog.info(
+      `Push-to-talk registered: ${PUSH_TO_TALK_HOTKEY} (keyboard + overlay hotkey)`
+    );
 
     return () => {
       window.removeEventListener("keydown", handleKeyDown);

--- a/src/lib/ai/recommendation-engine.ts
+++ b/src/lib/ai/recommendation-engine.ts
@@ -64,8 +64,11 @@ export async function getCoachingResponse(
     return result.output;
   } catch (err) {
     const elapsedMs = Date.now() - startMs;
-    const message = err instanceof Error ? err.message : String(err);
-    coachingLog.error(`Request failed (${elapsedMs}ms): ${message}`);
+    coachingLog.error("Request failed", {
+      elapsedMs,
+      error: err instanceof Error ? err.message : String(err),
+      stack: err instanceof Error ? err.stack : undefined,
+    });
     throw err;
   }
 }

--- a/src/lib/ai/recommendation-engine.ts
+++ b/src/lib/ai/recommendation-engine.ts
@@ -3,14 +3,9 @@ import type { CoachingContext, CoachingQuery, CoachingResponse } from "./types";
 import { createCoachingModel, MODEL_CONFIG } from "./model-config";
 import { buildSystemPrompt, buildUserPrompt } from "./prompts";
 import { coachingResponseSchema } from "./schemas";
+import { getLogger } from "../logger";
 
-function logToFile(text: string): void {
-  const timestamp = new Date().toISOString();
-  const line = `[${timestamp}] ${text}`;
-  if (window.electronAPI) {
-    window.electronAPI.invoke("append_coaching_log", line).catch(() => {});
-  }
-}
+const coachingLog = getLogger("coaching:reactive");
 
 export async function getCoachingResponse(
   context: CoachingContext,
@@ -25,25 +20,19 @@ export async function getCoachingResponse(
   });
   const userPrompt = buildUserPrompt(context, query);
 
-  logToFile(
-    [
-      "=== COACHING REQUEST ===",
-      `Model: ${MODEL_CONFIG.id}`,
-      `Question: ${query.question}`,
-      `Champion: ${context.champion.name} Lv${context.champion.level}`,
-      `Items: ${context.currentItems.map((i) => i.name).join(", ") || "None"}`,
-      `Augments: ${context.currentAugments.map((a) => a.name).join(", ") || "None"}`,
-      `Mode: ${context.gameMode} (LCU: ${context.lcuGameMode}) | Augments tracked: ${context.currentAugments.length > 0 ? context.currentAugments.map((a) => a.name).join(", ") : "None"}`,
-      `Enemies: ${context.enemyTeam.map((e) => e.champion).join(", ") || "None"}`,
-      `History: ${query.history?.length ?? 0} exchanges`,
-      "",
-      "--- SYSTEM PROMPT ---",
-      systemPrompt,
-      "",
-      "--- USER PROMPT ---",
-      userPrompt,
-    ].join("\n")
+  coachingLog.info(
+    `Request: ${query.question} | ${context.champion.name} Lv${context.champion.level} | ${context.gameMode}`,
+    {
+      model: MODEL_CONFIG.id,
+      items: context.currentItems.map((i) => i.name),
+      augments: context.currentAugments.map((a) => a.name),
+      enemies: context.enemyTeam.map((e) => e.champion),
+      historyLength: query.history?.length ?? 0,
+    }
   );
+
+  coachingLog.trace("System prompt:", systemPrompt);
+  coachingLog.trace("User prompt:", userPrompt);
 
   const startMs = Date.now();
   const model = createCoachingModel(apiKey);
@@ -62,28 +51,21 @@ export async function getCoachingResponse(
     const usage = result.usage;
     const recs = result.output.recommendations;
 
-    logToFile(
-      [
-        `--- RESPONSE (${elapsedMs}ms) ---`,
-        `Tokens: ${usage.inputTokens ?? "?"}in / ${usage.outputTokens ?? "?"}out`,
-        `Answer: ${result.output.answer}`,
-        ...(recs.length > 0
-          ? [
-              "Recommendations:",
-              ...recs.map((r, i) => `  #${i + 1} ${r.name}: ${r.reasoning}`),
-            ]
-          : []),
-        "=== END COACHING REQUEST ===",
-      ].join("\n")
+    coachingLog.info(
+      `Response (${elapsedMs}ms): ${usage.inputTokens ?? "?"}in/${usage.outputTokens ?? "?"}out`,
+      {
+        answer: result.output.answer,
+        recommendations: recs.map((r) => r.name),
+      }
     );
+
+    coachingLog.trace("Full response:", result.output);
 
     return result.output;
   } catch (err) {
     const elapsedMs = Date.now() - startMs;
     const message = err instanceof Error ? err.message : String(err);
-    logToFile(
-      `--- ERROR (${elapsedMs}ms) ---\n${message}\n=== END COACHING REQUEST ===`
-    );
+    coachingLog.error(`Request failed (${elapsedMs}ms): ${message}`);
     throw err;
   }
 }

--- a/src/lib/data-ingest/champion-id-map.ts
+++ b/src/lib/data-ingest/champion-id-map.ts
@@ -1,0 +1,22 @@
+/**
+ * Module-level reverse lookup: champion numeric key → display name.
+ *
+ * Populated once when game data loads. Used by the debug panel summarizer
+ * to show champion names instead of numeric IDs during champ select
+ * (the LCU champ select API only provides numeric champion keys).
+ */
+
+const championIdToName = new Map<number, string>();
+
+export function populateChampionIdMap(
+  champions: Map<string, { key: number; name: string }>
+): void {
+  championIdToName.clear();
+  for (const champ of champions.values()) {
+    championIdToName.set(champ.key, champ.name);
+  }
+}
+
+export function resolveChampionName(championId: number): string | undefined {
+  return championIdToName.get(championId);
+}

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,0 +1,56 @@
+/**
+ * Structured logger for the renderer process.
+ *
+ * Wraps electron-log's renderer module with type-enforced module scopes.
+ * In Electron, logs are sent via IPC to the main process which writes
+ * them to the NDJSON log file. In non-Electron contexts (tests),
+ * the module mock or console fallback handles it.
+ *
+ * Usage:
+ *   import { getLogger } from '../lib/logger';
+ *   const log = getLogger('engine');
+ *   log.info('LCU found', { port: 1234 });
+ */
+
+import electronLog from "electron-log/renderer";
+
+export type LogModule =
+  | "app"
+  | "engine"
+  | "game-state"
+  | "coaching:reactive"
+  | "coaching:proactive"
+  | "gep"
+  | "voice"
+  | "data-ingest"
+  | "ui"
+  | "ipc";
+
+export interface ScopedLogger {
+  error: (...args: unknown[]) => void;
+  warn: (...args: unknown[]) => void;
+  info: (...args: unknown[]) => void;
+  debug: (...args: unknown[]) => void;
+  /** Lowest level — raw payloads, per-tick data */
+  trace: (...args: unknown[]) => void;
+}
+
+const scopeCache = new Map<LogModule, ScopedLogger>();
+
+export function getLogger(module: LogModule): ScopedLogger {
+  let logger = scopeCache.get(module);
+  if (logger) return logger;
+
+  const scoped = electronLog.scope(module);
+  logger = {
+    error: (...args: unknown[]) => scoped.error(...args),
+    warn: (...args: unknown[]) => scoped.warn(...args),
+    info: (...args: unknown[]) => scoped.info(...args),
+    debug: (...args: unknown[]) => scoped.debug(...args),
+    // electron-log calls this "silly" — we expose it as "trace"
+    trace: (...args: unknown[]) => scoped.silly(...args),
+  };
+
+  scopeCache.set(module, logger);
+  return logger;
+}

--- a/src/lib/reactive/debug-summarizers.test.ts
+++ b/src/lib/reactive/debug-summarizers.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import {
   summarizeLifecycleEvent,
   summarizeLiveGameState,
@@ -10,6 +10,19 @@ import type {
   UserInputEvent,
 } from "./types";
 import type { ActivePlayer } from "../game-state/types";
+
+vi.mock("../data-ingest/champion-id-map", () => {
+  const nameMap: Record<number, string> = {
+    136: "Aurelion Sol",
+    497: "Rakan",
+    254: "Vi",
+    202: "Jhin",
+    68: "Rumble",
+  };
+  return {
+    resolveChampionName: vi.fn((id: number) => nameMap[id]),
+  };
+});
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -99,6 +112,19 @@ describe("summarizeLifecycleEvent", () => {
     expect(summarizeLifecycleEvent(event)).toBe("Lobby: ARAM, 3 members");
   });
 
+  it("includes queue ID when present", () => {
+    const event: GameLifecycleEvent = {
+      type: "lobby",
+      data: {
+        gameConfig: { gameMode: "ARAM", queueId: 450 },
+        members: [{}, {}],
+      },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe(
+      "Lobby: ARAM (queue 450), 2 members"
+    );
+  });
+
   it("falls back to generic lobby summary when data is missing", () => {
     const event: GameLifecycleEvent = { type: "lobby", data: {} };
     expect(summarizeLifecycleEvent(event)).toBe("Lobby update");
@@ -128,6 +154,20 @@ describe("summarizeLifecycleEvent", () => {
       },
     };
     expect(summarizeLifecycleEvent(event)).toBe("Session: ChampSelect, ARAM");
+  });
+
+  it("includes map ID when present", () => {
+    const event: GameLifecycleEvent = {
+      type: "session",
+      data: {
+        phase: "InProgress",
+        gameData: { queue: { gameMode: "CLASSIC" } },
+        map: { mapId: 11 },
+      },
+    };
+    expect(summarizeLifecycleEvent(event)).toBe(
+      "Session: InProgress, CLASSIC, map 11"
+    );
   });
 
   it("falls back to generic session summary when data is missing", () => {
@@ -172,15 +212,72 @@ describe("summarizeLiveGameState", () => {
     );
   });
 
-  it("indicates champ select active", () => {
-    expect(
-      summarizeLiveGameState(
-        createDefaultLiveGameState({ champSelect: { myTeam: [] } })
-      )
-    ).toBe("Champ select active");
+  it("shows your champion and allies during champ select", () => {
+    const champSelect = {
+      localPlayerCellId: 0,
+      myTeam: [
+        {
+          cellId: 0,
+          championId: 136,
+          championPickIntent: 0,
+          assignedPosition: "",
+          gameName: "niftymonkey",
+        },
+        {
+          cellId: 1,
+          championId: 497,
+          championPickIntent: 0,
+          assignedPosition: "utility",
+          gameName: "",
+        },
+        {
+          cellId: 2,
+          championId: 254,
+          championPickIntent: 0,
+          assignedPosition: "jungle",
+          gameName: "",
+        },
+      ],
+      theirTeam: [],
+      timer: { phase: "BAN_PICK", adjustedTimeLeftInPhase: 25000 },
+    };
+    const result = summarizeLiveGameState(
+      createDefaultLiveGameState({ champSelect })
+    );
+    expect(result).toContain("Champ Select");
+    expect(result).toContain("You: Aurelion Sol");
+    expect(result).toContain("Rakan (utility)");
+    expect(result).toContain("Vi (jungle)");
+    expect(result).toContain("BAN_PICK (25s)");
   });
 
-  it("shows EOG win/loss", () => {
+  it("shows hovering intent when not locked in", () => {
+    const champSelect = {
+      localPlayerCellId: 0,
+      myTeam: [
+        {
+          cellId: 0,
+          championId: 0,
+          championPickIntent: 202,
+          assignedPosition: "",
+        },
+      ],
+      theirTeam: [],
+      timer: { phase: "BAN_PICK", adjustedTimeLeftInPhase: 60000 },
+    };
+    const result = summarizeLiveGameState(
+      createDefaultLiveGameState({ champSelect })
+    );
+    expect(result).toContain("Hovering: Jhin");
+  });
+
+  it("falls back gracefully when champSelect has no team data", () => {
+    expect(
+      summarizeLiveGameState(createDefaultLiveGameState({ champSelect: {} }))
+    ).toBe("Champ Select");
+  });
+
+  it("shows EOG with game mode and duration", () => {
     const eogStats = {
       gameId: "123",
       gameLength: 1200,
@@ -191,7 +288,21 @@ describe("summarizeLiveGameState", () => {
     };
     expect(
       summarizeLiveGameState(createDefaultLiveGameState({ eogStats }))
-    ).toBe("EOG: WIN");
+    ).toBe("EOG: WIN | ARAM | 20:00");
+  });
+
+  it("shows EOG loss", () => {
+    const eogStats = {
+      gameId: "456",
+      gameLength: 900,
+      gameMode: "CHERRY",
+      isWin: false,
+      championId: 222,
+      items: [],
+    };
+    expect(
+      summarizeLiveGameState(createDefaultLiveGameState({ eogStats }))
+    ).toBe("EOG: LOSS | CHERRY | 15:00");
   });
 
   it("shows champion, level, time, mode, and player count", () => {
@@ -213,7 +324,7 @@ describe("summarizeLiveGameState", () => {
 // ---------------------------------------------------------------------------
 
 describe("summarizeUserInput", () => {
-  it("shows augment name", () => {
+  it("shows augment name and tier", () => {
     const event: UserInputEvent = {
       type: "augment",
       augment: {
@@ -224,7 +335,25 @@ describe("summarizeUserInput", () => {
         mode: "mayhem",
       },
     };
-    expect(summarizeUserInput(event)).toBe("Augment: Blade Waltz");
+    expect(summarizeUserInput(event)).toBe(
+      "Augment picked: Blade Waltz (Gold)"
+    );
+  });
+
+  it("shows augment name with tier", () => {
+    const event: UserInputEvent = {
+      type: "augment",
+      augment: {
+        name: "Blade Waltz",
+        description: "desc",
+        tier: "Silver",
+        sets: [],
+        mode: "mayhem",
+      },
+    };
+    expect(summarizeUserInput(event)).toBe(
+      "Augment picked: Blade Waltz (Silver)"
+    );
   });
 
   it("shows query text", () => {

--- a/src/lib/reactive/debug-summarizers.test.ts
+++ b/src/lib/reactive/debug-summarizers.test.ts
@@ -271,6 +271,25 @@ describe("summarizeLiveGameState", () => {
     expect(result).toContain("Hovering: Jhin");
   });
 
+  it("falls back to numeric ID for unknown champions", () => {
+    const champSelect = {
+      localPlayerCellId: 0,
+      myTeam: [
+        {
+          cellId: 0,
+          championId: 999,
+          championPickIntent: 0,
+          assignedPosition: "",
+        },
+      ],
+      theirTeam: [],
+    };
+    const result = summarizeLiveGameState(
+      createDefaultLiveGameState({ champSelect })
+    );
+    expect(result).toContain("You: #999");
+  });
+
   it("falls back gracefully when champSelect has no team data", () => {
     expect(
       summarizeLiveGameState(createDefaultLiveGameState({ champSelect: {} }))

--- a/src/lib/reactive/debug-summarizers.ts
+++ b/src/lib/reactive/debug-summarizers.ts
@@ -4,6 +4,7 @@ import type {
   UserInputEvent,
 } from "./types";
 import { formatGameTime } from "../format";
+import { resolveChampionName } from "../data-ingest/champion-id-map";
 
 // Safe accessor for unknown nested data from LCU payloads
 function get(obj: unknown, ...path: string[]): unknown {
@@ -35,22 +36,38 @@ function summarizeLobby(data: unknown): string {
   const gameMode = get(data, "gameConfig", "gameMode");
   if (typeof gameMode !== "string") return "Lobby update";
 
+  const parts = [`Lobby: ${gameMode}`];
+
+  const queueId = get(data, "gameConfig", "queueId");
+  if (typeof queueId === "number" && queueId > 0) {
+    parts[0] += ` (queue ${queueId})`;
+  }
+
   const members = get(data, "members");
   if (Array.isArray(members) && members.length > 0) {
-    return `Lobby: ${gameMode}, ${members.length} members`;
+    parts.push(`${members.length} members`);
   }
-  return `Lobby: ${gameMode}`;
+
+  return parts.join(", ");
 }
 
 function summarizeSession(data: unknown): string {
   const phase = get(data, "phase");
   if (typeof phase !== "string") return "Session update";
 
+  const parts = [`Session: ${phase}`];
+
   const gameMode = get(data, "gameData", "queue", "gameMode");
-  if (typeof gameMode === "string") {
-    return `Session: ${phase}, ${gameMode}`;
+  if (typeof gameMode === "string" && gameMode) {
+    parts.push(gameMode);
   }
-  return `Session: ${phase}`;
+
+  const mapId = get(data, "map", "mapId");
+  if (typeof mapId === "number") {
+    parts.push(`map ${mapId}`);
+  }
+
+  return parts.join(", ");
 }
 
 function summarizeMatchmaking(data: unknown): string {
@@ -67,8 +84,9 @@ function summarizeMatchmaking(data: unknown): string {
 /** Summarize live game state into a compact one-liner. */
 export function summarizeLiveGameState(state: LiveGameState): string {
   if (!state.activePlayer) {
-    if (state.champSelect != null) return "Champ select active";
-    if (state.eogStats) return `EOG: ${state.eogStats.isWin ? "WIN" : "LOSS"}`;
+    if (state.champSelect != null)
+      return summarizeChampSelect(state.champSelect);
+    if (state.eogStats) return summarizeEog(state);
     return "Default (no data)";
   }
   const parts = [
@@ -81,8 +99,100 @@ export function summarizeLiveGameState(state: LiveGameState): string {
   return parts.join(" | ");
 }
 
+/** Resolve a champion ID to a display name, falling back to the numeric ID. */
+function champName(id: number): string {
+  return resolveChampionName(id) ?? `#${id}`;
+}
+
+/** Extract useful info from champ select session data. */
+function summarizeChampSelect(champSelect: unknown): string {
+  if (champSelect == null || typeof champSelect !== "object") {
+    return "Champ select active";
+  }
+
+  const cs = champSelect as Record<string, unknown>;
+  const localCellId = cs.localPlayerCellId as number | undefined;
+  const parts: string[] = ["Champ Select"];
+
+  // Identify what the local player picked/is hovering
+  const myTeam = cs.myTeam as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(myTeam)) {
+    const localPlayer = myTeam.find((m) => m.cellId === localCellId);
+    if (localPlayer) {
+      const lockedId = localPlayer.championId as number;
+      const hoverIntentId = localPlayer.championPickIntent as number;
+      if (lockedId > 0) {
+        parts.push(`You: ${champName(lockedId)}`);
+      } else if (hoverIntentId > 0) {
+        parts.push(`Hovering: ${champName(hoverIntentId)}`);
+      }
+    }
+
+    // Summarize allies (excluding local player)
+    const allies = myTeam
+      .filter((m) => m.cellId !== localCellId)
+      .map((m) => {
+        const id = (m.championId as number) || (m.championPickIntent as number);
+        const pos = m.assignedPosition as string;
+        if (id > 0) {
+          return pos ? `${champName(id)} (${pos})` : champName(id);
+        }
+        return null;
+      })
+      .filter(Boolean);
+
+    if (allies.length > 0) {
+      parts.push(`Allies: ${allies.join(", ")}`);
+    }
+  }
+
+  // Summarize enemy picks (only those with champion IDs)
+  const theirTeam = cs.theirTeam as Array<Record<string, unknown>> | undefined;
+  if (Array.isArray(theirTeam)) {
+    const enemies = theirTeam
+      .map((m) => {
+        const id = (m.championId as number) || (m.championPickIntent as number);
+        return id > 0 ? champName(id) : null;
+      })
+      .filter(Boolean);
+
+    if (enemies.length > 0) {
+      parts.push(`Enemies: ${enemies.join(", ")}`);
+    }
+  }
+
+  // Timer phase
+  const timer = cs.timer as Record<string, unknown> | undefined;
+  if (timer) {
+    const phase = timer.phase as string | undefined;
+    const timeLeft = timer.adjustedTimeLeftInPhase as number | undefined;
+    if (phase && typeof timeLeft === "number" && timeLeft > 0) {
+      parts.push(`${phase} (${Math.ceil(timeLeft / 1000)}s)`);
+    } else if (phase) {
+      parts.push(phase);
+    }
+  }
+
+  return parts.join(" — ");
+}
+
+/** Summarize end-of-game stats with useful detail. */
+function summarizeEog(state: LiveGameState): string {
+  const eog = state.eogStats!;
+  const parts = [eog.isWin ? "WIN" : "LOSS"];
+
+  if (eog.gameMode) parts.push(eog.gameMode);
+  if (eog.gameLength > 0) parts.push(formatGameTime(eog.gameLength));
+
+  return `EOG: ${parts.join(" | ")}`;
+}
+
 /** Summarize a user input event. */
 export function summarizeUserInput(event: UserInputEvent): string {
-  if (event.type === "augment") return `Augment: ${event.augment.name}`;
+  if (event.type === "augment") {
+    const parts = [`Augment picked: ${event.augment.name}`];
+    if (event.augment.tier) parts.push(`(${event.augment.tier})`);
+    return parts.join(" ");
+  }
   return `Query: "${event.text}"`;
 }

--- a/src/lib/reactive/electron-bridge.ts
+++ b/src/lib/reactive/electron-bridge.ts
@@ -60,8 +60,8 @@ function createNoOpBridge(): PlatformBridge {
     fetchLcu: fail,
     fetchRiotApi: fail,
     connectLcuWebSocket: fail,
-    listenLcuEvent: async () => () => {},
-    listenLcuDisconnect: async () => () => {},
+    listenLcuEvent: () => () => {},
+    listenLcuDisconnect: () => () => {},
   };
 }
 
@@ -94,13 +94,13 @@ export function createElectronBridge(): PlatformBridge {
       );
     },
 
-    async listenLcuEvent(handler: (event: LcuEventPayload) => void) {
+    listenLcuEvent(handler: (event: LcuEventPayload) => void) {
       return api.onLcuEvent((payload) => {
         handler(payload as LcuEventPayload);
       });
     },
 
-    async listenLcuDisconnect(handler: (event: LcuDisconnectPayload) => void) {
+    listenLcuDisconnect(handler: (event: LcuDisconnectPayload) => void) {
       return api.onLcuDisconnect((payload) => {
         handler(payload as LcuDisconnectPayload);
       });

--- a/src/lib/reactive/electron-bridge.ts
+++ b/src/lib/reactive/electron-bridge.ts
@@ -10,8 +10,8 @@ import type {
  */
 interface ElectronAPI {
   invoke(channel: string, ...args: unknown[]): Promise<unknown>;
-  onLcuEvent(callback: (event: unknown) => void): () => void;
-  onLcuDisconnect(callback: (event: unknown) => void): () => void;
+  onLcuEvent(callback: (event: LcuEventPayload) => void): () => void;
+  onLcuDisconnect(callback: (event: LcuDisconnectPayload) => void): () => void;
   onHotkeyEvent(callback: (event: unknown) => void): () => void;
   onGepInfoUpdate(callback: (event: unknown) => void): () => void;
   onGepGameEvent(callback: (event: unknown) => void): () => void;
@@ -95,15 +95,11 @@ export function createElectronBridge(): PlatformBridge {
     },
 
     listenLcuEvent(handler: (event: LcuEventPayload) => void) {
-      return api.onLcuEvent((payload) => {
-        handler(payload as LcuEventPayload);
-      });
+      return api.onLcuEvent(handler);
     },
 
     listenLcuDisconnect(handler: (event: LcuDisconnectPayload) => void) {
-      return api.onLcuDisconnect((payload) => {
-        handler(payload as LcuDisconnectPayload);
-      });
+      return api.onLcuDisconnect(handler);
     },
   };
 }

--- a/src/lib/reactive/engine.test.ts
+++ b/src/lib/reactive/engine.test.ts
@@ -76,14 +76,14 @@ function createMockBridge(): MockBridge {
 
     connectLcuWebSocket: vi.fn(async () => {}),
 
-    listenLcuEvent: vi.fn(async (handler) => {
+    listenLcuEvent: vi.fn((handler) => {
       eventHandler = handler;
       return () => {
         eventHandler = null;
       };
     }),
 
-    listenLcuDisconnect: vi.fn(async (handler) => {
+    listenLcuDisconnect: vi.fn((handler) => {
       disconnectHandler = handler;
       return () => {
         disconnectHandler = null;

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -23,7 +23,6 @@ import {
   userInput$,
   manualInput$,
   playerIntent$,
-  debugInput$,
 } from "./streams";
 import { normalizeGameState } from "../game-state/normalize";
 import type { PlatformBridge, LcuEventPayload } from "./platform-bridge";
@@ -35,6 +34,9 @@ import {
   shouldLogWebSocketEvent,
   describeEvent,
 } from "./debug-filters";
+import { getLogger } from "../logger";
+
+const engineLog = getLogger("engine");
 
 const DISCOVERY_INTERVAL_MS = 3000;
 const POLL_INTERVAL_MS = 2000;
@@ -160,12 +162,11 @@ export class ReactiveEngine {
           this.currentPort !== status.port ||
           (status.connected && this.currentPort === 0);
         if (isNewDiscovery || !status.connected) {
-          debugInput$.next({
-            source: "discovery",
-            summary: status.connected
+          engineLog.info(
+            status.connected
               ? `LCU found — port ${status.port}`
-              : "LCU not found",
-          });
+              : "LCU not found"
+          );
         }
         if (status.connected) {
           this.currentPort = status.port;
@@ -193,56 +194,42 @@ export class ReactiveEngine {
           filter((s) => s.connected),
           switchMap((creds) => {
             return new Observable<void>(() => {
-              let unlisten: (() => void) | null = null;
-              let unlistenDisconnect: (() => void) | null = null;
-
               const isRetry = this.wsRetrySeq > 0;
-              debugInput$.next({
-                source: "websocket",
-                summary: isRetry
+              engineLog.info(
+                isRetry
                   ? `Retrying WebSocket connection... (attempt ${this.wsRetrySeq + 1})`
-                  : `Connecting WebSocket to port ${creds.port}...`,
-              });
+                  : `Connecting WebSocket to port ${creds.port}...`
+              );
 
-              Promise.all([
-                this.bridge.listenLcuEvent((event) =>
-                  this.wsEvents$.next(event)
-                ),
-                this.bridge.listenLcuDisconnect((event) => {
-                  debugInput$.next({
-                    source: "websocket",
-                    summary: `WebSocket disconnected: ${event.reason}`,
-                  });
+              // Register IPC listeners synchronously — unlisten functions are
+              // available immediately, so cleanup works even if stop() is called
+              // before the WebSocket finishes connecting (React StrictMode remount).
+              const unlisten = this.bridge.listenLcuEvent((event) =>
+                this.wsEvents$.next(event)
+              );
+              const unlistenDisconnect = this.bridge.listenLcuDisconnect(
+                (event) => {
+                  engineLog.warn(`WebSocket disconnected: ${event.reason}`);
                   this.wsRetrySeq++;
-                }),
-                this.bridge.connectLcuWebSocket(creds.port, creds.token),
-              ])
-                .then(([ul, uld]) => {
-                  unlisten = ul;
-                  unlistenDisconnect = uld;
+                }
+              );
 
-                  debugInput$.next({
-                    source: "websocket",
-                    summary: "WebSocket connected and subscribed",
-                  });
-
-                  // Fetch current phase via REST so we don't miss state
-                  // if the app started after a phase transition already happened
+              this.bridge
+                .connectLcuWebSocket(creds.port, creds.token)
+                .then(() => {
+                  engineLog.info("WebSocket connected and subscribed");
                   this.fetchInitialState(creds.port, creds.token);
                 })
                 .catch((err) => {
-                  debugInput$.next({
-                    source: "websocket",
-                    summary: `WebSocket connection FAILED: ${err instanceof Error ? err.message : String(err)}`,
-                  });
-                  // Bump retry seq so the next discovery tick re-emits
-                  // and triggers a new connection attempt
+                  engineLog.error(
+                    `WebSocket connection FAILED: ${err instanceof Error ? err.message : String(err)}`
+                  );
                   this.wsRetrySeq++;
                 });
 
               return () => {
-                unlisten?.();
-                unlistenDisconnect?.();
+                unlisten();
+                unlistenDisconnect();
               };
             });
           })
@@ -254,10 +241,7 @@ export class ReactiveEngine {
     this.subscription.add(
       this.wsEvents$.subscribe((evt) => {
         if (isDebugWorthy(evt.uri) && shouldLogWebSocketEvent(evt.uri)) {
-          debugInput$.next({
-            source: "websocket",
-            summary: describeEvent(evt.event_type, evt.uri),
-          });
+          engineLog.debug(describeEvent(evt.event_type, evt.uri));
         }
       })
     );
@@ -438,10 +422,7 @@ export class ReactiveEngine {
       .fetchLcu(port, token, "/lol-gameflow/v1/gameflow-phase")
       .then((json) => {
         const phase = JSON.parse(json) as string;
-        debugInput$.next({
-          source: "initial-state",
-          summary: `Phase: ${phase}`,
-        });
+        engineLog.debug(`Initial phase: ${phase}`);
         if (phase && phase !== "None") {
           this.wsEvents$.next({
             uri: "/lol-gameflow/v1/gameflow-phase",
@@ -451,10 +432,9 @@ export class ReactiveEngine {
         }
       })
       .catch((err) => {
-        debugInput$.next({
-          source: "initial-state",
-          summary: `Phase fetch failed: ${err instanceof Error ? err.message : String(err)}`,
-        });
+        engineLog.warn(
+          `Initial phase fetch failed: ${err instanceof Error ? err.message : String(err)}`
+        );
       });
 
     // Fetch current session
@@ -462,11 +442,7 @@ export class ReactiveEngine {
       .fetchLcu(port, token, "/lol-gameflow/v1/session")
       .then((json) => {
         const session: unknown = JSON.parse(json);
-        debugInput$.next({
-          source: "initial-state",
-          summary: "Session fetched",
-          detail: JSON.stringify(session, null, 2),
-        });
+        engineLog.debug("Initial session fetched");
         this.wsEvents$.next({
           uri: "/lol-gameflow/v1/session",
           event_type: "Update",
@@ -474,10 +450,7 @@ export class ReactiveEngine {
         });
       })
       .catch(() => {
-        debugInput$.next({
-          source: "initial-state",
-          summary: "Session not available",
-        });
+        engineLog.debug("Initial session not available");
       });
   }
 
@@ -511,10 +484,7 @@ export class ReactiveEngine {
               const normalized = normalizeGameState(raw);
               const status = `OK — ${normalized.gameMode} ${formatGameTime(normalized.gameTime)} ${normalized.players.length}p`;
               if (shouldLogPollStatus("OK", this.lastPollStatus)) {
-                debugInput$.next({
-                  source: "riot-api",
-                  summary: `Poll ${status}`,
-                });
+                engineLog.debug(`Poll ${status}`);
               }
               this.lastPollStatus = "OK";
               return { success: true as const, data: normalized };
@@ -525,10 +495,7 @@ export class ReactiveEngine {
                 ? "LOADING"
                 : "CONNECTION_FAILED";
               if (shouldLogPollStatus(status, this.lastPollStatus)) {
-                debugInput$.next({
-                  source: "riot-api",
-                  summary: `Poll failed — ${errMsg}`,
-                });
+                engineLog.warn(`Poll failed — ${errMsg}`);
               }
               this.lastPollStatus = status;
               return { success: false as const, data: null };

--- a/src/lib/reactive/gep-bridge.ts
+++ b/src/lib/reactive/gep-bridge.ts
@@ -10,7 +10,9 @@
 
 import { Subject, Subscription } from "rxjs";
 import { distinctUntilChanged } from "rxjs/operators";
-import { debugInput$ } from "./streams";
+import { getLogger } from "../logger";
+
+const gepLog = getLogger("gep");
 
 export interface GepAugmentOfferPayload {
   augment_1: { name: string };
@@ -72,17 +74,10 @@ export function initGepBridge(): () => void {
     distinctUntilChanged((a, b) => JSON.stringify(a) === JSON.stringify(b))
   );
 
-  // Log and process deduplicated info updates
+  // Process deduplicated info updates
   subs.add(
     dedupedInfo$.subscribe((payload) => {
-      const timestamp = new Date().toISOString();
-      api
-        .invoke(
-          "append_gep_log",
-          `[${timestamp}] [info] ${JSON.stringify(payload)}`
-        )
-        .catch(() => {});
-
+      gepLog.trace("GEP info update", payload);
       gepInfoUpdate$.next(payload);
 
       const update = payload as {
@@ -107,17 +102,10 @@ export function initGepBridge(): () => void {
             augments.augment_3?.name,
           ].filter(Boolean);
 
-          debugInput$.next({
-            source: "gep",
-            summary: `Augment offer: ${names.join(", ")}`,
-          });
-
+          gepLog.info(`Augment offer: ${names.join(", ")}`);
           augmentOffer$.next(names);
         } catch (err) {
-          debugInput$.next({
-            source: "gep",
-            summary: `Failed to parse augment offer: ${err}`,
-          });
+          gepLog.error(`Failed to parse augment offer: ${err}`);
         }
       }
 
@@ -125,28 +113,17 @@ export function initGepBridge(): () => void {
       if (update.feature === "augments" && update.key === "picked_augment") {
         const name = String(update.value ?? "").trim();
         if (name) {
-          debugInput$.next({
-            source: "gep",
-            summary: `Augment picked: ${name}`,
-          });
-
+          gepLog.info(`Augment picked: ${name}`);
           augmentPicked$.next(name);
         }
       }
     })
   );
 
-  // Log and forward deduplicated game events
+  // Forward deduplicated game events
   subs.add(
     dedupedEvent$.subscribe((payload) => {
-      const timestamp = new Date().toISOString();
-      api
-        .invoke(
-          "append_gep_log",
-          `[${timestamp}] [event] ${JSON.stringify(payload)}`
-        )
-        .catch(() => {});
-
+      gepLog.trace("GEP game event", payload);
       gepGameEvent$.next(payload);
     })
   );
@@ -157,10 +134,7 @@ export function initGepBridge(): () => void {
     rawEvent$.next(payload)
   );
 
-  debugInput$.next({
-    source: "gep",
-    summary: "GEP bridge initialized — listening for augment events",
-  });
+  gepLog.info("GEP bridge initialized — listening for augment events");
 
   return () => {
     bridgeActive = false;

--- a/src/lib/reactive/platform-bridge.ts
+++ b/src/lib/reactive/platform-bridge.ts
@@ -32,12 +32,10 @@ export interface PlatformBridge {
   connectLcuWebSocket(port: number, token: string): Promise<void>;
 
   /** Listen for LCU WebSocket events. Returns an unlisten function. */
-  listenLcuEvent(
-    handler: (event: LcuEventPayload) => void
-  ): Promise<() => void>;
+  listenLcuEvent(handler: (event: LcuEventPayload) => void): () => void;
 
   /** Listen for LCU WebSocket disconnects. Returns an unlisten function. */
   listenLcuDisconnect(
     handler: (event: LcuDisconnectPayload) => void
-  ): Promise<() => void>;
+  ): () => void;
 }

--- a/src/test/setup.ts
+++ b/src/test/setup.ts
@@ -1,1 +1,27 @@
 import "@testing-library/jest-dom/vitest";
+import { vi } from "vitest";
+
+// Mock electron-log/renderer for all tests — it requires Electron IPC
+// which isn't available in the jsdom test environment.
+vi.mock("electron-log/renderer", () => {
+  const noop = () => {};
+  const scopedLogger = {
+    error: noop,
+    warn: noop,
+    info: noop,
+    verbose: noop,
+    debug: noop,
+    silly: noop,
+  };
+  return {
+    default: {
+      scope: () => scopedLogger,
+      error: noop,
+      warn: noop,
+      info: noop,
+      verbose: noop,
+      debug: noop,
+      silly: noop,
+    },
+  };
+});


### PR DESCRIPTION
## Summary

- Implements structured logging using electron-log with NDJSON file output, module-scoped loggers, and a File menu for log level control
- Migrates all 36 `debugInput$.next()` calls and 25 `console.*` calls to typed scoped loggers; removes ad-hoc coaching/GEP log files
- Reworks debug panel to single-column app observables view with improved summarizers (champion names in champ select, richer EOG/lobby info, consecutive dedup)
- Fixes race condition where `listenLcuEvent`/`listenLcuDisconnect` async interface caused leaked IPC listeners on React StrictMode remount — now synchronous
- Adds champion ID reverse-lookup map for resolving LCU numeric IDs to display names
- Documents champ select session payload structure in technical reference

Closes #53

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Log level selector in the app menu with persistent setting (defaults to info).
  * "Open Log Folder" action for quick access to logs.
  * Unified, structured logging across main and renderer processes.

* **Documentation**
  * Added Champ Select (LCU) technical reference.
  * Added comprehensive logging design/specification.

* **Chores**
  * Daily log rotation with automatic pruning of files older than 5 days.
  * Simplified debug panel UI; removed expandable detailed entries and related debug styling.

* **Bug Fixes**
  * Prevent duplicate augment selections in the augment picker.

* **Tests**
  * Tests updated to stub logging for consistent test runs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->