### PR TITLE
fix: suppress WebSocket noise — EPIPE, CloseEvent dumps, reply-never-sent (#74)

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -20,6 +20,21 @@ import {
 
 const app = electronApp;
 
+// Intercept console.log to suppress raw CloseEvent dumps from the ws library.
+// Something in the ws/Node internals prints "Received on close: CloseEvent {...}"
+// which produces walls of unreadable output. We filter those out.
+const originalConsoleLog = console.log;
+console.log = (...args: unknown[]) => {
+  if (
+    args.length > 0 &&
+    typeof args[0] === "string" &&
+    args[0].startsWith("Received on close")
+  ) {
+    return;
+  }
+  originalConsoleLog.apply(console, args);
+};
+
 // ow-electron detection — when running under ow-electron, the app object
 // has an `overwolf` property with packages (overlay, gep). We don't need
 // to require anything — the runtime injects it onto the app object.
@@ -76,18 +91,32 @@ function lcuBasicAuth(token: string): string {
 // ---------------------------------------------------------------------------
 
 let activeWs: WebSocket | null = null;
+let activeWsReject: ((err: Error) => void) | null = null;
+let shuttingDown = false;
 
 function cleanupWebSocket(): void {
   if (!activeWs) return;
 
   const ws = activeWs;
+  const pendingReject = activeWsReject;
   activeWs = null;
+  activeWsReject = null;
+
+  // Remove all listeners BEFORE closing to prevent close/error handlers
+  // from firing during teardown (which causes EPIPE and CloseEvent dumps)
   ws.removeAllListeners();
 
-  if (ws.readyState === WebSocket.CONNECTING) {
+  // Reject any pending connection promise so Electron doesn't warn
+  // "reply was never sent"
+  if (pendingReject) {
+    pendingReject(new Error("WebSocket cleanup — connection aborted"));
+  }
+
+  if (
+    ws.readyState === WebSocket.CONNECTING ||
+    ws.readyState === WebSocket.OPEN
+  ) {
     ws.terminate();
-  } else if (ws.readyState === WebSocket.OPEN) {
-    ws.close();
   }
 }
 
@@ -210,15 +239,25 @@ function registerIpcHandlers(): void {
         headers: { Authorization: lcuBasicAuth(token) },
         rejectUnauthorized: false,
       });
-      // Suppress ws library's default onclose/onerror console logging
-      (ws as any).onclose = null;
-      (ws as any).onerror = null;
       activeWs = ws;
 
       return new Promise<void>((resolve, reject) => {
+        let settled = false;
+        const settle = (fn: () => void) => {
+          if (settled) return;
+          settled = true;
+          fn();
+        };
+
+        // Track reject so cleanupWebSocket() can settle the Promise
+        activeWsReject = (err: Error) => settle(() => reject(err));
+
         ws.on("open", () => {
-          ws.send(JSON.stringify([5, "OnJsonApiEvent"]));
-          resolve();
+          settle(() => {
+            activeWsReject = null;
+            ws.send(JSON.stringify([5, "OnJsonApiEvent"]));
+            resolve();
+          });
         });
 
         ws.on("message", (raw: Buffer) => {
@@ -231,38 +270,43 @@ function registerIpcHandlers(): void {
               eventType: string;
               data: unknown;
             };
-            sendToAllWindows("lcu-event", {
-              uri: payload.uri ?? "",
-              event_type: payload.eventType ?? "",
-              data: payload.data ?? null,
-            });
+            if (!shuttingDown) {
+              sendToAllWindows("lcu-event", {
+                uri: payload.uri ?? "",
+                event_type: payload.eventType ?? "",
+                data: payload.data ?? null,
+              });
+            }
           } catch {
             // Non-JSON message
           }
         });
 
-        ws.on("close", (_code: number, _reason: Buffer) => {
-          try {
+        ws.on("close", () => {
+          // Settle with rejection if the Promise is still pending
+          // (connection dropped before open fired)
+          settle(() =>
+            reject(new Error("WebSocket closed before connection completed"))
+          );
+
+          if (!shuttingDown) {
             sendToAllWindows("lcu-disconnect", {
               reason: "Server closed connection",
             });
-          } catch {
-            // Ignore — app may be shutting down
           }
           activeWs = null;
+          activeWsReject = null;
         });
 
         ws.on("error", (err: Error) => {
-          try {
-            if (ws.readyState === WebSocket.CONNECTING) {
-              reject(new Error(`WebSocket connection failed: ${err.message}`));
-            } else {
-              sendToAllWindows("lcu-disconnect", {
-                reason: `WebSocket error: ${err.message}`,
-              });
-            }
-          } catch {
-            // Ignore — app may be shutting down
+          settle(() =>
+            reject(new Error(`WebSocket connection failed: ${err.message}`))
+          );
+
+          if (!shuttingDown) {
+            sendToAllWindows("lcu-disconnect", {
+              reason: `WebSocket error: ${err.message}`,
+            });
           }
           activeWs = null;
         });
@@ -763,16 +807,25 @@ app.whenReady().then(() => {
 });
 
 app.on("window-all-closed", () => {
+  shuttingDown = true;
   cleanupWebSocket();
   if (process.platform !== "darwin") {
     app.quit();
   }
 });
 
-// Suppress EPIPE errors during shutdown — the WebSocket may try to
-// write to a broken pipe as the app is closing.
+app.on("before-quit", () => {
+  shuttingDown = true;
+  cleanupWebSocket();
+});
+
+// Suppress EPIPE and other pipe errors during shutdown.
+// ow-electron may show an error dialog for uncaught exceptions —
+// this handler prevents EPIPE from reaching that dialog.
 process.on("uncaughtException", (err) => {
+  if (shuttingDown) return;
   if (err.message?.includes("EPIPE")) return;
+  if (err.message?.includes("broken pipe")) return;
   appLog.error("Uncaught exception:", err.message);
 });
 process.stdout?.on?.("error", () => {});

--- a/scripts/launch-electron.sh
+++ b/scripts/launch-electron.sh
@@ -18,4 +18,7 @@ while ! curl -s http://localhost:1420 > /dev/null 2>&1; do
 done
 echo "[launch-electron] Vite is ready. Launching Electron..."
 
+# Change to a Windows-compatible directory before running powershell.exe to avoid UNC path warnings
+# and use double quotes for the PowerShell command to handle paths correctly.
+cd /mnt/c
 powershell.exe -ExecutionPolicy Bypass -Command "\$env:VITE_DEV_SERVER_URL='http://localhost:1420'; ow-electron '${PROJECT_WIN}'"

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -207,8 +207,14 @@ export class ReactiveEngine {
               const unlisten = this.bridge.listenLcuEvent((event) =>
                 this.wsEvents$.next(event)
               );
+              // Track whether this connection attempt already failed
+              // to avoid double-logging (error + close both fire on failure)
+              let failed = false;
+
               const unlistenDisconnect = this.bridge.listenLcuDisconnect(
                 (event) => {
+                  if (failed) return;
+                  failed = true;
                   engineLog.warn(`WebSocket disconnected: ${event.reason}`);
                   this.wsRetrySeq++;
                 }
@@ -221,8 +227,10 @@ export class ReactiveEngine {
                   this.fetchInitialState(creds.port, creds.token);
                 })
                 .catch((err) => {
-                  engineLog.error(
-                    `WebSocket connection FAILED: ${err instanceof Error ? err.message : String(err)}`
+                  if (failed) return;
+                  failed = true;
+                  engineLog.warn(
+                    `WebSocket connection failed: ${err instanceof Error ? err.message : String(err)}`
                   );
                   this.wsRetrySeq++;
                 });


### PR DESCRIPTION
Closes #74

## Summary

- Intercept `console.log` to filter out raw `CloseEvent` object dumps from ws library internals ("Received on close: CloseEvent {...}")
- Shutdown flag (`shuttingDown`) prevents all WebSocket I/O (logging, `sendToAllWindows`) during app teardown — eliminates EPIPE broken pipe errors
- WebSocket Promise always settles via `settled` guard — `open` resolves, `close`/`error`/`cleanup` all reject, double-fires are no-ops. Eliminates "reply was never sent" warnings
- Deduplicate retry logging — each failed connection attempt produces one log line instead of three (error + close + catch all fired per failure, now guarded by `failed` flag)
- `cleanupWebSocket()` removes all listeners before terminating and rejects any pending connection Promise
- `before-quit` handler sets shutdown flag early