### PR TITLE
refactor: extract mode filter functions into shared utils module

### DIFF
--- a/src/lib/mode/aram-mayhem.ts
+++ b/src/lib/mode/aram-mayhem.ts
@@ -1,6 +1,5 @@
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
-import type { Augment, Item } from "../data-ingest/types";
 import type {
   GameMode,
   ModeContext,
@@ -8,6 +7,7 @@ import type {
   TeamComposition,
 } from "./types";
 import { GAME_MODE_MAYHEM, GAME_MODE_ARAM } from "./types";
+import { filterItemsByMode, filterAugmentsByMode } from "./utils";
 
 export const aramMayhemMode: GameMode = {
   id: "aram-mayhem",
@@ -62,28 +62,6 @@ export const aramMayhemMode: GameMode = {
     };
   },
 };
-
-function filterItemsByMode(
-  items: Map<number, Item>,
-  mode: string
-): Map<number, Item> {
-  const filtered = new Map<number, Item>();
-  for (const [id, item] of items) {
-    if (item.mode === mode) filtered.set(id, item);
-  }
-  return filtered;
-}
-
-function filterAugmentsByMode(
-  augments: Map<string, Augment>,
-  mode: string
-): Map<string, Augment> {
-  const filtered = new Map<string, Augment>();
-  for (const [key, augment] of augments) {
-    if (augment.mode === mode) filtered.set(key, augment);
-  }
-  return filtered;
-}
 
 function buildTeamComposition(players: PlayerModeContext[]): TeamComposition {
   const classCounts: Record<string, number> = {};

--- a/src/lib/mode/utils.test.ts
+++ b/src/lib/mode/utils.test.ts
@@ -1,0 +1,117 @@
+import { describe, it, expect } from "vitest";
+import { filterItemsByMode, filterAugmentsByMode } from "./utils";
+import type { Augment, Item } from "../data-ingest/types";
+
+function makeItem(id: number, mode: string): Item {
+  return {
+    id,
+    name: `Item ${id}`,
+    description: "",
+    plaintext: "",
+    gold: { base: 100, total: 100, sell: 70, purchasable: true },
+    tags: [],
+    stats: {},
+    image: "",
+    mode: mode as Item["mode"],
+  };
+}
+
+function makeAugment(name: string, mode: string): Augment {
+  return {
+    name,
+    description: "",
+    tier: "Silver",
+    sets: [],
+    mode: mode as Augment["mode"],
+  };
+}
+
+describe("filterItemsByMode", () => {
+  it("returns only items matching the given mode", () => {
+    const items = new Map<number, Item>([
+      [1, makeItem(1, "aram")],
+      [2, makeItem(2, "standard")],
+      [3, makeItem(3, "aram")],
+    ]);
+
+    const result = filterItemsByMode(items, "aram");
+
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(3)).toBe(true);
+    expect(result.has(2)).toBe(false);
+  });
+
+  it("returns empty map when no items match", () => {
+    const items = new Map<number, Item>([[1, makeItem(1, "standard")]]);
+
+    const result = filterItemsByMode(items, "arena");
+
+    expect(result.size).toBe(0);
+  });
+
+  it("works with arena mode", () => {
+    const items = new Map<number, Item>([
+      [1, makeItem(1, "arena")],
+      [2, makeItem(2, "aram")],
+      [3, makeItem(3, "arena")],
+    ]);
+
+    const result = filterItemsByMode(items, "arena");
+
+    expect(result.size).toBe(2);
+    expect(result.has(1)).toBe(true);
+    expect(result.has(3)).toBe(true);
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = filterItemsByMode(new Map(), "aram");
+    expect(result.size).toBe(0);
+  });
+});
+
+describe("filterAugmentsByMode", () => {
+  it("returns only augments matching the given mode", () => {
+    const augments = new Map<string, Augment>([
+      ["a", makeAugment("Typhoon", "mayhem")],
+      ["b", makeAugment("Blade Waltz", "arena")],
+      ["c", makeAugment("Storm", "mayhem")],
+    ]);
+
+    const result = filterAugmentsByMode(augments, "mayhem");
+
+    expect(result.size).toBe(2);
+    expect(result.has("a")).toBe(true);
+    expect(result.has("c")).toBe(true);
+    expect(result.has("b")).toBe(false);
+  });
+
+  it("returns empty map when no augments match", () => {
+    const augments = new Map<string, Augment>([
+      ["a", makeAugment("Typhoon", "mayhem")],
+    ]);
+
+    const result = filterAugmentsByMode(augments, "arena");
+
+    expect(result.size).toBe(0);
+  });
+
+  it("works with arena mode", () => {
+    const augments = new Map<string, Augment>([
+      ["a", makeAugment("Blade Waltz", "arena")],
+      ["b", makeAugment("Typhoon", "mayhem")],
+      ["c", makeAugment("Shield Bash", "arena")],
+    ]);
+
+    const result = filterAugmentsByMode(augments, "arena");
+
+    expect(result.size).toBe(2);
+    expect(result.has("a")).toBe(true);
+    expect(result.has("c")).toBe(true);
+  });
+
+  it("returns empty map for empty input", () => {
+    const result = filterAugmentsByMode(new Map(), "mayhem");
+    expect(result.size).toBe(0);
+  });
+});

--- a/src/lib/mode/utils.ts
+++ b/src/lib/mode/utils.ts
@@ -1,0 +1,23 @@
+import type { Augment, Item } from "../data-ingest/types";
+
+export function filterItemsByMode(
+  items: Map<number, Item>,
+  mode: string
+): Map<number, Item> {
+  const filtered = new Map<number, Item>();
+  for (const [id, item] of items) {
+    if (item.mode === mode) filtered.set(id, item);
+  }
+  return filtered;
+}
+
+export function filterAugmentsByMode(
+  augments: Map<string, Augment>,
+  mode: string
+): Map<string, Augment> {
+  const filtered = new Map<string, Augment>();
+  for (const [key, augment] of augments) {
+    if (augment.mode === mode) filtered.set(key, augment);
+  }
+  return filtered;
+}


### PR DESCRIPTION
## Summary                                                                                                                                                                                                                                   
   - Moved `filterItemsByMode()` and `filterAugmentsByMode()` from `aram-mayhem.ts` into `src/lib/mode/utils.ts` so any future mode implementation can reuse them                                                                               
   - Updated `aram-mayhem.ts` to import from the shared module — no behavior change                                                                                                                                                             
   - Added 8 tests covering both functions across multiple mode strings (aram, arena, mayhem) and empty-input edge cases                                                                                                                        
                                                                                                                                                                                                                                                
   Closes #72 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive test coverage for mode-filtering utilities to ensure correct behavior.

* **Refactor**
  * Reorganized mode-filtering logic into a dedicated utility module for improved code maintainability and reduced duplication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->