### PR TITLE
feat: background data refresh with cache-first launch

### DIFF
--- a/docs/plans/2026-04-01-background-data-refresh-design.md
+++ b/docs/plans/2026-04-01-background-data-refresh-design.md
@@ -18,7 +18,7 @@ On launch, the app serves data instantly from localStorage cache. In the backgro
 **New functions:**
 
 - `loadCachedGameData(): Promise<LoadedGameData | null>` — reads from cache only, returns null on miss. This is the "instant serve" path.
-- `checkForNewVersion(cachedVersion: string): Promise<boolean>` — calls `fetchLatestVersion()` and compares against the cached version. Returns `true` if they differ, or if the check fails (treat errors as "might be new" so we don't block refresh on transient failures).
+- `checkForNewVersion(cachedVersion: string): Promise<boolean>` — calls `fetchLatestVersion()` and compares against the cached version. Returns `true` if they differ. Returns `false` on failure — don't trigger a full fetch across all data sources on a transient error. Users can force-refresh manually.
 
 **Modified:**
 

--- a/docs/plans/2026-04-01-background-data-refresh-design.md
+++ b/docs/plans/2026-04-01-background-data-refresh-design.md
@@ -1,0 +1,142 @@
+# Background Data Refresh on Launch
+
+**Issue:** #75  
+**Date:** 2026-04-01
+
+## Problem
+
+The app fetches game data from free community resources (Data Dragon, League Wiki, Community Dragon). If the app scales to many concurrent users, every client fetching on every launch would overwhelm these sources — especially on patch day when thousands of clients launch simultaneously.
+
+## Design
+
+### Cache-first with smart version check
+
+On launch, the app serves data instantly from localStorage cache. In the background, it checks whether a new patch version exists. Only when the version has changed does it fetch fresh data — with a random jitter delay to spread load across time.
+
+### Data Ingest Layer (`src/lib/data-ingest/index.ts`)
+
+**New functions:**
+
+- `loadCachedGameData(): Promise<LoadedGameData | null>` — reads from cache only, returns null on miss. This is the "instant serve" path.
+- `checkForNewVersion(cachedVersion: string): Promise<boolean>` — calls `fetchLatestVersion()` and compares against the cached version. Returns `true` if they differ, or if the check fails (treat errors as "might be new" so we don't block refresh on transient failures).
+
+**Modified:**
+
+- `CachedGameData` gains a `lastRefreshedAt: number` field (epoch ms timestamp), written by `fetchAndCache()`.
+- `fetchAndCache()` stays as-is but writes `lastRefreshedAt: Date.now()` into the cached data.
+- `loadGameData()` behavior unchanged (still the entry point for dev mode and cold-cache fallback).
+
+### Hook Orchestration (`src/hooks/useGameData.ts`)
+
+The hook drives the two-phase load:
+
+**Warm cache (production, common case):**
+
+1. `loadCachedGameData()` → cache hit → `setData(cached)` immediately (no loading spinner)
+2. `checkForNewVersion(cached.version)` → push "checking for updates" notification
+3. Version matches → push "data is current" notification (silent/logged only), done
+4. Version differs → random jitter delay (0–300 seconds), then `fetchAndCache()`, push "updating" notification
+5. Success → `setData(newData)`, push "updated to patch X.Y" notification
+6. Failure → push error notification, keep serving cached data
+
+**Cold cache (first launch):**
+
+1. `loadCachedGameData()` returns null
+2. Show loading state, call `fetchAndCache()` directly (no jitter — nothing to serve yet)
+3. `setData(result)`
+
+**Dev mode:**
+
+- Unchanged: skip cache, call `fetchAndCache()` directly, no version check, no jitter.
+
+**Manual refresh button:**
+
+- Runs `checkForNewVersion()` first (no jitter). If current, pushes "already up to date" notification without fetching. If stale, calls `fetchAndCache()` and updates data.
+
+### Jitter
+
+When a version mismatch is detected during the automatic launch check, the background fetch is delayed by a random duration between 0 and 300 seconds. This spreads load across ~5 minutes when many clients detect a new patch simultaneously.
+
+Jitter applies only to the automatic launch refresh, not to manual refresh.
+
+### Notifications
+
+Refresh status flows through the existing `notifications$` stream (`AppNotification` in `src/lib/reactive/types.ts`). No new RxJS subjects.
+
+Notification messages:
+
+- `{ level: "info", message: "Checking for updates..." }`
+- `{ level: "info", message: "Updating to patch X.Y..." }`
+- `{ level: "success", message: "Updated to patch X.Y" }`
+- `{ level: "info", message: "Data is current" }` (logged only, no UI)
+- `{ level: "error", message: "Update check failed — using cached data" }`
+
+**Note:** `AppNotification.level` needs `"success"` added to its union type.
+
+### Hook Internal State
+
+The hook tracks refresh phase with local React state (not an observable) to drive button text:
+
+- `refreshState: "idle" | "checking" | "refreshing"`
+- Button text: "Refresh" / "Checking..." / "Updating..."
+- Button disabled during checking/refreshing
+
+### UI Changes (`src/App.tsx`)
+
+The existing refresh button adapts:
+
+- During version check: disabled, text "Checking..."
+- During background fetch: disabled, text "Updating..."
+- After update: version string updates in place (already happens via `data.version` re-render)
+- Notifications surface through whatever notification UI exists or is built later
+
+### Data Flow to LLM Context
+
+When `setData(newData)` is called after a background refresh, React re-renders `App` with the new `data` reference. All downstream consumers update automatically:
+
+- `effectiveState` useMemo recomputes (has `data` in deps)
+- `DataBrowser` receives new `data` prop
+- `assembleContext()` is called with the current `data` at request time
+
+Any coaching request made after the refresh completes uses the fresh data. An in-flight request uses the data it was assembled with, which is acceptable.
+
+## Testing
+
+### `src/lib/data-ingest/index.test.ts` (extend)
+
+- `loadCachedGameData()` returns data when cache hit
+- `loadCachedGameData()` returns null when cache miss
+- `checkForNewVersion()` returns false when versions match
+- `checkForNewVersion()` returns true when versions differ
+- `checkForNewVersion()` returns true when fetch fails (safe fallback)
+- `lastRefreshedAt` is written by `fetchAndCache()`
+
+### `src/hooks/useGameData.test.ts` (new)
+
+Mock `loadCachedGameData`, `checkForNewVersion`, `fetchAndCache` at the module boundary.
+
+- Warm cache: sets data immediately, then kicks off version check
+- Cold cache: shows loading state, fetches, sets data
+- Version match: no fetch triggered after check
+- Version mismatch: `fetchAndCache()` called after jitter
+- Manual refresh with current version: no fetch, "already up to date" notification
+- Manual refresh with stale version: fetches and updates data
+- Background fetch failure: cached data preserved, error notification pushed
+- Jitter is within 0–300s bounds (test range, not exact value)
+
+## Files Changed
+
+**Modified:**
+
+- `src/lib/data-ingest/index.ts` — add `loadCachedGameData()`, `checkForNewVersion()`, `lastRefreshedAt`
+- `src/lib/data-ingest/cache.ts` — update comment (still references Tauri)
+- `src/lib/reactive/types.ts` — add `"success"` to `AppNotification.level`
+- `src/hooks/useGameData.ts` — two-phase load, version check, jitter, notifications
+- `src/App.tsx` — refresh button reflects richer status states
+- `src/lib/data-ingest/index.test.ts` — tests for new functions
+
+**Added:**
+
+- `src/hooks/useGameData.test.ts`
+
+No new dependencies. No new RxJS streams.

--- a/scripts/launch-electron.sh
+++ b/scripts/launch-electron.sh
@@ -21,4 +21,4 @@ echo "[launch-electron] Vite is ready. Launching Electron..."
 # Change to a Windows-compatible directory before running powershell.exe to avoid UNC path warnings
 # and use double quotes for the PowerShell command to handle paths correctly.
 cd /mnt/c
-powershell.exe -ExecutionPolicy Bypass -Command "\$env:VITE_DEV_SERVER_URL='http://localhost:1420'; ow-electron '${PROJECT_WIN}'"
+powershell.exe -ExecutionPolicy Bypass -Command "\$env:VITE_DEV_SERVER_URL='http://localhost:1420'; ow-electron \"${PROJECT_WIN}\""

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -57,7 +57,7 @@ function App() {
     };
   }, []);
 
-  const { data, loading, error, refresh } = useGameData();
+  const { data, loading, error, refreshState, refresh } = useGameData();
   const lifecycle = useGameLifecycle();
   const liveGame = useLiveGameState();
   const { submit } = useUserInput();
@@ -207,10 +207,17 @@ function App() {
           {data && (
             <button
               className="refresh-btn"
-              onClick={refresh}
-              disabled={loading}
+              onClick={(e) => refresh(e.ctrlKey || e.metaKey)}
+              disabled={loading || refreshState !== "idle"}
+              title="Ctrl+click to force refresh"
             >
-              {loading ? "Loading..." : "Refresh"}
+              {refreshState === "checking"
+                ? "Checking..."
+                : refreshState === "refreshing"
+                  ? "Updating..."
+                  : loading
+                    ? "Loading..."
+                    : "Refresh"}
             </button>
           )}
         </div>

--- a/src/hooks/useGameData.test.ts
+++ b/src/hooks/useGameData.test.ts
@@ -1,0 +1,307 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act, waitFor } from "@testing-library/react";
+import { useGameData } from "./useGameData";
+import * as dataIngest from "../lib/data-ingest";
+import { notifications$ } from "../lib/reactive";
+import type { AppNotification } from "../lib/reactive";
+import type { LoadedGameData } from "../lib/data-ingest";
+
+vi.mock("../lib/data-ingest", () => ({
+  loadCachedGameData: vi.fn(),
+  checkForNewVersion: vi.fn(),
+  fetchAndCache: vi.fn(),
+  loadGameData: vi.fn(),
+}));
+
+vi.mock("../lib/data-ingest/champion-id-map", () => ({
+  populateChampionIdMap: vi.fn(),
+}));
+
+vi.mock("../lib/logger", () => ({
+  getLogger: () => ({
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }),
+}));
+
+function createMockGameData(version = "15.6.1"): LoadedGameData {
+  return {
+    version,
+    champions: new Map(),
+    items: new Map(),
+    runes: [],
+    augments: new Map(),
+    augmentSets: [],
+    dictionary: {
+      allNames: [],
+      champions: [],
+      items: [],
+      augments: [],
+      search: () => [],
+      findInText: () => [],
+    },
+  };
+}
+
+let capturedNotifications: AppNotification[];
+let notificationSub: { unsubscribe: () => void };
+
+beforeEach(() => {
+  vi.resetAllMocks();
+  capturedNotifications = [];
+  notificationSub = notifications$.subscribe((n) =>
+    capturedNotifications.push(n)
+  );
+
+  // Default: production mode, zero jitter for deterministic tests
+  import.meta.env.DEV = false;
+  vi.spyOn(Math, "random").mockReturnValue(0);
+});
+
+afterEach(() => {
+  notificationSub.unsubscribe();
+  vi.restoreAllMocks();
+});
+
+describe("useGameData", () => {
+  describe("warm cache (production)", () => {
+    it("sets data immediately from cache without loading spinner", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data).not.toBeNull();
+      });
+
+      expect(result.current.data!.version).toBe("15.6.1");
+      expect(result.current.loading).toBe(false);
+    });
+
+    it("checks version after serving cached data", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(dataIngest.checkForNewVersion).toHaveBeenCalledWith("15.6.1");
+      });
+    });
+
+    it("does not fetch when version matches", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(dataIngest.checkForNewVersion).toHaveBeenCalled();
+      });
+
+      expect(dataIngest.fetchAndCache).not.toHaveBeenCalled();
+    });
+
+    it("updates data after background refresh succeeds", async () => {
+      const cached = createMockGameData("15.6.1");
+      const fresh = createMockGameData("15.7.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(true);
+      vi.mocked(dataIngest.fetchAndCache).mockResolvedValue(fresh);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data?.version).toBe("15.7.1");
+      });
+    });
+
+    it("pushes success notification after background update", async () => {
+      const cached = createMockGameData("15.6.1");
+      const fresh = createMockGameData("15.7.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(true);
+      vi.mocked(dataIngest.fetchAndCache).mockResolvedValue(fresh);
+
+      renderHook(() => useGameData());
+
+      await waitFor(() => {
+        const successNotif = capturedNotifications.find(
+          (n) => n.level === "success"
+        );
+        expect(successNotif).toBeDefined();
+        expect(successNotif!.message).toContain("15.7.1");
+      });
+    });
+
+    it("preserves cached data on background refresh failure", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(true);
+      vi.mocked(dataIngest.fetchAndCache).mockRejectedValue(
+        new Error("Network error")
+      );
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        const errorNotif = capturedNotifications.find(
+          (n) => n.level === "error"
+        );
+        expect(errorNotif).toBeDefined();
+      });
+
+      expect(result.current.data?.version).toBe("15.6.1");
+    });
+  });
+
+  describe("cold cache (first launch)", () => {
+    it("shows loading state and fetches directly", async () => {
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(null);
+      const fresh = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.fetchAndCache).mockResolvedValue(fresh);
+
+      const { result } = renderHook(() => useGameData());
+
+      // Initially loading with no data
+      expect(result.current.loading).toBe(true);
+      expect(result.current.data).toBeNull();
+
+      await waitFor(() => {
+        expect(result.current.data?.version).toBe("15.6.1");
+        expect(result.current.loading).toBe(false);
+      });
+
+      // No version check needed on cold cache
+      expect(dataIngest.checkForNewVersion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("dev mode", () => {
+    it("skips cache and fetches directly", async () => {
+      import.meta.env.DEV = true;
+      const fresh = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadGameData).mockResolvedValue(fresh);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data?.version).toBe("15.6.1");
+      });
+
+      expect(dataIngest.loadCachedGameData).not.toHaveBeenCalled();
+      expect(dataIngest.checkForNewVersion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("manual refresh", () => {
+    it("does not fetch when version is current", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data).not.toBeNull();
+      });
+
+      // Reset mocks after initial load
+      vi.mocked(dataIngest.checkForNewVersion).mockClear();
+      vi.mocked(dataIngest.fetchAndCache).mockClear();
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      await act(async () => {
+        result.current.refresh();
+      });
+
+      expect(dataIngest.checkForNewVersion).toHaveBeenCalled();
+      expect(dataIngest.fetchAndCache).not.toHaveBeenCalled();
+    });
+
+    it("fetches without jitter when version differs", async () => {
+      const cached = createMockGameData("15.6.1");
+      const fresh = createMockGameData("15.7.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data).not.toBeNull();
+      });
+
+      // Manual refresh: version now differs
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(true);
+      vi.mocked(dataIngest.fetchAndCache).mockResolvedValue(fresh);
+
+      await act(async () => {
+        result.current.refresh();
+      });
+
+      await waitFor(() => {
+        expect(dataIngest.fetchAndCache).toHaveBeenCalled();
+        expect(result.current.data?.version).toBe("15.7.1");
+      });
+    });
+
+    it("pushes 'already up to date' notification when current", async () => {
+      const cached = createMockGameData("15.6.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      const { result } = renderHook(() => useGameData());
+
+      await waitFor(() => {
+        expect(result.current.data).not.toBeNull();
+      });
+
+      capturedNotifications = [];
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(false);
+
+      await act(async () => {
+        result.current.refresh();
+      });
+
+      await waitFor(() => {
+        const infoNotif = capturedNotifications.find((n) =>
+          n.message.toLowerCase().includes("up to date")
+        );
+        expect(infoNotif).toBeDefined();
+      });
+    });
+  });
+
+  describe("jitter", () => {
+    it("applies delay within 0-300s range", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: false });
+      vi.spyOn(Math, "random").mockReturnValue(0.5); // 150s jitter
+
+      const cached = createMockGameData("15.6.1");
+      const fresh = createMockGameData("15.7.1");
+      vi.mocked(dataIngest.loadCachedGameData).mockResolvedValue(cached);
+      vi.mocked(dataIngest.checkForNewVersion).mockResolvedValue(true);
+      vi.mocked(dataIngest.fetchAndCache).mockResolvedValue(fresh);
+
+      renderHook(() => useGameData());
+
+      // Flush the async init (loadCachedGameData + checkForNewVersion)
+      await vi.advanceTimersByTimeAsync(0);
+
+      // At 149s: should not have fetched yet
+      await vi.advanceTimersByTimeAsync(149_000);
+      expect(dataIngest.fetchAndCache).not.toHaveBeenCalled();
+
+      // At 150s: should have fetched
+      await vi.advanceTimersByTimeAsync(1_000);
+      expect(dataIngest.fetchAndCache).toHaveBeenCalled();
+
+      vi.useRealTimers();
+    });
+  });
+});

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,46 +1,194 @@
-import { useState, useEffect, useCallback } from "react";
-import { loadGameData, type LoadedGameData } from "../lib/data-ingest";
+import { useState, useEffect, useCallback, useRef } from "react";
+import {
+  loadGameData,
+  loadCachedGameData,
+  checkForNewVersion,
+  fetchAndCache,
+  type LoadedGameData,
+} from "../lib/data-ingest";
 import { populateChampionIdMap } from "../lib/data-ingest/champion-id-map";
+import { notifications$ } from "../lib/reactive";
 import { getLogger } from "../lib/logger";
 
 const dataLog = getLogger("data-ingest");
 
-interface UseGameDataResult {
+const JITTER_MAX_MS = 300_000; // 5 minutes in ms
+
+let notificationId = 0;
+function notify(level: "info" | "success" | "error", message: string): void {
+  notifications$.next({
+    id: `data-refresh-${++notificationId}`,
+    level,
+    message,
+    timestamp: Date.now(),
+  });
+}
+
+export interface UseGameDataResult {
   data: LoadedGameData | null;
   loading: boolean;
   error: string | null;
-  refresh: () => void;
+  refreshState: "idle" | "checking" | "refreshing";
+  refresh: (force?: boolean) => void;
 }
 
 export function useGameData(): UseGameDataResult {
   const [data, setData] = useState<LoadedGameData | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [refreshState, setRefreshState] = useState<
+    "idle" | "checking" | "refreshing"
+  >("idle");
+  const jitterTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
-  const load = useCallback(() => {
-    setLoading(true);
-    setError(null);
-
-    loadGameData()
-      .then((result) => {
-        populateChampionIdMap(result.champions);
-        dataLog.info(
-          `Data loaded: ${result.champions.size} champions, ${result.items.size} items, ${result.augments.size} augments (v${result.version})`
-        );
-        setData(result);
-        setLoading(false);
-      })
-      .catch((err) => {
-        const msg = err instanceof Error ? err.message : String(err);
-        dataLog.error(`Data ingest failed: ${msg}`);
-        setError(msg);
-        setLoading(false);
-      });
+  const applyData = useCallback((result: LoadedGameData) => {
+    populateChampionIdMap(result.champions);
+    dataLog.info(
+      `Data loaded: ${result.champions.size} champions, ${result.items.size} items, ${result.augments.size} augments (v${result.version})`
+    );
+    setData(result);
   }, []);
 
-  useEffect(() => {
-    load();
-  }, [load]);
+  // Background refresh: check version, fetch if needed (with optional jitter)
+  const backgroundRefresh = useCallback(
+    async (currentVersion: string, applyJitter: boolean) => {
+      setRefreshState("checking");
 
-  return { data, loading, error, refresh: load };
+      try {
+        const hasNewVersion = await checkForNewVersion(currentVersion);
+
+        if (!hasNewVersion) {
+          if (!applyJitter) {
+            // Manual refresh — tell the user
+            notify("info", "Data is already up to date");
+          }
+          setRefreshState("idle");
+          return;
+        }
+
+        setRefreshState("refreshing");
+        notify("info", "Updating game data...");
+
+        const doFetch = async () => {
+          try {
+            const result = await fetchAndCache();
+            applyData(result);
+            notify("success", `Updated to patch ${result.version}`);
+          } catch (err) {
+            const msg = err instanceof Error ? err.message : String(err);
+            dataLog.error(`Background refresh failed: ${msg}`);
+            notify("error", "Update check failed — using cached data");
+          } finally {
+            setRefreshState("idle");
+          }
+        };
+
+        if (applyJitter) {
+          const delayMs = Math.floor(Math.random() * JITTER_MAX_MS);
+          jitterTimerRef.current = setTimeout(doFetch, delayMs);
+        } else {
+          await doFetch();
+        }
+      } catch (err) {
+        const msg = err instanceof Error ? err.message : String(err);
+        dataLog.error(`Version check failed: ${msg}`);
+        notify("error", "Update check failed — using cached data");
+        setRefreshState("idle");
+      }
+    },
+    [applyData]
+  );
+
+  // Initial load on mount
+  useEffect(() => {
+    let cancelled = false;
+
+    async function init() {
+      // Dev mode: skip cache, fetch directly (existing behavior)
+      if (import.meta.env.DEV) {
+        try {
+          const result = await loadGameData();
+          if (!cancelled) {
+            applyData(result);
+            setLoading(false);
+          }
+        } catch (err) {
+          if (!cancelled) {
+            const msg = err instanceof Error ? err.message : String(err);
+            dataLog.error(`Data ingest failed: ${msg}`);
+            setError(msg);
+            setLoading(false);
+          }
+        }
+        return;
+      }
+
+      // Production: cache-first with background version check
+      const cached = await loadCachedGameData();
+
+      if (cancelled) return;
+
+      if (cached) {
+        // Serve cached data immediately — no loading spinner
+        applyData(cached);
+        setLoading(false);
+
+        // Background version check with jitter
+        backgroundRefresh(cached.version, true);
+      } else {
+        // Cold cache (first launch): fetch directly, no jitter
+        try {
+          const result = await fetchAndCache();
+          if (!cancelled) {
+            applyData(result);
+            setLoading(false);
+          }
+        } catch (err) {
+          if (!cancelled) {
+            const msg = err instanceof Error ? err.message : String(err);
+            dataLog.error(`Data ingest failed: ${msg}`);
+            setError(msg);
+            setLoading(false);
+          }
+        }
+      }
+    }
+
+    init();
+
+    return () => {
+      cancelled = true;
+      if (jitterTimerRef.current) {
+        clearTimeout(jitterTimerRef.current);
+      }
+    };
+  }, [applyData, backgroundRefresh]);
+
+  // Manual refresh: version check without jitter
+  // Force mode skips the version check and fetches regardless
+  const refresh = useCallback(
+    async (force = false) => {
+      if (!data) return;
+      if (force) {
+        setRefreshState("refreshing");
+        notify("info", "Force refreshing game data...");
+        try {
+          const result = await fetchAndCache();
+          applyData(result);
+          notify("success", `Refreshed to patch ${result.version}`);
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          dataLog.error(`Force refresh failed: ${msg}`);
+          notify("error", "Force refresh failed — using cached data");
+        } finally {
+          setRefreshState("idle");
+        }
+        return;
+      }
+      backgroundRefresh(data.version, false);
+    },
+    [data, applyData, backgroundRefresh]
+  );
+
+  return { data, loading, error, refreshState, refresh };
 }

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -66,10 +66,9 @@ export function useGameData(): UseGameDataResult {
           return;
         }
 
-        setRefreshState("refreshing");
-        notify("info", "Updating game data...");
-
         const doFetch = async () => {
+          setRefreshState("refreshing");
+          notify("info", "Updating game data...");
           try {
             const result = await fetchAndCache();
             applyData(result);
@@ -84,6 +83,8 @@ export function useGameData(): UseGameDataResult {
         };
 
         if (applyJitter) {
+          // Return to idle during jitter wait so the button stays enabled
+          setRefreshState("idle");
           const delayMs = Math.floor(Math.random() * JITTER_MAX_MS);
           jitterTimerRef.current = setTimeout(doFetch, delayMs);
         } else {

--- a/src/lib/data-ingest/cache.ts
+++ b/src/lib/data-ingest/cache.ts
@@ -1,5 +1,5 @@
 /**
- * Cache layer for game data. Uses localStorage in the browser (Tauri webview)
+ * Cache layer for game data. Uses localStorage in the Electron renderer
  * and falls back gracefully if unavailable.
  */
 

--- a/src/lib/data-ingest/index.test.ts
+++ b/src/lib/data-ingest/index.test.ts
@@ -305,13 +305,13 @@ describe("checkForNewVersion", () => {
     expect(result).toBe(true);
   });
 
-  it("returns true when fetch fails (safe fallback)", async () => {
+  it("returns false when fetch fails (avoid thundering herd)", async () => {
     vi.mocked(dataDragon.fetchLatestVersion).mockRejectedValue(
       new Error("Network error")
     );
 
     const result = await checkForNewVersion("15.6.1");
 
-    expect(result).toBe(true);
+    expect(result).toBe(false);
   });
 });

--- a/src/lib/data-ingest/index.test.ts
+++ b/src/lib/data-ingest/index.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { loadGameData } from "./index";
+import { loadGameData, loadCachedGameData, checkForNewVersion } from "./index";
 import * as dataDragon from "./sources/data-dragon";
 import * as wikiAugments from "./sources/wiki-augments";
 import * as arenaAugments from "./sources/wiki-arena-augments";
@@ -234,5 +234,84 @@ describe("loadGameData", () => {
     const data = await loadGameData();
     const aatrox = data.champions.get("aatrox");
     expect(aatrox!.aramOverrides).toBeUndefined();
+  });
+
+  it("writes lastRefreshedAt timestamp to cache", async () => {
+    const before = Date.now();
+    await loadGameData();
+    const after = Date.now();
+
+    const writtenData = vi.mocked(cache.writeCache).mock.calls[0][1] as {
+      lastRefreshedAt: number;
+    };
+    expect(writtenData.lastRefreshedAt).toBeGreaterThanOrEqual(before);
+    expect(writtenData.lastRefreshedAt).toBeLessThanOrEqual(after);
+  });
+});
+
+describe("loadCachedGameData", () => {
+  it("returns data when cache hit", async () => {
+    const origDev = import.meta.env.DEV;
+    import.meta.env.DEV = false;
+
+    vi.mocked(cache.readCache).mockResolvedValue({
+      version: "15.6.1",
+      champions: { aatrox: createMockChampions().get("aatrox") },
+      items: { "1001": mockItems.get(1001) },
+      runes: mockRunes,
+      augments: { typhoon: mockMayhemAugments.get("typhoon") },
+      augmentSets: [],
+      lastRefreshedAt: 1000,
+    });
+
+    const data = await loadCachedGameData();
+
+    expect(data).not.toBeNull();
+    expect(data!.version).toBe("15.6.1");
+    expect(data!.champions.size).toBe(1);
+    expect(dataDragon.fetchLatestVersion).not.toHaveBeenCalled();
+
+    import.meta.env.DEV = origDev;
+  });
+
+  it("returns null when cache miss", async () => {
+    const origDev = import.meta.env.DEV;
+    import.meta.env.DEV = false;
+
+    vi.mocked(cache.readCache).mockResolvedValue(null);
+
+    const data = await loadCachedGameData();
+
+    expect(data).toBeNull();
+
+    import.meta.env.DEV = origDev;
+  });
+});
+
+describe("checkForNewVersion", () => {
+  it("returns false when versions match", async () => {
+    vi.mocked(dataDragon.fetchLatestVersion).mockResolvedValue("15.6.1");
+
+    const result = await checkForNewVersion("15.6.1");
+
+    expect(result).toBe(false);
+  });
+
+  it("returns true when versions differ", async () => {
+    vi.mocked(dataDragon.fetchLatestVersion).mockResolvedValue("15.7.1");
+
+    const result = await checkForNewVersion("15.6.1");
+
+    expect(result).toBe(true);
+  });
+
+  it("returns true when fetch fails (safe fallback)", async () => {
+    vi.mocked(dataDragon.fetchLatestVersion).mockRejectedValue(
+      new Error("Network error")
+    );
+
+    const result = await checkForNewVersion("15.6.1");
+
+    expect(result).toBe(true);
   });
 });

--- a/src/lib/data-ingest/index.ts
+++ b/src/lib/data-ingest/index.ts
@@ -32,10 +32,30 @@ interface CachedGameData {
   runes: RuneTree[];
   augments: Record<string, Augment>;
   augmentSets: AugmentSet[];
+  lastRefreshedAt: number;
 }
 
 export interface LoadedGameData extends GameData {
   dictionary: EntityDictionary;
+}
+
+export async function loadCachedGameData(): Promise<LoadedGameData | null> {
+  const cached = await readCache<CachedGameData>(CACHE_KEY);
+  if (!cached) return null;
+  return fromCached(cached);
+}
+
+export async function checkForNewVersion(
+  cachedVersion: string
+): Promise<boolean> {
+  try {
+    const latest = await fetchLatestVersion();
+    return latest !== cachedVersion;
+  } catch {
+    // If the version check fails, assume there might be an update
+    // so we don't skip a refresh due to a transient error
+    return true;
+  }
 }
 
 export async function loadGameData(): Promise<LoadedGameData> {
@@ -100,6 +120,7 @@ export async function fetchAndCache(): Promise<LoadedGameData> {
     runes,
     augments: mapToObject(augments),
     augmentSets,
+    lastRefreshedAt: Date.now(),
   };
 
   await writeCache(CACHE_KEY, data);

--- a/src/lib/data-ingest/index.ts
+++ b/src/lib/data-ingest/index.ts
@@ -52,9 +52,10 @@ export async function checkForNewVersion(
     const latest = await fetchLatestVersion();
     return latest !== cachedVersion;
   } catch {
-    // If the version check fails, assume there might be an update
-    // so we don't skip a refresh due to a transient error
-    return true;
+    // If the version check fails, assume we're current — don't trigger
+    // a full fetch across all data sources on a transient error.
+    // Users can force-refresh manually if needed.
+    return false;
   }
 }
 

--- a/src/lib/reactive/types.ts
+++ b/src/lib/reactive/types.ts
@@ -69,7 +69,7 @@ export interface CoachingMessage {
 // Notification output (placeholder)
 export interface AppNotification {
   id: string;
-  level: "info" | "warning" | "error";
+  level: "info" | "success" | "warning" | "error";
   message: string;
   timestamp: number;
 }


### PR DESCRIPTION
## Summary
- App now serves game data instantly from localStorage cache on launch — no loading delay
- Background version check compares cached patch version against Data Dragon; only fetches when a new patch is detected
- Random jitter (0–300s) spreads background fetches across time to avoid overwhelming free data sources at scale
- Manual refresh button also runs the version check first; Ctrl+click forces a full re-fetch (dev convenience)
- Refresh status shown in header button (Checking.../Updating.../Refresh)
- Notifications pushed through existing `notifications$` stream for refresh lifecycle events
- Added `"success"` level to `AppNotification` type

Closes #6 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Background cache-first data refresh on launch with immediate cached render and optional background update.
  * Refresh button shows status (“Checking…”, “Updating…”) and supports modifier-key manual refresh.
  * “Success” notification level for completed refreshes.

* **Bug Fixes**
  * Improved error handling: preserve cached data when background checks or refreshes fail.

* **Documentation**
  * Added a design plan describing the background refresh flow and behaviors.

* **Tests**
  * New and expanded tests covering cache-hit/miss, version checks, manual refresh, jitter, and failure cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->