### PR TITLE
feat: multi-turn conversation with tiered context delivery

### DIFF
--- a/docs/plans/2026-04-04-tiered-context-design.md
+++ b/docs/plans/2026-04-04-tiered-context-design.md
@@ -15,7 +15,7 @@ Every coaching LLM call rebuilds full context from scratch: champion abilities, 
 
 Convert from single-turn `generateText()` with pasted history to a real multi-turn message array, the same architecture as ChatGPT/Claude conversations:
 
-```
+```text
 system:    coaching rules + static game data
 user:      [first question with full state snapshot]
 assistant: [response]
@@ -58,7 +58,7 @@ The system prompt tells the LLM to expect a `[Game State]` block before each que
 
 **Every message format:**
 
-```
+```text
 [Game State]
 Player Champion: Ahri (Level 12)
 KDA: 5/3/8

--- a/docs/plans/2026-04-04-tiered-context-design.md
+++ b/docs/plans/2026-04-04-tiered-context-design.md
@@ -1,0 +1,152 @@
+# Tiered Context Delivery — Design Document
+
+Issue #68. Explored 2026-04-03/04.
+
+## Problem
+
+Every coaching LLM call rebuilds full context from scratch: champion abilities, all item descriptions, enemy builds, augments, team analysis, plus conversation history flattened as text. This causes:
+
+- **Signal dilution**: the LLM wades through repeated static context to find what matters, leading to inconsistencies (e.g., double-MR recommendations without acknowledging overlap)
+- **No conversational continuity**: prior exchanges are pasted as quoted text, not real assistant messages — the LLM doesn't treat its own prior reasoning as something to be consistent with
+- **Token waste**: thousands of tokens re-sent every call, no prompt caching benefit
+- **No change awareness**: the LLM can't distinguish newly purchased items from ones held all game
+
+## Core Decision: Real Multi-Turn Conversation
+
+Convert from single-turn `generateText()` with pasted history to a real multi-turn message array, the same architecture as ChatGPT/Claude conversations:
+
+```
+system:    coaching rules + static game data
+user:      [first question with full state snapshot]
+assistant: [response]
+user:      [state update + next question]
+assistant: [response]
+...
+```
+
+The LLM sees its own prior responses as `assistant` messages and maintains coherence across the session. The message array grows over the game and is sent in full on each call. At 400k context window (GPT-5.4 mini), token budget is a non-issue for any game session length.
+
+Prompt caching benefits: the system prompt and early messages form a stable prefix that gets cache hits on subsequent calls, reducing cost and latency.
+
+## System Prompt (Set Once Per Game)
+
+Contains everything that doesn't change mid-game:
+
+**Behavioral rules:**
+
+- Coaching persona and data priority instructions
+- Item awareness rules (don't recommend owned items)
+- Gold awareness rules (NOTE: needs tweaking — separate follow-up)
+- Response format rules (concise, lead with recommendation)
+- Augment re-roll mechanics (included if mode supports augment-selection)
+- Instruction to flag concerns noticed in state updates (build gaps, missing resistances) briefly at end of responses
+
+**Static game data:**
+
+- Champion abilities and base stats
+- Rune setup
+- Game mode and balance overrides (if applicable to mode)
+- All 10 champions in the match (names, tags/roles)
+
+**Mode-awareness:** Use the `GameMode` interface to decide what to include. No hardcoded mode strings. If `mode.decisionTypes` includes `augment-selection`, include augment rules. If the mode matches ARAM, include balance overrides. Everything is driven by the mode interface.
+
+## State Updates (Per User Message)
+
+Every user turn is prefixed with a state update showing what changed since the last message. The system prompt tells the LLM to expect this format.
+
+**First message** gets a full state snapshot:
+
+```
+[Game State]
+Player Champion: Ahri (Level 3)
+KDA: 0/0/0
+Items: Doran's Ring
+Gold: 500
+Stats: 200 AP, 60 Armor, 40 MR, 30 AH, 350 MS, 1800 HP
+Augments: None
+
+Ally Team: Garen, Lux, Jinx, Thresh
+Enemy Team:
+- Zed (Level 3): 85 AD, 35 Armor, 32 MR, 340 MS, 1600 HP — Doran's Blade
+- Darius (Level 2): 70 AD, 42 Armor, 32 MR, 340 MS, 1500 HP — no items
+...
+```
+
+**Subsequent messages** get diffs:
+
+```
+[State Update]
+New items: Zhonya's Hourglass (Active: Stasis for 2.5s)
+Gold: 3200 → 800
+Level: 12 → 13
+Stats: 250 AP, 120 Armor, 40 MR, 40 AH, 350 MS, 2200 HP
+KDA: 5/2/8 → 5/3/8
+Enemy changes:
+- Garen (Level 13): 145 AD, 180 Armor, 72 MR, 370 MS, 2800 HP — Thornmail, Sunfire Aegis, Plated Steelcaps
+```
+
+**POV:** Neutral/agnostic phrasing throughout. "New items:" not "You purchased." "Enemy changes:" not "They built."
+
+**What counts as a change:** Everything — gold, level, items, KDA, enemy items/stats. Start comprehensive, optimize later if noisy.
+
+### Player Champion Stats
+
+- **Source:** Live Client Data API (`activePlayer.stats`) — exact computed values including temporary buffs, rune effects, everything
+- No calculation needed; use API values directly
+
+### Enemy Champion Stats
+
+- **Source:** Computed approximation from base stats + per-level growth + item bonuses
+- **Formula:** `stat = base + (growth × (level-1) × (0.7025 + 0.0175 × (level-1))) + Σ(item stat bonuses)`
+- **Data sources:** Champion base stats from Data Dragon (`ChampionStats`), item stats from Data Dragon (`Item.stats`), player level and items from Live Client Data API (`PlayerInfo`)
+- **Computation strategy:** Reactive — recalculate on every game state poll, store in memory. No calculation at question time.
+- **Limitations:** Won't capture temporary buffs (Baron, elixirs, ability steroids, stacking passives). Accurate for permanent build stats.
+
+### Player Item Display
+
+- Name + passives/actives only (e.g., "Zhonya's Hourglass (Active: Stasis for 2.5s)")
+- Flat stat contributions are already reflected in the computed stats — no need to repeat them
+- Descriptions needed because passives/actives affect what the LLM should recommend next
+
+## Proactive Coaching
+
+### Event-based triggers (existing)
+
+- Augment offers (GEP event) — already implemented
+- Stat anvil offers — already working via same GEP event as augments
+
+### Opportunistic coaching (new)
+
+- No new trigger infrastructure. Instead, the system prompt instructs the LLM to flag concerns it notices in state updates (build gaps, missing resistances, unused gold) briefly at the end of its response.
+- This keeps coaching intelligence in the prompt, not in trigger logic.
+- Stays within Riot compliance: build/purchase observations are allowed; tactical map actions are not.
+
+### Cancelled proactive requests
+
+- When a proactive augment/stat anvil request is cancelled (player picked before LLM responded), replace the orphaned question with a statement: "Augment selected: [X] from [X, Y, Z]"
+- Preserves the information in the conversation thread without an unanswered question
+
+## Mode-Awareness
+
+Use the `GameMode` interface throughout — no hardcoded mode checks against strings like "KIWI" or "ARAM."
+
+- `mode.decisionTypes` determines whether augment rules appear in system prompt
+- `mode.matches()` determines whether balance overrides are included
+- `filterItemsByMode()` and `filterAugmentsByMode()` filter game data appropriately
+
+Requires concrete `GameMode` implementations for at least three modes: ARAM Mayhem (existing), straight ARAM (no augments/sets, but has balance overrides), and Classic/Summoner's Rift (no augments, no balance overrides). The design must not be specific to any one mode.
+
+## Out of Scope
+
+- **Cross-game player preferences** — tracked as #82. Within-game learning happens naturally via conversation thread.
+- **Coaching tone calibration** — already improved via ranked recommendations schema (`name` + `reasoning` per recommendation). Further tweaks are prompt iteration once multi-turn is in place.
+- **Patch notes / meta context injection** — referenced in #68 acceptance criteria and #61. Separate work.
+- **Build trajectory tracking** — the multi-turn conversation should naturally improve build coherence (LLM sees its own prior recommendations). Iterate if still a problem.
+
+## Key Implementation Notes
+
+- `assembleContext()` will likely be split or replaced: static data goes into system prompt builder, state snapshots/diffs become a separate concern
+- `buildSystemPrompt()` and `buildUserPrompt()` need significant rework to support message array construction
+- `getCoachingResponse()` switches from `generateText()` (single turn) to a message-array-based call
+- Conversation state (message array) lives per game session, reset on new game
+- Enemy stat computation is a new module that subscribes to game state updates

--- a/docs/plans/2026-04-04-tiered-context-design.md
+++ b/docs/plans/2026-04-04-tiered-context-design.md
@@ -50,44 +50,33 @@ Contains everything that doesn't change mid-game:
 
 **Mode-awareness:** Use the `GameMode` interface to decide what to include. No hardcoded mode strings. If `mode.decisionTypes` includes `augment-selection`, include augment rules. If the mode matches ARAM, include balance overrides. Everything is driven by the mode interface.
 
-## State Updates (Per User Message)
+## State Snapshots (Per User Message)
 
-Every user turn is prefixed with a state update showing what changed since the last message. The system prompt tells the LLM to expect this format.
+Every user turn includes a full state snapshot — not a diff. Research (Laban et al., arXiv:2505.06120) shows LLMs degrade significantly when tracking accumulated state across many diffs in multi-turn conversations. Full snapshots re-anchor the model to ground truth each turn, at negligible token cost (~100-200 tokens, cached as input).
 
-**First message** gets a full state snapshot:
+The system prompt tells the LLM to expect a `[Game State]` block before each question.
+
+**Every message format:**
 
 ```
 [Game State]
-Player Champion: Ahri (Level 3)
-KDA: 0/0/0
-Items: Doran's Ring
-Gold: 500
-Stats: 200 AP, 60 Armor, 40 MR, 30 AH, 350 MS, 1800 HP
-Augments: None
+Player Champion: Ahri (Level 12)
+KDA: 5/3/8
+Items: Zhonya's Hourglass (Active: Stasis for 2.5s), Rabadon's Deathcap
+Gold: 800
+Stats: 250 AP, 120 Armor, 40 MR, 40 AH, 350 MS, 2200 HP
+Augments: Jeweled Gauntlet, Ethereal Blades
 
 Ally Team: Garen, Lux, Jinx, Thresh
 Enemy Team:
-- Zed (Level 3): 85 AD, 35 Armor, 32 MR, 340 MS, 1600 HP — Doran's Blade
-- Darius (Level 2): 70 AD, 42 Armor, 32 MR, 340 MS, 1500 HP — no items
+- Zed (Level 12): 180 AD, 75 Armor, 42 MR, 380 MS, 2000 HP — Duskblade, Edge of Night
+- Garen (Level 13): 145 AD, 180 Armor, 72 MR, 370 MS, 2800 HP — Thornmail, Sunfire Aegis
 ...
 ```
 
-**Subsequent messages** get diffs:
+**POV:** Neutral/agnostic phrasing throughout. "Items:" not "Your items." "Enemy Team:" not "They have."
 
-```
-[State Update]
-New items: Zhonya's Hourglass (Active: Stasis for 2.5s)
-Gold: 3200 → 800
-Level: 12 → 13
-Stats: 250 AP, 120 Armor, 40 MR, 40 AH, 350 MS, 2200 HP
-KDA: 5/2/8 → 5/3/8
-Enemy changes:
-- Garen (Level 13): 145 AD, 180 Armor, 72 MR, 370 MS, 2800 HP — Thornmail, Sunfire Aegis, Plated Steelcaps
-```
-
-**POV:** Neutral/agnostic phrasing throughout. "New items:" not "You purchased." "Enemy changes:" not "They built."
-
-**What counts as a change:** Everything — gold, level, items, KDA, enemy items/stats. Start comprehensive, optimize later if noisy.
+**Message history:** All messages are kept in the array (no sliding window or summarization). At 400k context window, even a 30-exchange game session (~12k tokens total) is well within budget. If quality degrades in long sessions during playtesting, summarization can be added later via a cheap LLM call to compress evicted messages.
 
 ### Player Champion Stats
 
@@ -123,8 +112,8 @@ Enemy changes:
 
 ### Cancelled proactive requests
 
-- When a proactive augment/stat anvil request is cancelled (player picked before LLM responded), replace the orphaned question with a statement: "Augment selected: [X] from [X, Y, Z]"
-- Preserves the information in the conversation thread without an unanswered question
+- When a proactive augment/stat anvil request is cancelled (player picked before LLM responded), remove the orphaned question from the message array entirely
+- No replacement statement needed — the next turn's full state snapshot will show the chosen augment/stat anvil in the player's current state
 
 ## Mode-Awareness
 
@@ -149,4 +138,6 @@ Requires concrete `GameMode` implementations for at least three modes: ARAM Mayh
 - `buildSystemPrompt()` and `buildUserPrompt()` need significant rework to support message array construction
 - `getCoachingResponse()` switches from `generateText()` (single turn) to a message-array-based call
 - Conversation state (message array) lives per game session, reset on new game
+- All messages kept in array (no sliding window) — 400k context window handles any game session length
+- If quality degrades in very long sessions, add summarization later via cheap LLM call
 - Enemy stat computation is a new module that subscribes to game state updates

--- a/fixtures/coaching-sessions-v2/mayhem-volibear-2026-03-27.json
+++ b/fixtures/coaching-sessions-v2/mayhem-volibear-2026-03-27.json
@@ -1,0 +1,4596 @@
+[
+  {
+    "label": "Volibear @0:18: augment choice",
+    "index": 0,
+    "timestamp": "2026-03-27T19:40:25.750Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 43,
+          "magicResist": 35,
+          "maxHealth": 803,
+          "currentHealth": 803,
+          "moveSpeed": 340,
+          "attackSpeed": 0.643,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 18
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "poor o'blaster, demons dance, or vampirism.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Demon's Dance",
+          "tier": "Gold",
+          "description": "Gain the Fleet Footwork and Grasp of the Undying keystone runes."
+        },
+        {
+          "name": "Vampirism",
+          "tier": "Gold",
+          "description": "You can no longer be healed by allies and your health regeneration is set to 0. Gain 25% omnivamp."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Demon's Dance**. Best on Volibear: Fleet + Grasp both fit melee trade/stacking, and you keep ally healing. **Vampirism** is too risky here; losing ally heals + all regen is bad on tank Voli. Poor o'blaster only if you’re committing full damage, which this comp doesn’t need.",
+      "latencyMs": 1644,
+      "tokensIn": 926,
+      "tokensOut": 179
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 1400,
+      "champion": "Volibear",
+      "gameTime": "0:18"
+    }
+  },
+  {
+    "label": "Volibear @0:34: general question",
+    "index": 1,
+    "timestamp": "2026-03-27T19:40:43.341Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 43,
+          "magicResist": 35,
+          "maxHealth": 803,
+          "currentHealth": 803,
+          "moveSpeed": 340,
+          "attackSpeed": 0.643,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 34
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "spiritual purification. Demon's dance. Big brain.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Spiritual Purification",
+          "tier": "Gold",
+          "description": "Scoring a champion takedown causes the area around the slain champion to explode in a 500 unit radius, dealing adaptive damage to enemies within equal to 15% of their current health and leaving behind a zone for 1.5 seconds that slows enemies within by 60%."
+        },
+        {
+          "name": "Demon's Dance",
+          "tier": "Gold",
+          "description": "Gain the Fleet Footwork and Grasp of the Undying keystone runes."
+        },
+        {
+          "name": "Big Brain",
+          "tier": "Gold",
+          "description": "Gain a shield that absorbs damage equal to 300% AP and lasts until destroyed. Shield is replenished upon respawn."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Demon's Dance**. Best with Voli melee trading/stacking; strong tank-fighter value. **Spiritual Purification** only if snowballing kills. **Big Brain** low value on your current build.",
+      "latencyMs": 1500,
+      "tokensIn": 1085,
+      "tokensOut": 146
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 1400,
+      "champion": "Volibear",
+      "gameTime": "0:34"
+    }
+  },
+  {
+    "label": "Volibear @0:44: augment confirmation",
+    "index": 2,
+    "timestamp": "2026-03-27T19:40:51.106Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 43,
+          "magicResist": 35,
+          "maxHealth": 803,
+          "currentHealth": 803,
+          "moveSpeed": 340,
+          "attackSpeed": 0.643,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 44
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "I chose Demon's Dance.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Demon's Dance",
+          "tier": "Gold",
+          "description": "Gain the Fleet Footwork and Grasp of the Undying keystone runes."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Good. **Take Demon's Dance**; it’s the best Voli tempo/tank augment here. Spend the voucher on core combat stats, not greed.",
+      "latencyMs": 1170,
+      "tokensIn": 1052,
+      "tokensOut": 80
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 1400,
+      "champion": "Volibear",
+      "gameTime": "0:44"
+    }
+  },
+  {
+    "label": "Volibear @4:05: item question",
+    "index": 3,
+    "timestamp": "2026-03-27T19:44:13.160Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 6,
+        "currentGold": 84,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 56,
+          "magicResist": 40,
+          "maxHealth": 1061,
+          "currentHealth": 1061,
+          "moveSpeed": 340,
+          "attackSpeed": 0.674,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 2508,
+              "name": "Fated Ashes"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3147,
+              "name": "Haunting Guise"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6670,
+              "name": "Noonquiver"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 245
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "What's my next item?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Bami’s Cinder** next. Best immediate HP + waveclear/tank value for Voli, and it progresses cleanly into tank core without wasting your Heartsteel start.",
+      "latencyMs": 1486,
+      "tokensIn": 855,
+      "tokensOut": 139
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 84,
+      "champion": "Volibear",
+      "gameTime": "4:05"
+    }
+  },
+  {
+    "label": "Volibear @4:24: general question",
+    "index": 4,
+    "timestamp": "2026-03-27T19:44:31.175Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 6,
+        "currentGold": 241,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 56,
+          "magicResist": 40,
+          "maxHealth": 1061,
+          "currentHealth": 1061,
+          "moveSpeed": 340,
+          "attackSpeed": 0.674,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 2508,
+              "name": "Fated Ashes"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3147,
+              "name": "Haunting Guise"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6670,
+              "name": "Noonquiver"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 264
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "Do I get that before boots?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "No — keep **Boots** if you don’t already have tier 2, then save for the next **Heartsteel** component. If your Boots are already bought, don’t spend 241 gold on Heartsteel progress yet.",
+      "latencyMs": 1189,
+      "tokensIn": 909,
+      "tokensOut": 116
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 241,
+      "champion": "Volibear",
+      "gameTime": "4:24"
+    }
+  },
+  {
+    "label": "Volibear @4:38: augment choice",
+    "index": 5,
+    "timestamp": "2026-03-27T19:44:44.996Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 6,
+        "currentGold": 115,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 56,
+          "magicResist": 40,
+          "maxHealth": 1061,
+          "currentHealth": 1061,
+          "moveSpeed": 340,
+          "attackSpeed": 0.674,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 278
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "No, I meant Tier 2 boots. Do I get those before whatever these boots upgrade into you?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Yes — get **Tier 2 Boots** first. Best immediate power/mobility for Voli; don’t sit on basic Boots. After that, build toward your next tank component, not the Boots upgrade path. Don’t buy anything else yet with 115g.",
+      "latencyMs": 1113,
+      "tokensIn": 989,
+      "tokensOut": 97
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 115,
+      "champion": "Volibear",
+      "gameTime": "4:38"
+    }
+  },
+  {
+    "label": "Volibear @5:15: augment choice",
+    "index": 6,
+    "timestamp": "2026-03-27T19:45:22.424Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 7,
+        "currentGold": 475,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 60,
+          "magicResist": 42,
+          "maxHealth": 1154,
+          "currentHealth": 1154,
+          "moveSpeed": 340,
+          "attackSpeed": 0.686,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 315
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "Quest, steal your heart, recursion, or firebrand.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Firebrand",
+          "tier": "Gold",
+          "description": "Basic attacks apply a Burn for 5 seconds that deals bonus magic damage equal to2/5% of the target's maximum health per second.This Burn stacks infinitely and refreshes with each application."
+        },
+        {
+          "name": "Recursion",
+          "tier": "Gold",
+          "description": "Grants 60 ability haste."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Firebrand**. Best with Voli autos + Heartsteel; huge sustained tank shred. **Recursion** only if you need pure spell spam. Re-roll the other one if possible.",
+      "latencyMs": 2733,
+      "tokensIn": 1253,
+      "tokensOut": 108
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 475,
+      "champion": "Volibear",
+      "gameTime": "5:15"
+    }
+  },
+  {
+    "label": "Volibear @5:36: item question",
+    "index": 7,
+    "timestamp": "2026-03-27T19:45:45.168Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 7,
+        "currentGold": 679,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 60,
+          "magicResist": 42,
+          "maxHealth": 1154,
+          "currentHealth": 1154,
+          "moveSpeed": 340,
+          "attackSpeed": 0.686,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 336
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "But I already have a heart steal and I'm building a tank. Why is that better than what I have currently when half the time I can't reach the chance",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Because **Heartsteel** is your best payoff item here even if some fights are hard to reach. You’re Voli tank with Grasp/Fleet: when you do get in, Heartsteel gives way more HP scaling and snowball value than the weak options. With 679g, **don’t finish a new item path**—buy **Tier 2 Boots** if you can, otherwise **save gold** toward your next tank component. If you’re asking for the next actual build direction: **Bami’s Cinder / tank HP item**, not damage.",
+      "latencyMs": 1529,
+      "tokensIn": 979,
+      "tokensOut": 188
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 679,
+      "champion": "Volibear",
+      "gameTime": "5:36"
+    }
+  },
+  {
+    "label": "Volibear @6:07: augment confirmation",
+    "index": 8,
+    "timestamp": "2026-03-27T19:46:15.365Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 7,
+        "currentGold": 938,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 60,
+          "magicResist": 42,
+          "maxHealth": 1154,
+          "currentHealth": 1154,
+          "moveSpeed": 340,
+          "attackSpeed": 0.686,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 367
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance"],
+    "query": {
+      "question": "I chose Quest Steel Your Heart.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Quest: Steel Your Heart",
+          "tier": "Gold",
+          "description": "Quest: Obtain Heartsteel and accumulate over 300 bonus health from Colossal Consumption. Reward: Upon completing your Quest, increase the bonus health gained from Heartsteel Colossal Consumption by 200%. [Heartsteel stats: 900 Health]"
+        }
+      ]
+    },
+    "response": {
+      "answer": "Yes — **Quest: Steel Your Heart** is a good take here. You already own **Heartsteel**, so this augment can fully pay off; finish stacking it and stay tanky. With 938g, **get Tier 2 Boots now if you can**, otherwise hold for your next tank HP component. Don’t buy Heartsteel again.",
+      "latencyMs": 1279,
+      "tokensIn": 1354,
+      "tokensOut": 153
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 938,
+      "champion": "Volibear",
+      "gameTime": "6:07"
+    }
+  },
+  {
+    "label": "Volibear @8:20: item question",
+    "index": 9,
+    "timestamp": "2026-03-27T19:48:28.420Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 9,
+        "currentGold": 261,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 70,
+          "magicResist": 46,
+          "maxHealth": 1351,
+          "currentHealth": 1351,
+          "moveSpeed": 340,
+          "attackSpeed": 0.709,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 2140,
+              "name": "Elixir of Wrath"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 500
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "So I have a balmies now. What is the item I'm building this into?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "**Bami’s Cinder is usually just a holding piece here — don’t rush a specific damage upgrade.** With your current setup, next real build should be **HP/tank, not damage**: **Warmog’s Armor** or **Kaenic Rookern** depending on whether you need vs AD/AP. If you want one clear direction: **finish a big HP tank item next, then keep stacking Heartsteel value.**",
+      "latencyMs": 2012,
+      "tokensIn": 1204,
+      "tokensOut": 205
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 261,
+      "champion": "Volibear",
+      "gameTime": "8:20"
+    }
+  },
+  {
+    "label": "Volibear @8:51: augment choice",
+    "index": 10,
+    "timestamp": "2026-03-27T19:48:59.399Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 9,
+        "currentGold": 520,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 70,
+          "magicResist": 46,
+          "maxHealth": 1351,
+          "currentHealth": 1351,
+          "moveSpeed": 340,
+          "attackSpeed": 0.709,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 221011,
+              "name": "Giant's Belt"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 531
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "Okay, I wanna know what the next main item I should have is. I bought bommies and some other items thinking I was building it into something. Please don't tell me stuff like that anymore. Just tell me the main item I'm moving towards.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "**Warmog’s Armor** is your next main item. Best direct HP tank follow-up for Voli here with Heartsteel already started; gives you the big health spike you actually want. If you need anti-AP instead, **Kaenic Rookern** is the only real alternative.",
+      "latencyMs": 1173,
+      "tokensIn": 1285,
+      "tokensOut": 124
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 520,
+      "champion": "Volibear",
+      "gameTime": "8:51"
+    }
+  },
+  {
+    "label": "Volibear @10:55: augment choice",
+    "index": 11,
+    "timestamp": "2026-03-27T19:51:03.318Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 11,
+        "currentGold": 664,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 81,
+          "magicResist": 50,
+          "maxHealth": 1563,
+          "currentHealth": 1563,
+          "moveSpeed": 340,
+          "attackSpeed": 0.735,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 2140,
+              "name": "Elixir of Wrath"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 655
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "dropkick, final form, or ultimate revolution.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Ultimate Revolution",
+          "tier": "Prismatic",
+          "description": "Casting your ultimate ability resets its cooldown once its effect For instant-cast spells or has For duration-based spells (75 second cooldown, reset upon death)."
+        },
+        {
+          "name": "Final Form",
+          "tier": "Prismatic",
+          "description": "Casting your ultimate ability empowers you for 10 seconds, causing you to gain a shield for 50% of your maximum health, 20% omnivamp, and 30% bonus movement speed for the duration (20 second cooldown)."
+        },
+        {
+          "name": "Dropkick",
+          "tier": "Prismatic",
+          "description": "Your basic attacks and abilities execute enemy champions below 5% (+ 3.5% per 100 base AD) (+ 2% per 1000 bonus health) of their maximum health, which causes their corpse to be sent flying away in a line. Upon collision with an enemy champion or terrain, the target's corpse explodes to deal 150 to 500 (+ 100% bonus armor) (+ 100% bonus magic resistance) magic damage to nearby enemies. Successful executions heal you for 100 to 300 (+ 25% bonus health). The execution may also be triggered by the explosion and goes through shields."
+        }
+      ]
+    },
+    "response": {
+      "answer": "**Final Form**. Best now: huge HP shield + omnivamp + MS on R = lets Voli actually live after ult engage and stick fights. Re-roll the other two.",
+      "latencyMs": 3037,
+      "tokensIn": 1760,
+      "tokensOut": 137
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 664,
+      "champion": "Volibear",
+      "gameTime": "10:55"
+    }
+  },
+  {
+    "label": "Volibear @11:12: augment choice",
+    "index": 12,
+    "timestamp": "2026-03-27T19:51:19.660Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 11,
+        "currentGold": 804,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 81,
+          "magicResist": 50,
+          "maxHealth": 1563,
+          "currentHealth": 1563,
+          "moveSpeed": 340,
+          "attackSpeed": 0.735,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 223116,
+              "name": "Rylai's Crystal Scepter"
+            },
+            {
+              "id": 3916,
+              "name": "Oblivion Orb"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 672
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "courage of the Colossus, final form or slow cooker.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Courage of the Colossus",
+          "tier": "Prismatic",
+          "description": "Immobilizing or grounding an enemy champion grants a shield for 3 seconds that absorbs 150 to 450 (+ 4% maximum health) damage (5 second cooldown per cast instance). Shields can stack between multiple triggers of this effect, though not refreshing the duration of previous shields."
+        },
+        {
+          "name": "Slow Cooker",
+          "tier": "Prismatic",
+          "description": "Surrounds you in flames, causing you to apply a Burn every second to enemy champions within 500 units for 3 seconds that deals magic damage equal to0.66% of your maximum health per second.This Burn stacks infinitely and refreshes with each application."
+        },
+        {
+          "name": "Final Form",
+          "tier": "Prismatic",
+          "description": "Casting your ultimate ability empowers you for 10 seconds, causing you to gain a shield for 50% of your maximum health, 20% omnivamp, and 30% bonus movement speed for the duration (20 second cooldown)."
+        }
+      ]
+    },
+    "response": {
+      "answer": "**Final Form**. Best by far: huge ult shield + omnivamp + MS solves your engage/survive problem on Voli. Re-roll **Courage of the Colossus** and **Slow Cooker**.",
+      "latencyMs": 1645,
+      "tokensIn": 1726,
+      "tokensOut": 162
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 804,
+      "champion": "Volibear",
+      "gameTime": "11:12"
+    }
+  },
+  {
+    "label": "Volibear @17:31: augment choice",
+    "index": 13,
+    "timestamp": "2026-03-27T19:57:40.286Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 17,
+        "currentGold": 6124,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 117,
+          "magicResist": 64,
+          "maxHealth": 2285,
+          "currentHealth": 2285,
+          "moveSpeed": 340,
+          "attackSpeed": 0.822,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223165,
+              "name": "Morellonomicon"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 223116,
+              "name": "Rylai's Crystal Scepter"
+            },
+            {
+              "id": 1052,
+              "name": "Amplifying Tome"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 223084,
+              "name": "Heartsteel"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 226695,
+              "name": "Serpent's Fang"
+            },
+            {
+              "id": 226697,
+              "name": "Hubris"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 323042,
+              "name": "Muramana"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1051
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "shrink engine, sole eater, or red envelopes.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Red Envelopes",
+          "tier": "Gold",
+          "description": "Red envelopes will now randomly appear around you every 25 to 15 seconds. You can pick up these envelopes by moving over them, granting you between 8 to 15 gold and 22 to 46 gold, and 150 bonus movement speed for 4 seconds. Additionally, whenever you pick an envelope, you gain one of the following stats by random: 5 bonus attack damage 5 ability power 5 ability haste 5 bonus armor 5 bonus magic resistance 50 bonus health 10% bonus attack speed 5 bonus movement speed 5 Lethality 5 magic penetration"
+        },
+        {
+          "name": "Shrink Engine",
+          "tier": "Gold",
+          "description": "Scoring a champion takedown generates a stack, stacking infinitely. For each stack, gain 8 ability haste and 1% bonus movement speed, and reduce your size by 4%. Lose 65% of stacks on death. Size reduction is capped at 80%"
+        }
+      ]
+    },
+    "response": {
+      "answer": "**Shrink Engine**. Best with your reset-heavy takedown fights; stacks AH + MS forever and pairs well with Voli frontlining. Re-roll **Red Envelopes** if you have one left, otherwise just take Shrink Engine.",
+      "latencyMs": 1578,
+      "tokensIn": 1685,
+      "tokensOut": 158
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 6124,
+      "champion": "Volibear",
+      "gameTime": "17:31"
+    }
+  },
+  {
+    "label": "Volibear @17:54: augment choice",
+    "index": 14,
+    "timestamp": "2026-03-27T19:58:03.315Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 17,
+        "currentGold": 6591,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 117,
+          "magicResist": 64,
+          "maxHealth": 2285,
+          "currentHealth": 2285,
+          "moveSpeed": 340,
+          "attackSpeed": 0.822,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223165,
+              "name": "Morellonomicon"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 223116,
+              "name": "Rylai's Crystal Scepter"
+            },
+            {
+              "id": 224645,
+              "name": "Shadowflame"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 223084,
+              "name": "Heartsteel"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 226695,
+              "name": "Serpent's Fang"
+            },
+            {
+              "id": 226697,
+              "name": "Hubris"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 323042,
+              "name": "Muramana"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 17,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 3133,
+              "name": "Caulfield's Warhammer"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1074
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "donation, sole leader, or overflow.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Overflow",
+          "tier": "Gold",
+          "description": "Your abilities' mana costs are doubled, but you also gain 10%"
+        },
+        {
+          "name": "Donation",
+          "tier": "Gold",
+          "description": "Gain 1750 gold upon acquiring this augment."
+        }
+      ]
+    },
+    "response": {
+      "answer": "**Overflow**. Best on Voli here: extra damage + self/outgoing healing/shielding is huge with Heartsteel/Warmog’s tank-bruiser setup. Re-roll **Donation**; take **Sole Leader** only if it’s obviously stronger in the other card pool.",
+      "latencyMs": 1164,
+      "tokensIn": 1487,
+      "tokensOut": 116
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 6591,
+      "champion": "Volibear",
+      "gameTime": "17:54"
+    }
+  },
+  {
+    "label": "Volibear @19:45: augment confirmation",
+    "index": 15,
+    "timestamp": "2026-03-27T19:59:52.536Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 18,
+        "currentGold": 691,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 123,
+          "magicResist": 67,
+          "maxHealth": 2418,
+          "currentHealth": 2418,
+          "moveSpeed": 340,
+          "attackSpeed": 0.838,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323040,
+              "name": "Seraph's Embrace"
+            },
+            {
+              "id": 223165,
+              "name": "Morellonomicon"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 223116,
+              "name": "Rylai's Crystal Scepter"
+            },
+            {
+              "id": 224645,
+              "name": "Shadowflame"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 223084,
+              "name": "Heartsteel"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 226695,
+              "name": "Serpent's Fang"
+            },
+            {
+              "id": 226697,
+              "name": "Hubris"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 323042,
+              "name": "Muramana"
+            },
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223161,
+              "name": "Spear of Shojin"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 223508,
+              "name": "Essence Reaver"
+            },
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1185
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest"],
+    "query": {
+      "question": "I chose final form.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Final Form",
+          "tier": "Prismatic",
+          "description": "Casting your ultimate ability empowers you for 10 seconds, causing you to gain a shield for 50% of your maximum health, 20% omnivamp, and 30% bonus movement speed for the duration (20 second cooldown)."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Correct. **Final Form**. Keep it; best for Voli here. No reroll needed.",
+      "latencyMs": 703,
+      "tokensIn": 1427,
+      "tokensOut": 35
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 691,
+      "champion": "Volibear",
+      "gameTime": "19:45"
+    }
+  },
+  {
+    "label": "Volibear @19:49: augment confirmation",
+    "index": 16,
+    "timestamp": "2026-03-27T19:59:58.231Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Volibear",
+        "level": 18,
+        "currentGold": 751,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 123,
+          "magicResist": 67,
+          "maxHealth": 2418,
+          "currentHealth": 2418,
+          "moveSpeed": 340,
+          "attackSpeed": 0.838,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Volibear",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Sion",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Tahm Kench",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Annie",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Smolder",
+          "team": "ORDER",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 6653,
+              "name": "Liandry's Torment"
+            },
+            {
+              "id": 323040,
+              "name": "Seraph's Embrace"
+            },
+            {
+              "id": 223165,
+              "name": "Morellonomicon"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 223116,
+              "name": "Rylai's Crystal Scepter"
+            },
+            {
+              "id": 224645,
+              "name": "Shadowflame"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Alistar",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 443083,
+              "name": "Warmog's Armor"
+            },
+            {
+              "id": 223084,
+              "name": "Heartsteel"
+            },
+            {
+              "id": 0,
+              "name": "Jak'Sho"
+            },
+            {
+              "id": 0,
+              "name": "The Protean"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226692,
+              "name": "Eclipse"
+            },
+            {
+              "id": 223071,
+              "name": "Black Cleaver"
+            },
+            {
+              "id": 226695,
+              "name": "Serpent's Fang"
+            },
+            {
+              "id": 226697,
+              "name": "Hubris"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223078,
+              "name": "Trinity Force"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 323042,
+              "name": "Muramana"
+            },
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223161,
+              "name": "Spear of Shojin"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Gangplank",
+          "team": "CHAOS",
+          "level": 18,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223158,
+              "name": "Ionian Boots of Lucidity"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 223508,
+              "name": "Essence Reaver"
+            },
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1189
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Demon's Dance", "Quest", "Final Form"],
+    "query": {
+      "question": "I chose overflow.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Overflow",
+          "tier": "Gold",
+          "description": "Your abilities' mana costs are doubled, but you also gain 10%"
+        }
+      ]
+    },
+    "response": {
+      "answer": "Good. Keep **Overflow**. Best with your Heartsteel/Warmog/Jak'Sho tank-bruiser setup: more damage + stronger self-heal/shields. Spend gold on **Bramble/Chain Vest upgrade path? no** — you already have Thornmail. Best buy is **no item needed now** unless you can finish a high-value component toward damage/utility; otherwise hold for next spike.",
+      "latencyMs": 1567,
+      "tokensIn": 1475,
+      "tokensOut": 135
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 751,
+      "champion": "Volibear",
+      "gameTime": "19:49"
+    }
+  }
+]

--- a/fixtures/coaching-sessions-v2/mayhem-warwick-2026-03-26.json
+++ b/fixtures/coaching-sessions-v2/mayhem-warwick-2026-03-26.json
@@ -1,0 +1,8285 @@
+[
+  {
+    "label": "Warwick @0:13: augment choice",
+    "index": 0,
+    "timestamp": "2026-03-26T22:48:19.017Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 35,
+          "maxHealth": 766,
+          "currentHealth": 766,
+          "moveSpeed": 335,
+          "attackSpeed": 0.657,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 220008,
+              "name": "Anvil Voucher"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 13
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "Pinball, Outlaw's Grit, and Big Brain.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Outlaw's Grit",
+          "tier": "Gold",
+          "description": "Dashing or blinking grants 12 bonus armor and bonus magic resistance, stacking up to 5 times for a total of 60 bonus resistances. Stacks are reset every 60 seconds since acquiring the augment."
+        },
+        {
+          "name": "Big Brain",
+          "tier": "Gold",
+          "description": "Gain a shield that absorbs damage equal to 300% AP and lasts until destroyed. Shield is replenished upon respawn."
+        },
+        {
+          "name": "Pinball",
+          "tier": "Gold",
+          "description": "Your Mark is empowered to instead throw a pinball, which deals 100 to 500 bonus true damage and ricochets off of terrain that it collides with. Each time the pinball ricochets, its remaining travel distance is reset, it increases in radius by 25%, deals 20% increased damage, and reduces Mark remaining cooldown by 30% of its total. The pinball can ricochet up to 4 times, for a maximum radius increase of 100% and a damage increase of 80%. Additionally, your Mark cooldown is reduced equivalent to 50 ability haste. If Mark is not equipped, the summoner spell in the slot not occupied by Flash is replaced with Mark. If you also did not equip Flash, then you will be prompted to replace one of your summoner spells with Mark."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Outlaw's Grit**. Warwick can stack it fast with R, and the raw resists are always useful into this mixed-damage comp. Skip Pinball and Big Brain.",
+      "latencyMs": 3062,
+      "tokensIn": 1456,
+      "tokensOut": 163
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Anvil Voucher"],
+      "gold": 1400,
+      "champion": "Warwick",
+      "gameTime": "0:13"
+    }
+  },
+  {
+    "label": "Warwick @0:30: augment choice",
+    "index": 1,
+    "timestamp": "2026-03-26T22:48:36.785Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 35,
+          "maxHealth": 766,
+          "currentHealth": 766,
+          "moveSpeed": 335,
+          "attackSpeed": 0.657,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 220008,
+              "name": "Anvil Voucher"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 30
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "Rabble Rousing, Outlaw's Grit, and Searing Dawn.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Rabble Rousing",
+          "tier": "Gold",
+          "description": "Casting an ability heals you for 5 to 60 (+ 1% maximum health)."
+        },
+        {
+          "name": "Outlaw's Grit",
+          "tier": "Gold",
+          "description": "Dashing or blinking grants 12 bonus armor and bonus magic resistance, stacking up to 5 times for a total of 60 bonus resistances. Stacks are reset every 60 seconds since acquiring the augment."
+        },
+        {
+          "name": "Searing Dawn",
+          "tier": "Gold",
+          "description": "Gain Sunlight. Sunlight: Your damaging abilities mark enemies, causing them to take 40 to 200 bonus magic damage from your ally's next basic attack or ability hit against them (0.75-second cooldown per target)."
+        }
+      ]
+    },
+    "response": null,
+    "error": "Failed to fetch",
+    "scorerContext": {
+      "items": ["Anvil Voucher"],
+      "gold": 1400,
+      "champion": "Warwick",
+      "gameTime": "0:30"
+    }
+  },
+  {
+    "label": "Warwick @0:46: augment choice",
+    "index": 2,
+    "timestamp": "2026-03-26T22:48:51.589Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 3,
+        "currentGold": 1400,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 35,
+          "maxHealth": 766,
+          "currentHealth": 766,
+          "moveSpeed": 335,
+          "attackSpeed": 0.657,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 220008,
+              "name": "Anvil Voucher"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 46
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "Rabble Rousing, Outlaw's Grit, and Searing Dawn",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Rabble Rousing",
+          "tier": "Gold",
+          "description": "Casting an ability heals you for 5 to 60 (+ 1% maximum health)."
+        },
+        {
+          "name": "Outlaw's Grit",
+          "tier": "Gold",
+          "description": "Dashing or blinking grants 12 bonus armor and bonus magic resistance, stacking up to 5 times for a total of 60 bonus resistances. Stacks are reset every 60 seconds since acquiring the augment."
+        },
+        {
+          "name": "Searing Dawn",
+          "tier": "Gold",
+          "description": "Gain Sunlight. Sunlight: Your damaging abilities mark enemies, causing them to take 40 to 200 bonus magic damage from your ally's next basic attack or ability hit against them (0.75-second cooldown per target)."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Outlaw's Grit**. Warwick gets full value off **R** instantly, and the stacked armor/MR is the best fit into this mixed-damage enemy team.",
+      "latencyMs": 2219,
+      "tokensIn": 1386,
+      "tokensOut": 163
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Anvil Voucher"],
+      "gold": 1400,
+      "champion": "Warwick",
+      "gameTime": "0:46"
+    }
+  },
+  {
+    "label": "Warwick @1:00: item question",
+    "index": 3,
+    "timestamp": "2026-03-26T22:49:05.402Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 3,
+        "currentGold": 1404,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 35,
+          "maxHealth": 766,
+          "currentHealth": 766,
+          "moveSpeed": 335,
+          "attackSpeed": 0.657,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 220008,
+              "name": "Anvil Voucher"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 60
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "What should I buy with my first 1400 gold?",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Transmute: Gold",
+          "tier": "Silver",
+          "description": "Gain one random Gold augment, excluding the other two offerings in your current assortment."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Use the **Anvil Voucher** and take the **best Stat Anvil for Warwick**. With only 1400g and no shop item power spike this early, the anvil is the highest-value first buy.",
+      "latencyMs": 2302,
+      "tokensIn": 1354,
+      "tokensOut": 130
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Anvil Voucher"],
+      "gold": 1404,
+      "champion": "Warwick",
+      "gameTime": "1:00"
+    }
+  },
+  {
+    "label": "Warwick @1:16: augment choice",
+    "index": 4,
+    "timestamp": "2026-03-26T22:49:21.299Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 3,
+        "currentGold": 1544,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 35,
+          "maxHealth": 766,
+          "currentHealth": 766,
+          "moveSpeed": 335,
+          "attackSpeed": 0.657,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223057,
+              "name": "Sheen"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 3,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 76
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "No, I mean like an actual item. What should I start building first as my first item?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Bami's Cinder** first, then build **Titanic Hydra**. Warwick needs the early health and wavefight damage, and it fits your bruiser/tank path way better than rushing pure damage.",
+      "latencyMs": 2975,
+      "tokensIn": 1354,
+      "tokensOut": 135
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 1544,
+      "champion": "Warwick",
+      "gameTime": "1:16"
+    }
+  },
+  {
+    "label": "Warwick @5:26: general question",
+    "index": 5,
+    "timestamp": "2026-03-26T22:53:31.219Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 7,
+        "currentGold": 1190,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 54,
+          "magicResist": 42,
+          "maxHealth": 1100,
+          "currentHealth": 1100,
+          "moveSpeed": 335,
+          "attackSpeed": 0.7,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Warwick",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 326
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "Witt...",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Finish **Bami's Cinder** first. It’s the best immediate power spike for Warwick here, then keep building into **Titanic Hydra** after that.",
+      "latencyMs": 2483,
+      "tokensIn": 1498,
+      "tokensOut": 126
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Boots", "Tiamat", "Tunneler", "Ruby Crystal"],
+      "gold": 1190,
+      "champion": "Warwick",
+      "gameTime": "5:26"
+    }
+  },
+  {
+    "label": "Warwick @5:37: general question",
+    "index": 6,
+    "timestamp": "2026-03-26T22:53:44.594Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 7,
+        "currentGold": 1292,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 54,
+          "magicResist": 42,
+          "maxHealth": 1100,
+          "currentHealth": 1100,
+          "moveSpeed": 335,
+          "attackSpeed": 0.7,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 337
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "I choose...",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Take **Bami's Cinder**. It’s your best first spike on Warwick here—cheap, tanky, and it makes your all-ins and wavefights much stronger. ",
+      "latencyMs": 1299,
+      "tokensIn": 1537,
+      "tokensOut": 92
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Boots", "Tiamat", "Tunneler", "Ruby Crystal"],
+      "gold": 1292,
+      "champion": "Warwick",
+      "gameTime": "5:37"
+    }
+  },
+  {
+    "label": "Warwick @5:44: augment confirmation",
+    "index": 7,
+    "timestamp": "2026-03-26T22:53:50.229Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 7,
+        "currentGold": 1352,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 54,
+          "magicResist": 42,
+          "maxHealth": 1100,
+          "currentHealth": 1100,
+          "moveSpeed": 335,
+          "attackSpeed": 0.7,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 344
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "I chose Outlaw's Grit",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Outlaw's Grit",
+          "tier": "Gold",
+          "description": "Dashing or blinking grants 12 bonus armor and bonus magic resistance, stacking up to 5 times for a total of 60 bonus resistances. Stacks are reset every 60 seconds since acquiring the augment."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Good. Keep playing for all-in windows and use R aggressively to stack it fast; the bonus resists are huge for Warwick into this mixed-damage comp.",
+      "latencyMs": 1060,
+      "tokensIn": 1661,
+      "tokensOut": 46
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Boots", "Tiamat", "Tunneler", "Ruby Crystal"],
+      "gold": 1352,
+      "champion": "Warwick",
+      "gameTime": "5:44"
+    }
+  },
+  {
+    "label": "Warwick @5:51: augment choice",
+    "index": 8,
+    "timestamp": "2026-03-26T22:53:58.324Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 8,
+        "currentGold": 1411,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 58,
+          "magicResist": 44,
+          "maxHealth": 1192,
+          "currentHealth": 1192,
+          "moveSpeed": 335,
+          "attackSpeed": 0.712,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 351
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Recursion, Overflow, Bread and Cheese",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Bread And Cheese",
+          "tier": "Gold",
+          "description": "Your champion's third basic ability (E) gains 100 ability haste."
+        },
+        {
+          "name": "Recursion",
+          "tier": "Gold",
+          "description": "Grants 60 ability haste."
+        },
+        {
+          "name": "Overflow",
+          "tier": "Gold",
+          "description": "Your abilities' mana costs are doubled, but you also gain 10%"
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Overflow**. Warwick gets real value from the damage amp and healing amp, and he doesn’t care much about the mana cost downside in this mode. Re-roll **Recursion** and **Bread and Cheese**.",
+      "latencyMs": 2412,
+      "tokensIn": 1755,
+      "tokensOut": 151
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Boots", "Tiamat", "Tunneler", "Ruby Crystal"],
+      "gold": 1411,
+      "champion": "Warwick",
+      "gameTime": "5:51"
+    }
+  },
+  {
+    "label": "Warwick @6:12: augment choice",
+    "index": 9,
+    "timestamp": "2026-03-26T22:54:19.364Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 8,
+        "currentGold": 1590,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 58,
+          "magicResist": 44,
+          "maxHealth": 1192,
+          "currentHealth": 1192,
+          "moveSpeed": 335,
+          "attackSpeed": 0.712,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3077,
+              "name": "Tiamat"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 372
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Scopier Weapons, Overflow, Divine Intervention",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Divine Intervention",
+          "tier": "Gold",
+          "description": "Automatically cast Cosmic Radiance, calling down a protective star upon you that descends over 2.5 seconds. Afterwards, you and all allied champions within icononly=true 400 units become invulnerable for 2.5 seconds"
+        },
+        {
+          "name": "Scopier Weapons",
+          "tier": "Gold",
+          "description": "Gain 200 bonus attack range."
+        },
+        {
+          "name": "Overflow",
+          "tier": "Gold",
+          "description": "Your abilities' mana costs are doubled, but you also gain 10%"
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Overflow**. Warwick doesn’t care about the mana tax nearly as much as he loves the free damage + healing amp, and it supercharges your bite, ult, and sustain. Re-roll **Scopier Weapons** and **Divine Intervention**.",
+      "latencyMs": 2290,
+      "tokensIn": 1864,
+      "tokensOut": 162
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Boots", "Tiamat", "Tunneler", "Ruby Crystal"],
+      "gold": 1590,
+      "champion": "Warwick",
+      "gameTime": "6:12"
+    }
+  },
+  {
+    "label": "Warwick @7:16: item question",
+    "index": 10,
+    "timestamp": "2026-03-26T22:55:21.087Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 8,
+        "currentGold": 765,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 58,
+          "magicResist": 44,
+          "maxHealth": 1192,
+          "currentHealth": 1192,
+          "moveSpeed": 335,
+          "attackSpeed": 0.712,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 436
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "What item should I build next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Build **Bami's Cinder** next. It’s the best immediate spike for Warwick here: cheap, tanky, and it massively improves your skirmish and waveclear before you finish Titanic Hydra.",
+      "latencyMs": 1323,
+      "tokensIn": 1803,
+      "tokensOut": 92
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra"],
+      "gold": 765,
+      "champion": "Warwick",
+      "gameTime": "7:16"
+    }
+  },
+  {
+    "label": "Warwick @7:37: item question",
+    "index": 11,
+    "timestamp": "2026-03-26T22:55:43.982Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 9,
+        "currentGold": 44,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 63,
+          "magicResist": 46,
+          "maxHealth": 1287,
+          "currentHealth": 1287,
+          "moveSpeed": 335,
+          "attackSpeed": 0.724,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 457
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "What item should I buy next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Bami’s Cinder** now. It’s the best immediate spike on Warwick here: cheap HP, strong wavefight damage, and it keeps you on track to finish **Titanic Hydra**.",
+      "latencyMs": 1894,
+      "tokensIn": 1944,
+      "tokensOut": 91
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Elixir of Iron",
+        "Bami's Cinder"
+      ],
+      "gold": 44,
+      "champion": "Warwick",
+      "gameTime": "7:37"
+    }
+  },
+  {
+    "label": "Warwick @7:48: augment choice",
+    "index": 12,
+    "timestamp": "2026-03-26T22:55:54.095Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 9,
+        "currentGold": 142,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 63,
+          "magicResist": 46,
+          "maxHealth": 1287,
+          "currentHealth": 1287,
+          "moveSpeed": 335,
+          "attackSpeed": 0.724,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 468
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I already bought that one, what item should I buy next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Build **Titanic Hydra** next. You already have Bami’s, and Titanic is your real damage spike with HP scaling, waveclear, and better all-in pressure on Warwick.",
+      "latencyMs": 1110,
+      "tokensIn": 2005,
+      "tokensOut": 90
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Elixir of Iron",
+        "Bami's Cinder"
+      ],
+      "gold": 142,
+      "champion": "Warwick",
+      "gameTime": "7:48"
+    }
+  },
+  {
+    "label": "Warwick @7:58: augment choice",
+    "index": 13,
+    "timestamp": "2026-03-26T22:56:03.258Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 9,
+        "currentGold": 222,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 63,
+          "magicResist": 46,
+          "maxHealth": 1287,
+          "currentHealth": 1287,
+          "moveSpeed": 335,
+          "attackSpeed": 0.724,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 478
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I have a titanic hydra, do you not see what items I have?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Yes — you already have **Titanic Hydra**. Your next buy should be **finish Bami’s Cinder into Sunfire/Abyssal path only if that’s available in KIWI; otherwise buy the best HP+resist item you can from shop right now**. Your current core is Titanic + Mercs + Outlaw’s Grit, so you need **tank stats next**, not another damage item.",
+      "latencyMs": 1750,
+      "tokensIn": 2063,
+      "tokensOut": 182
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Elixir of Iron",
+        "Bami's Cinder"
+      ],
+      "gold": 222,
+      "champion": "Warwick",
+      "gameTime": "7:58"
+    }
+  },
+  {
+    "label": "Warwick @8:23: item question",
+    "index": 14,
+    "timestamp": "2026-03-26T22:56:28.864Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 9,
+        "currentGold": 339,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 63,
+          "magicResist": 46,
+          "maxHealth": 1287,
+          "currentHealth": 1287,
+          "moveSpeed": 335,
+          "attackSpeed": 0.724,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1029,
+              "name": "Cloth Armor"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 2139,
+              "name": "Elixir of Sorcery"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 503
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Please look at my items and tell me what I should buy next.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Chain Vest** next. You’re into 3 AD threats, and Warwick already has enough damage from Titanic; you need armor to stop getting deleted by MF/Cait/Viego while you frontload with R.",
+      "latencyMs": 1843,
+      "tokensIn": 2133,
+      "tokensOut": 121
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Bami's Cinder",
+        "Cloth Armor"
+      ],
+      "gold": 339,
+      "champion": "Warwick",
+      "gameTime": "8:23"
+    }
+  },
+  {
+    "label": "Warwick @9:17: item question",
+    "index": 15,
+    "timestamp": "2026-03-26T22:57:24.052Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 10,
+        "currentGold": 342,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 67,
+          "magicResist": 48,
+          "maxHealth": 1386,
+          "currentHealth": 1386,
+          "moveSpeed": 335,
+          "attackSpeed": 0.737,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 3051,
+              "name": "Hearthbound Axe"
+            },
+            {
+              "id": 6690,
+              "name": "Rectrix"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 2140,
+              "name": "Elixir of Wrath"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 557
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Now what items should I buy next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Chain Vest** now, then turn your **Ruby Crystal + Bami’s Cinder + Chain Vest** into your next tank item path. You already have enough damage from Titanic; into MF/Cait/Viego, armor is the best immediate value.",
+      "latencyMs": 1583,
+      "tokensIn": 2225,
+      "tokensOut": 149
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Chain Vest",
+        "Bami's Cinder",
+        "Ruby Crystal"
+      ],
+      "gold": 342,
+      "champion": "Warwick",
+      "gameTime": "9:17"
+    }
+  },
+  {
+    "label": "Warwick @9:31: item question",
+    "index": 16,
+    "timestamp": "2026-03-26T22:57:36.778Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 10,
+        "currentGold": 461,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 67,
+          "magicResist": 48,
+          "maxHealth": 1386,
+          "currentHealth": 1386,
+          "moveSpeed": 335,
+          "attackSpeed": 0.737,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 3051,
+              "name": "Hearthbound Axe"
+            },
+            {
+              "id": 6690,
+              "name": "Rectrix"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 571
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I literally just bought that. What item should I buy next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **another Chain Vest / armor component** if the shop lets you. You’re still getting hit by 3 AD carries, and Warwick already has enough damage from Titanic—stack armor before anything else.",
+      "latencyMs": 1663,
+      "tokensIn": 2290,
+      "tokensOut": 123
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Chain Vest",
+        "Bami's Cinder",
+        "Ruby Crystal"
+      ],
+      "gold": 461,
+      "champion": "Warwick",
+      "gameTime": "9:31"
+    }
+  },
+  {
+    "label": "Warwick @9:45: item question",
+    "index": 17,
+    "timestamp": "2026-03-26T22:57:50.264Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 10,
+        "currentGold": 580,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 67,
+          "magicResist": 48,
+          "maxHealth": 1386,
+          "currentHealth": 1386,
+          "moveSpeed": 335,
+          "attackSpeed": 0.737,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 221031,
+              "name": "Chain Vest"
+            },
+            {
+              "id": 6660,
+              "name": "Bami's Cinder"
+            },
+            {
+              "id": 1028,
+              "name": "Ruby Crystal"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 3051,
+              "name": "Hearthbound Axe"
+            },
+            {
+              "id": 6690,
+              "name": "Rectrix"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 585
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I mean the next main item. What are these items building into? What's the next main item?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Your next main item is **whatever the shop lets you finish from Bami’s + Chain Vest + Ruby Crystal** — in KIWI that should be your **armor/HP tank upgrade**, not another damage item. **Prioritize the Bami’s/Chain Vest tank completion first**, then go back for more armor/MR after that.",
+      "latencyMs": 2000,
+      "tokensIn": 2357,
+      "tokensOut": 173
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Chain Vest",
+        "Bami's Cinder",
+        "Ruby Crystal"
+      ],
+      "gold": 580,
+      "champion": "Warwick",
+      "gameTime": "9:45"
+    }
+  },
+  {
+    "label": "Warwick @10:11: augment choice",
+    "index": 18,
+    "timestamp": "2026-03-26T22:58:17.383Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 10,
+        "currentGold": 201,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 67,
+          "magicResist": 48,
+          "maxHealth": 1386,
+          "currentHealth": 1386,
+          "moveSpeed": 335,
+          "attackSpeed": 0.737,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 611
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I have Bomby's, I have those other things, is it Sunfire Aegis I should be getting?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Yes — if you already have Bami’s and the armor/HP components, finish **Sunfire Aegis** next. It’s your best immediate tank spike here into 3 AD threats, and you already have enough damage from Titanic.",
+      "latencyMs": 1585,
+      "tokensIn": 2443,
+      "tokensOut": 152
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 201,
+      "champion": "Warwick",
+      "gameTime": "10:11"
+    }
+  },
+  {
+    "label": "Warwick @11:07: augment choice",
+    "index": 19,
+    "timestamp": "2026-03-26T22:59:12.865Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 766,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223087,
+              "name": "Statikk Shiv"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 667
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Juiced, Goredrink, or ADAPT?",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Goredrink",
+          "tier": "Silver",
+          "description": "Gain 15% omnivamp."
+        },
+        {
+          "name": "Juiced",
+          "tier": "Silver",
+          "description": "Basic attacks on-hit against enemy champions consume 2.5% of your maximum mana to deal bonus magic damage equal to 4.5% of your maximum mana. This damage can critically strike for 100 bonus damage."
+        },
+        {
+          "name": "ADAPt",
+          "tier": "Silver",
+          "description": "Convert all of your bonus attack damage into ability power at a rate of 1 ability power per 0.6 bonus attack damage. Additionally, increase your ability power by 15%."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Goredrink**. Warwick gets way more value from 15% omnivamp than from mana-scaling auto damage or converting your AD into AP. Re-roll **Juiced** and **ADAPT**.",
+      "latencyMs": 2393,
+      "tokensIn": 2668,
+      "tokensOut": 159
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 766,
+      "champion": "Warwick",
+      "gameTime": "11:07"
+    }
+  },
+  {
+    "label": "Warwick @11:26: augment choice",
+    "index": 20,
+    "timestamp": "2026-03-26T22:59:31.552Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 923,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 686
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Upgrade Immolate, Goredrink, or Mighty Shield.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Upgrade Immolate",
+          "tier": "Silver",
+          "description": "Upgrades Bami's Cinder, Hollow Radiance, Sunfire Aegis, and Void Immolation, empowering Immolate to additionally grant you 12 gold per tick for each enemy champion afflicted by its effect. Additionally, gain 250 gold."
+        },
+        {
+          "name": "Mighty Shield",
+          "tier": "Silver",
+          "description": "Gain 40 to 100 adaptive force for 3 seconds upon gaining a shield (5 second cooldown)."
+        },
+        {
+          "name": "Goredrink",
+          "tier": "Silver",
+          "description": "Gain 15% omnivamp."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Goredrink**. You’re Warwick with Titanic/Sunfire path, so 15% omnivamp is huge and always live; **Upgrade Immolate** is good only if you’re already on the Bami/Sunfire line, but Goredrink is the stronger combat spike right now. Skip **Mighty Shield**.",
+      "latencyMs": 1805,
+      "tokensIn": 2721,
+      "tokensOut": 192
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 923,
+      "champion": "Warwick",
+      "gameTime": "11:26"
+    }
+  },
+  {
+    "label": "Warwick @11:40: general question",
+    "index": 21,
+    "timestamp": "2026-03-26T22:59:46.595Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 1046,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223153,
+              "name": "Blade of The Ruined King"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223085,
+              "name": "Runaan's Hurricane"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 3600,
+              "name": "Kalista's Black Spear"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 700
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "I am already on the balmy Sunfire line. I have a Sunfire Aegis. How do you not know that?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "You’re right — I should be tracking your current items better. If you’re already on **Sunfire Aegis**, then **Upgrade Immolate** is the better take; it directly amps your current item and is the cleanest fit for Warwick’s frontlining. ",
+      "latencyMs": 1651,
+      "tokensIn": 2712,
+      "tokensOut": 192
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 1046,
+      "champion": "Warwick",
+      "gameTime": "11:40"
+    }
+  },
+  {
+    "label": "Warwick @12:01: item question",
+    "index": 22,
+    "timestamp": "2026-03-26T23:00:07.805Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 1475,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 2138,
+              "name": "Elixir of Iron"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 721
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Does this mean I should buy the other Bommi's Cinder item now?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "No. If you already have **Sunfire Aegis**, don’t buy another Bami’s-style item — upgrade your next **armor/HP** slot instead and keep stacking tank stats for MF/Cait/Viego.",
+      "latencyMs": 2790,
+      "tokensIn": 2767,
+      "tokensOut": 106
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 1475,
+      "champion": "Warwick",
+      "gameTime": "12:01"
+    }
+  },
+  {
+    "label": "Warwick @12:15: item question",
+    "index": 23,
+    "timestamp": "2026-03-26T23:00:21.979Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 1594,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 735
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "What's my next item to buy?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy an **armor item next** — specifically **Chain Vest into a full armor tank item**. You’re already covered on damage with Titanic/Sunfire, and the enemy’s MF/Cait/Viego are the real threat right now.",
+      "latencyMs": 1406,
+      "tokensIn": 2820,
+      "tokensOut": 125
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 1594,
+      "champion": "Warwick",
+      "gameTime": "12:15"
+    }
+  },
+  {
+    "label": "Warwick @12:24: augment choice",
+    "index": 24,
+    "timestamp": "2026-03-26T23:00:29.547Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 1674,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 6,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 226694,
+              "name": "Serylda's Grudge"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 744
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Don't tell me the low level item, tell me the full item.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Randuin’s Omen** next. It’s the best full item into MF/Cait crit threat, and the armor + HP is exactly what Warwick needs right now.",
+      "latencyMs": 1015,
+      "tokensIn": 2889,
+      "tokensOut": 50
+    },
+    "error": null,
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 1674,
+      "champion": "Warwick",
+      "gameTime": "12:24"
+    }
+  },
+  {
+    "label": "Warwick @14:05: augment choice",
+    "index": 25,
+    "timestamp": "2026-03-26T23:02:10.057Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 12,
+        "currentGold": 766,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 76,
+          "magicResist": 52,
+          "maxHealth": 1595,
+          "currentHealth": 1595,
+          "moveSpeed": 335,
+          "attackSpeed": 0.764,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 3,
+          "deaths": 7,
+          "assists": 4,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 1052,
+              "name": "Amplifying Tome"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 221058,
+              "name": "Needlessly Large Rod"
+            },
+            {
+              "id": 1052,
+              "name": "Amplifying Tome"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 226694,
+              "name": "Serylda's Grudge"
+            },
+            {
+              "id": 2021,
+              "name": "Tunneler"
+            },
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 1018,
+              "name": "Cloak of Agility"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 845
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Alright, now I have a Randuin's, what else do I get? What's my next big item, main item?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Buy **Spirit Visage** next. You already have enough armor, and Warwick gets huge value from the extra healing on Q/passive and the mixed-damage enemy comp means MR is your best next big spike.",
+      "latencyMs": 1726,
+      "tokensIn": 3009,
+      "tokensOut": 143
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Randuin's Omen",
+        "Sunfire Aegis"
+      ],
+      "gold": 766,
+      "champion": "Warwick",
+      "gameTime": "14:05"
+    }
+  },
+  {
+    "label": "Warwick @15:41: augment choice",
+    "index": 26,
+    "timestamp": "2026-03-26T23:03:46.603Z",
+    "model": "gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 13,
+        "currentGold": 397,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 81,
+          "magicResist": 54,
+          "maxHealth": 1704,
+          "currentHealth": 1704,
+          "moveSpeed": 335,
+          "attackSpeed": 0.778,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 3,
+          "deaths": 8,
+          "assists": 6,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 3211,
+              "name": "Spectre's Cowl"
+            },
+            {
+              "id": 223067,
+              "name": "Kindlegem"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223157,
+              "name": "Zhonya's Hourglass"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            },
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 221053,
+              "name": "Vampiric Scepter"
+            },
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 226694,
+              "name": "Serylda's Grudge"
+            },
+            {
+              "id": 223814,
+              "name": "Edge of Night"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 221053,
+              "name": "Vampiric Scepter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 941
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Once I have Spirit Visage, I will only have room for one more item. What will that item be?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Your last item should be **Thornmail**. You need anti-heal and more armor for Viego plus the crit ADCs, and it finishes your tank profile better than any other option.",
+      "latencyMs": 1176,
+      "tokensIn": 3145,
+      "tokensOut": 91
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Randuin's Omen",
+        "Sunfire Aegis",
+        "Spectre's Cowl",
+        "Kindlegem"
+      ],
+      "gold": 397,
+      "champion": "Warwick",
+      "gameTime": "15:41"
+    }
+  },
+  {
+    "label": "Warwick @16:42: augment choice",
+    "index": 27,
+    "timestamp": "2026-03-26T23:04:49.007Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 15,
+        "currentGold": 1623,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 91,
+          "magicResist": 59,
+          "maxHealth": 1933,
+          "currentHealth": 1933,
+          "moveSpeed": 335,
+          "attackSpeed": 0.807,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 3,
+          "deaths": 9,
+          "assists": 10,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 3211,
+              "name": "Spectre's Cowl"
+            },
+            {
+              "id": 223067,
+              "name": "Kindlegem"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223157,
+              "name": "Zhonya's Hourglass"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            },
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223153,
+              "name": "Blade of The Ruined King"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 226694,
+              "name": "Serylda's Grudge"
+            },
+            {
+              "id": 223814,
+              "name": "Edge of Night"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 221053,
+              "name": "Vampiric Scepter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1002
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Slow and steady, cheating and holy fire.",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Slow and Steady",
+          "tier": "Gold",
+          "description": "Your base attack speed is set to a static amount of 0.625 and your attack rate no longer benefits from any source of attack speed bonuses. In return, you gain 25 bonus attack damage and convert every 1% bonus attack speed into 1 bonus attack damage."
+        },
+        {
+          "name": "Holy Fire",
+          "tier": "Gold",
+          "description": "Your heals and shields cause you to fire a missile to the nearest enemy unit within 650 units over 0.32 seconds, applying a Burn upon arrival that deals magic damage equal to 0.2% of the target's maximum health every second over 5 seconds, for a total of 1% (1.5-second cooldown). The Burn's per-tick damage increases to up to 0.8% of the target's maximum health based on the relative value of the triggering heal or shield against the maximum health of the ally recipient, for a total maximum damage of 4% of the target's maximum health."
+        },
+        {
+          "name": "Cheating",
+          "tier": "Gold",
+          "description": "Your Recall is now functional and is upgraded to Empowered Recall. Completing an Empowered Recall channel enables the shop. Additionally, the spawn platform will now provide healing and resource restoration for you."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Holy Fire**. Warwick constantly procs healing, so this turns your sustain into extra AoE damage and actually fits your build. Re-roll **Slow and Steady** and **Cheating**.",
+      "latencyMs": 2017,
+      "tokensIn": 3471,
+      "tokensOut": 159
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Randuin's Omen",
+        "Sunfire Aegis",
+        "Spectre's Cowl",
+        "Kindlegem"
+      ],
+      "gold": 1623,
+      "champion": "Warwick",
+      "gameTime": "16:42"
+    }
+  },
+  {
+    "label": "Warwick @16:56: augment choice",
+    "index": 28,
+    "timestamp": "2026-03-26T23:05:01.946Z",
+    "model": "gpt-5.4-mini",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 15,
+        "currentGold": 1812,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 91,
+          "magicResist": 59,
+          "maxHealth": 1933,
+          "currentHealth": 1933,
+          "moveSpeed": 335,
+          "attackSpeed": 0.807,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 3,
+          "deaths": 9,
+          "assists": 10,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 3211,
+              "name": "Spectre's Cowl"
+            },
+            {
+              "id": 223067,
+              "name": "Kindlegem"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223157,
+              "name": "Zhonya's Hourglass"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 323070,
+              "name": "Tear of the Goddess"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 223115,
+              "name": "Nashor's Tooth"
+            },
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 226672,
+              "name": "Kraken Slayer"
+            },
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223153,
+              "name": "Blade of The Ruined King"
+            },
+            {
+              "id": 1033,
+              "name": "Null-Magic Mantle"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 226694,
+              "name": "Serylda's Grudge"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 223814,
+              "name": "Edge of Night"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 223036,
+              "name": "Lord Dominik's Regards"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 223153,
+              "name": "Blade of The Ruined King"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 1016
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Demon's Dance, Soul Eater, and Holy Fire",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Demon's Dance",
+          "tier": "Gold",
+          "description": "Gain the Fleet Footwork and Grasp of the Undying keystone runes."
+        },
+        {
+          "name": "Soul Eater",
+          "tier": "Gold",
+          "description": "Immobilizing or grounding an enemy champion grants you 20 bonus health, stacking infinitely"
+        },
+        {
+          "name": "Holy Fire",
+          "tier": "Gold",
+          "description": "Your heals and shields cause you to fire a missile to the nearest enemy unit within 650 units over 0.32 seconds, applying a Burn upon arrival that deals magic damage equal to 0.2% of the target's maximum health every second over 5 seconds, for a total of 1% (1.5-second cooldown). The Burn's per-tick damage increases to up to 0.8% of the target's maximum health based on the relative value of the triggering heal or shield against the maximum health of the ally recipient, for a total maximum damage of 4% of the target's maximum health."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Take **Holy Fire**. Warwick constantly self-heals, so it gives you the most free damage in every fight. Re-roll **Demon's Dance** and **Soul Eater**.",
+      "latencyMs": 1750,
+      "tokensIn": 3496,
+      "tokensOut": 174
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Randuin's Omen",
+        "Sunfire Aegis",
+        "Spectre's Cowl",
+        "Kindlegem"
+      ],
+      "gold": 1812,
+      "champion": "Warwick",
+      "gameTime": "16:56"
+    }
+  }
+]

--- a/fixtures/coaching-sessions-v2/sr-yunara-2026-03-27.json
+++ b/fixtures/coaching-sessions-v2/sr-yunara-2026-03-27.json
@@ -1,0 +1,1557 @@
+[
+  {
+    "label": "Yunara @0:29: augment choice",
+    "index": 0,
+    "timestamp": "2026-03-27T19:24:44.139Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 1,
+        "currentGold": 50,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 25,
+          "magicResist": 30,
+          "maxHealth": 590,
+          "currentHealth": 590,
+          "moveSpeed": 325,
+          "attackSpeed": 0.65,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 1,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 29
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "All right, talk to me about what my go-to combo is for this champ.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Go-to: auto pokes > Q when they step up > E to keep spacing > R when you need DPS spike or chase. In lane: auto-Q-auto, save E for disengage. If fighting all-in: E in, Q mid-kite, R ASAP, then keep autoing. Core rule: keep attacking to stack your on-hit/crit value; don’t waste E if you can just kite with autos.",
+      "latencyMs": 2660,
+      "tokensIn": 630,
+      "tokensOut": 101
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 50,
+      "champion": "Yunara",
+      "gameTime": "0:29"
+    }
+  },
+  {
+    "label": "Yunara @3:54: item question",
+    "index": 1,
+    "timestamp": "2026-03-27T19:28:09.837Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 4,
+        "currentGold": 1033,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 35,
+          "magicResist": 33,
+          "maxHealth": 839,
+          "currentHealth": 839,
+          "moveSpeed": 325,
+          "attackSpeed": 0.679,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1107,
+              "name": "Scorchclaw Pup"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3865,
+              "name": "World Atlas"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1054,
+              "name": "Doran's Shield"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 234
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "That's my first item.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Best first buy: **Berserker’s Greaves** if you can buy now; otherwise **long sword + dagger** toward your core crit/on-hit start. Since enemy is mostly AD, if you need safety in lane, **Plated Steelcaps** is the defensive swap. Don’t buy Doran’s Blade again.",
+      "latencyMs": 1901,
+      "tokensIn": 777,
+      "tokensOut": 183
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 1033,
+      "champion": "Yunara",
+      "gameTime": "3:54"
+    }
+  },
+  {
+    "label": "Yunara @4:41: item question",
+    "index": 2,
+    "timestamp": "2026-03-27T19:28:56.703Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 4,
+        "currentGold": 29,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 35,
+          "magicResist": 33,
+          "maxHealth": 839,
+          "currentHealth": 839,
+          "moveSpeed": 325,
+          "attackSpeed": 0.679,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1107,
+              "name": "Scorchclaw Pup"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3865,
+              "name": "World Atlas"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 4,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1054,
+              "name": "Doran's Shield"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 281
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "Why did you say if you can buy now when you know exactly how much gold I have?",
+      "history": [],
+      "augmentOptions": [
+        {
+          "name": "Transmute: Gold",
+          "tier": "Silver",
+          "description": "Gain one random Gold augment, excluding the other two offerings in your current assortment."
+        }
+      ]
+    },
+    "response": {
+      "answer": "Because I was answering from the shop-state as a general condition, not your exact gold. With 29g, you can’t buy anything relevant right now, so the correct call is: wait. Also you already own Berserker’s Greaves, so don’t re-buy them.",
+      "latencyMs": 2166,
+      "tokensIn": 928,
+      "tokensOut": 72
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 29,
+      "champion": "Yunara",
+      "gameTime": "4:41"
+    }
+  },
+  {
+    "label": "Yunara @5:42: augment choice",
+    "index": 3,
+    "timestamp": "2026-03-27T19:29:56.980Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 5,
+        "currentGold": 726,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 34,
+          "maxHealth": 930,
+          "currentHealth": 930,
+          "moveSpeed": 325,
+          "attackSpeed": 0.69,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1107,
+              "name": "Scorchclaw Pup"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3865,
+              "name": "World Atlas"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1054,
+              "name": "Doran's Shield"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 342
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "Well, that was my next item",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Next: **B. Fated Ashes** if you want best damage spike. If not, **Long Sword + Dagger** is the safe stat buy. You already have Berserker’s Greaves and Doran’s Blade, so don’t repeat those.",
+      "latencyMs": 2007,
+      "tokensIn": 964,
+      "tokensOut": 135
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 726,
+      "champion": "Yunara",
+      "gameTime": "5:42"
+    }
+  },
+  {
+    "label": "Yunara @6:08: general question",
+    "index": 4,
+    "timestamp": "2026-03-27T19:30:22.896Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 5,
+        "currentGold": 779,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 34,
+          "maxHealth": 930,
+          "currentHealth": 930,
+          "moveSpeed": 325,
+          "attackSpeed": 0.69,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1107,
+              "name": "Scorchclaw Pup"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3865,
+              "name": "World Atlas"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1054,
+              "name": "Doran's Shield"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 368
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "This isn't faded ashes for AP champs.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Next buy: **Long Sword + Dagger**. Best raw spike for Yunara; builds into your damage core and fits your crit/on-hit plan. If you want safer lane only, **pick up a Cloth Armor component instead of extra damage** against this AD-heavy team, but don’t sit on gold.",
+      "latencyMs": 1805,
+      "tokensIn": 1033,
+      "tokensOut": 139
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 779,
+      "champion": "Yunara",
+      "gameTime": "6:08"
+    }
+  },
+  {
+    "label": "Yunara @6:29: item question",
+    "index": 5,
+    "timestamp": "2026-03-27T19:30:43.424Z",
+    "model": "openai/gpt-5.4-mini",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Yunara",
+        "level": 5,
+        "currentGold": 222,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 39,
+          "magicResist": 34,
+          "maxHealth": 930,
+          "currentHealth": 930,
+          "moveSpeed": 325,
+          "attackSpeed": 0.69,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Yunara",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Urgot",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Diana",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1107,
+              "name": "Scorchclaw Pup"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 223009,
+              "name": "Boots of Swiftness"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zyra",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3865,
+              "name": "World Atlas"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Volibear",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 222022,
+              "name": "Glowing Mote"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lucian",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1055,
+              "name": "Doran's Blade"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Irelia",
+          "team": "CHAOS",
+          "level": 5,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1054,
+              "name": "Doran's Shield"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1042,
+              "name": "Dagger"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            },
+            {
+              "id": 2055,
+              "name": "Control Ward"
+            },
+            {
+              "id": 3340,
+              "name": "Stealth Ward"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "PRACTICETOOL",
+      "gameTime": 389
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "I wanted to know what the next full item was. Not partial.",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": {
+      "answer": "Next full item: **Kraken Slayer**. Best immediate completed spike for Yunara here: strong DPS, good vs this AD-heavy enemy, and fits your crit/on-hit style. Save gold for it; don’t buy a partial unless you must lane.",
+      "latencyMs": 1545,
+      "tokensIn": 1017,
+      "tokensOut": 149
+    },
+    "error": null,
+    "scorerContext": {
+      "items": [],
+      "gold": 222,
+      "champion": "Yunara",
+      "gameTime": "6:29"
+    }
+  }
+]

--- a/fixtures/coaching-sessions-v2/synthetic-continuity.json
+++ b/fixtures/coaching-sessions-v2/synthetic-continuity.json
@@ -1,0 +1,879 @@
+[
+  {
+    "label": "SYNTHETIC: Reference to early tank recommendation after 6 exchanges",
+    "index": 0,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 720
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit"],
+    "query": {
+      "question": "Earlier you told me to go tank. Is that still the right call?",
+      "history": [
+        {
+          "question": "Pinball, Outlaw's Grit, and Big Brain.",
+          "answer": "Take Outlaw's Grit. Go full tank build with your augment giving free resists on dashes."
+        },
+        {
+          "question": "Recursion, Overflow, Bread and Cheese",
+          "answer": "Take Overflow. The healing amp synergizes with your tank sustain."
+        },
+        {
+          "question": "What item should I buy next?",
+          "answer": "Build Sunfire Aegis for armor into this AD-heavy comp."
+        },
+        {
+          "question": "Scopier Weapons, Overflow, Divine Intervention",
+          "answer": "Take Overflow again. Same reasoning as before."
+        },
+        {
+          "question": "Juiced, Goredrink, or ADAPT?",
+          "answer": "Take Goredrink. 15% omnivamp is huge on Warwick tank."
+        },
+        {
+          "question": "What's my next item?",
+          "answer": "Build Spirit Visage for MR and enhanced healing."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["tank"],
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 800,
+      "champion": "Warwick",
+      "gameTime": "12:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Reference to specific item recommendation after 7 exchanges",
+    "index": 1,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 13,
+        "currentGold": 1200,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 81,
+          "magicResist": 54,
+          "maxHealth": 1704,
+          "currentHealth": 1704,
+          "moveSpeed": 335,
+          "attackSpeed": 0.778,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 5,
+          "deaths": 6,
+          "assists": 9,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 3051,
+              "name": "Hearthbound Axe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 840
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Overflow"],
+    "query": {
+      "question": "You mentioned Thornmail earlier. Should I still get that?",
+      "history": [
+        {
+          "question": "What should I build after Sunfire?",
+          "answer": "Get Thornmail next. You need anti-heal for Viego and more armor for the AD threats."
+        },
+        {
+          "question": "Slow and Steady, Cheating, and Holy Fire.",
+          "answer": "Take Holy Fire. Your constant healing procs it for free AoE damage."
+        },
+        {
+          "question": "Demon's Dance, Soul Eater, and Holy Fire",
+          "answer": "Take Holy Fire again. Same reasoning."
+        },
+        {
+          "question": "What augment set am I closest to completing?",
+          "answer": "You're not close to any set bonus yet."
+        },
+        {
+          "question": "How should I play teamfights right now?",
+          "answer": "R into their backline, pop Primal Howl for fear, then stick to the carry."
+        },
+        {
+          "question": "Should I focus Viego or the ADCs?",
+          "answer": "Focus Caitlyn or MF first. Viego is harder to lock down."
+        },
+        {
+          "question": "I ended up getting Randuin's instead. What now?",
+          "answer": "Good call. Build Spirit Visage next for MR."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["Thornmail", "anti-heal", "grievous"],
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Sunfire Aegis",
+        "Randuin's Omen"
+      ],
+      "gold": 1200,
+      "champion": "Warwick",
+      "gameTime": "14:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Reference to playstyle advice after 6 exchanges",
+    "index": 2,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 15,
+        "currentGold": 500,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 91,
+          "magicResist": 59,
+          "maxHealth": 1933,
+          "currentHealth": 1933,
+          "moveSpeed": 335,
+          "attackSpeed": 0.807,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 6,
+          "deaths": 8,
+          "assists": 11,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            },
+            {
+              "id": 223143,
+              "name": "Randuin's Omen"
+            },
+            {
+              "id": 223065,
+              "name": "Spirit Visage"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            },
+            {
+              "id": 224646,
+              "name": "Stormsurge"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            },
+            {
+              "id": 223135,
+              "name": "Void Staff"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            },
+            {
+              "id": 223153,
+              "name": "Blade of the Ruined King"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            },
+            {
+              "id": 3035,
+              "name": "Last Whisper"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 15,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            },
+            {
+              "id": 223094,
+              "name": "Rapid Firecannon"
+            },
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 960
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Overflow"],
+    "query": {
+      "question": "Remember when you said I should focus the backline? That's not working. What should I do instead?",
+      "history": [
+        {
+          "question": "How should I play teamfights?",
+          "answer": "R into backline, Primal Howl for fear, stick to carries."
+        },
+        {
+          "question": "Demon's Dance, Soul Eater, and Holy Fire",
+          "answer": "Take Holy Fire."
+        },
+        {
+          "question": "What's my last item?",
+          "answer": "Thornmail. Anti-heal and armor."
+        },
+        {
+          "question": "Slow and Steady, Cheating, and Holy Fire",
+          "answer": "Take Holy Fire."
+        },
+        {
+          "question": "Should I sell boots for another item?",
+          "answer": "No. Keep Mercs for tenacity into Vex fear and Malphite knockup."
+        },
+        {
+          "question": "I keep dying before I reach the backline.",
+          "answer": "Try flanking from the side instead of running in from the front."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": [
+      "backline",
+      "flank",
+      "peel",
+      "frontline",
+      "Viego",
+      "carry"
+    ],
+    "scorerContext": {
+      "items": [
+        "Mercury's Treads",
+        "Titanic Hydra",
+        "Sunfire Aegis",
+        "Randuin's Omen",
+        "Spirit Visage"
+      ],
+      "gold": 500,
+      "champion": "Warwick",
+      "gameTime": "16:00"
+    }
+  }
+]

--- a/fixtures/coaching-sessions-v2/synthetic-sr.json
+++ b/fixtures/coaching-sessions-v2/synthetic-sr.json
@@ -1,0 +1,654 @@
+[
+  {
+    "label": "SYNTHETIC: SR lane vs roam decision",
+    "index": 0,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "sr",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Ahri",
+        "level": 8,
+        "currentGold": 450,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 53,
+          "abilityPower": 0,
+          "armor": 45,
+          "magicResist": 38,
+          "maxHealth": 1191,
+          "currentHealth": 1191,
+          "moveSpeed": 330,
+          "attackSpeed": 0.753,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 2,
+          "deaths": 1,
+          "assists": 3,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Vi",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kai'Sa",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3134,
+              "name": "Serrated Dirk"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lee Sin",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3051,
+              "name": "Hearthbound Axe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jinx",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1037,
+              "name": "Pickaxe"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Yone",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "CLASSIC",
+      "gameTime": 600
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "Should I keep farming mid or roam to help bot lane?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["roam", "bot", "lane", "push", "wave", "priority"],
+    "scorerContext": {
+      "items": ["Lost Chapter", "Boots"],
+      "gold": 450,
+      "champion": "Ahri",
+      "gameTime": "10:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: SR objective timing decision",
+    "index": 1,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "sr",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Vi",
+        "level": 7,
+        "currentGold": 300,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 63,
+          "abilityPower": 0,
+          "armor": 53,
+          "magicResist": 42,
+          "maxHealth": 1164,
+          "currentHealth": 1164,
+          "moveSpeed": 340,
+          "attackSpeed": 0.706,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Vi",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 1,
+          "deaths": 2,
+          "assists": 4,
+          "items": [
+            {
+              "id": 1106,
+              "name": "Gustwalker Hatchling"
+            },
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kai'Sa",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kayn",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1106,
+              "name": "Gustwalker Hatchling"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3044,
+              "name": "Phage"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "CLASSIC",
+      "gameTime": 480
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "Dragon spawns in 30 seconds. Should I set up or keep farming jungle?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": [
+      "dragon",
+      "objective",
+      "jungle",
+      "gank",
+      "priority",
+      "bot",
+      "vision"
+    ],
+    "scorerContext": {
+      "items": ["Gustwalker Hatchling", "Long Sword", "Boots"],
+      "gold": 300,
+      "champion": "Vi",
+      "gameTime": "8:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: SR jungle invade decision",
+    "index": 2,
+    "timestamp": "2026-03-27T00:00:00Z",
+    "model": "synthetic",
+    "category": "sr",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Vi",
+        "level": 6,
+        "currentGold": 150,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 63,
+          "abilityPower": 0,
+          "armor": 49,
+          "magicResist": 40,
+          "maxHealth": 1070,
+          "currentHealth": 1070,
+          "moveSpeed": 340,
+          "attackSpeed": 0.695,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Vi",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 3,
+          "deaths": 0,
+          "assists": 2,
+          "items": [
+            {
+              "id": 1106,
+              "name": "Gustwalker Hatchling"
+            },
+            {
+              "id": 1001,
+              "name": "Boots"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kai'Sa",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3802,
+              "name": "Lost Chapter"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kayn",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 1036,
+              "name": "Long Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 221038,
+              "name": "B. F. Sword"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 6,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 3044,
+              "name": "Phage"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "CLASSIC",
+      "gameTime": 420
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "Their jungler is bot side. Should I invade their top jungle?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": [
+      "invade",
+      "jungle",
+      "ward",
+      "vision",
+      "camp",
+      "counter"
+    ],
+    "scorerContext": {
+      "items": ["Gustwalker Hatchling", "Boots"],
+      "gold": 150,
+      "champion": "Vi",
+      "gameTime": "7:00"
+    }
+  }
+]

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "audit-augments": "tsx scripts/audit-augments.ts",
     "preview-prompts": "tsx scripts/preview-prompts.ts",
     "extract-fixtures": "tsx scripts/extract-fixtures.ts",
+    "convert-fixtures": "tsx scripts/convert-fixtures-multiturn.ts",
     "inspect-evals": "tsx scripts/inspect-evals.ts",
     "eval": "evalite src/lib/ai/coaching.eval.ts",
     "eval:watch": "evalite watch src/lib/ai/coaching.eval.ts",

--- a/scripts/convert-fixtures-multiturn.ts
+++ b/scripts/convert-fixtures-multiturn.ts
@@ -238,8 +238,9 @@ function resolveGameModeId(
 
 /** Format seconds as "M:SS" */
 function formatGameTime(seconds: number): string {
-  const mins = Math.floor(seconds / 60);
-  const secs = String(seconds % 60).padStart(2, "0");
+  const total = Math.floor(seconds);
+  const mins = Math.floor(total / 60);
+  const secs = String(total % 60).padStart(2, "0");
   return `${mins}:${secs}`;
 }
 

--- a/scripts/convert-fixtures-multiturn.ts
+++ b/scripts/convert-fixtures-multiturn.ts
@@ -1,0 +1,445 @@
+/**
+ * Convert coaching eval fixtures from the old CoachingContext format to a
+ * raw format consumable by buildGameSystemPrompt(), takeGameSnapshot(), and
+ * createConversationSession().
+ *
+ * Reads from:  fixtures/coaching-sessions/*.json
+ * Writes to:   fixtures/coaching-sessions-v2/*.json
+ *
+ * Usage:
+ *   pnpm convert-fixtures
+ */
+
+import { readFileSync, writeFileSync, readdirSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { fetchAndCache } from "../src/lib/data-ingest/index";
+import type {
+  Champion,
+  Item,
+  ChampionStats,
+} from "../src/lib/data-ingest/types";
+
+// ---------------------------------------------------------------------------
+// Old fixture shape
+// ---------------------------------------------------------------------------
+
+interface OldFixture {
+  label: string;
+  index: number;
+  timestamp: string;
+  model: string;
+  context: {
+    champion: {
+      name: string;
+      level: number;
+      abilities: string;
+      statProfile: string | null;
+    };
+    currentItems: Array<{ name: string; description: string }>;
+    currentGold: number;
+    kda: { kills: number; deaths: number; assists: number };
+    currentAugments: Array<{
+      name: string;
+      description: string;
+      sets?: string[];
+    }>;
+    enemyTeam: Array<{
+      champion: string;
+      items: Array<{ name: string; description: string }>;
+    }>;
+    allyTeam: Array<{ champion: string }>;
+    teamAnalysis: string | null;
+    augmentSets: Array<{
+      name: string;
+      bonuses: Array<{ threshold: number; description: string }>;
+    }>;
+    gameMode: string;
+    lcuGameMode: string;
+    gameTime: number;
+    balanceOverrides: string | null;
+  };
+  query: {
+    question: string;
+    history?: Array<{ question: string; answer: string }>;
+    augmentOptions?: Array<{
+      name: string;
+      description: string;
+      tier: string;
+      sets?: string[];
+    }>;
+  };
+  response: {
+    answer: string;
+    latencyMs: number;
+    tokensIn: number;
+    tokensOut: number;
+  } | null;
+  error: string | null;
+  expectedReferences?: string[];
+  category?: string;
+}
+
+// ---------------------------------------------------------------------------
+// New fixture shape
+// ---------------------------------------------------------------------------
+
+interface ActivePlayerStats {
+  abilityPower: number;
+  armor: number;
+  attackDamage: number;
+  attackSpeed: number;
+  abilityHaste: number;
+  critChance: number;
+  magicResist: number;
+  moveSpeed: number;
+  maxHealth: number;
+  currentHealth: number;
+}
+
+interface PlayerEntry {
+  championName: string;
+  team: "ORDER" | "CHAOS";
+  level: number;
+  kills: number;
+  deaths: number;
+  assists: number;
+  items: Array<{ id: number; name: string }>;
+  summonerSpells: [string, string];
+  riotIdGameName: string;
+  position: string;
+  isActivePlayer: boolean;
+}
+
+interface MultiTurnFixture {
+  label: string;
+  index: number;
+  timestamp: string;
+  model: string;
+  category: string;
+
+  gameState: {
+    status: "connected";
+    activePlayer: {
+      championName: string;
+      level: number;
+      currentGold: number;
+      runes: {
+        keystone: string;
+        primaryTree: string;
+        secondaryTree: string;
+      };
+      stats: ActivePlayerStats;
+    };
+    players: PlayerEntry[];
+    gameMode: string;
+    gameTime: number;
+  };
+
+  gameModeId: "aram-mayhem" | "aram" | "classic";
+  chosenAugments: string[];
+
+  query: {
+    question: string;
+    history?: Array<{ question: string; answer: string }>;
+    augmentOptions?: Array<{
+      name: string;
+      description: string;
+      tier: string;
+      sets?: string[];
+    }>;
+  };
+
+  response: {
+    answer: string;
+    latencyMs: number;
+    tokensIn: number;
+    tokensOut: number;
+  } | null;
+  error: string | null;
+  expectedReferences?: string[];
+
+  scorerContext: {
+    items: string[];
+    gold: number;
+    champion: string;
+    gameTime: string;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const ROOT = join(import.meta.dirname, "..");
+const INPUT_DIR = join(ROOT, "fixtures", "coaching-sessions");
+const OUTPUT_DIR = join(ROOT, "fixtures", "coaching-sessions-v2");
+
+/** Riot's per-level scaling factor */
+function levelScaleFactor(level: number): number {
+  return (level - 1) * (0.7025 + 0.0175 * (level - 1));
+}
+
+/** Compute approximate base+level stats for a champion */
+function computeBaseStats(
+  stats: ChampionStats,
+  level: number
+): ActivePlayerStats {
+  const scale = levelScaleFactor(level);
+  return {
+    attackDamage: Math.round(
+      stats.attackdamage + stats.attackdamageperlevel * scale
+    ),
+    abilityPower: 0, // base AP is always 0
+    armor: Math.round(stats.armor + stats.armorperlevel * scale),
+    magicResist: Math.round(
+      stats.spellblock + stats.spellblockperlevel * scale
+    ),
+    maxHealth: Math.round(stats.hp + stats.hpperlevel * scale),
+    currentHealth: Math.round(stats.hp + stats.hpperlevel * scale),
+    moveSpeed: stats.movespeed,
+    attackSpeed:
+      Math.round(
+        stats.attackspeed *
+          (1 + (stats.attackspeedperlevel * scale) / 100) *
+          1000
+      ) / 1000,
+    abilityHaste: 0,
+    critChance: 0,
+  };
+}
+
+/** Build a reverse lookup: lowercase item name -> Item */
+function buildItemNameIndex(items: Map<number, Item>): Map<string, Item> {
+  const index = new Map<string, Item>();
+  for (const item of items.values()) {
+    index.set(item.name.toLowerCase(), item);
+  }
+  return index;
+}
+
+/** Look up an item ID by name (case-insensitive), returning 0 if not found */
+function resolveItemId(name: string, itemNameIndex: Map<string, Item>): number {
+  return itemNameIndex.get(name.toLowerCase())?.id ?? 0;
+}
+
+/** Map gameMode string to gameModeId */
+function resolveGameModeId(
+  gameMode: string
+): "aram-mayhem" | "aram" | "classic" {
+  switch (gameMode.toUpperCase()) {
+    case "KIWI":
+      return "aram-mayhem";
+    case "ARAM":
+      return "aram";
+    default:
+      return "classic";
+  }
+}
+
+/** Format seconds as "M:SS" */
+function formatGameTime(seconds: number): string {
+  const mins = Math.floor(seconds / 60);
+  const secs = String(seconds % 60).padStart(2, "0");
+  return `${mins}:${secs}`;
+}
+
+// ---------------------------------------------------------------------------
+// Conversion
+// ---------------------------------------------------------------------------
+
+function convertFixture(
+  old: OldFixture,
+  champions: Map<string, Champion>,
+  itemNameIndex: Map<string, Item>
+): MultiTurnFixture {
+  const ctx = old.context;
+
+  // Champion lookup
+  const champion = champions.get(ctx.champion.name.toLowerCase());
+  if (!champion) {
+    console.warn(
+      `  WARN: Champion "${ctx.champion.name}" not found in game data — using placeholder stats`
+    );
+  }
+
+  const stats = champion
+    ? computeBaseStats(champion.stats, ctx.champion.level)
+    : {
+        attackDamage: 0,
+        abilityPower: 0,
+        armor: 0,
+        magicResist: 0,
+        maxHealth: 0,
+        currentHealth: 0,
+        moveSpeed: 0,
+        attackSpeed: 0,
+        abilityHaste: 0,
+        critChance: 0,
+      };
+
+  // Player items
+  const playerItems = ctx.currentItems.map((item) => ({
+    id: resolveItemId(item.name, itemNameIndex),
+    name: item.name,
+  }));
+
+  // Build players list
+  const players: PlayerEntry[] = [];
+
+  // Active player (ORDER team)
+  players.push({
+    championName: ctx.champion.name,
+    team: "ORDER",
+    level: ctx.champion.level,
+    kills: ctx.kda.kills,
+    deaths: ctx.kda.deaths,
+    assists: ctx.kda.assists,
+    items: playerItems,
+    summonerSpells: ["Flash", "Mark"],
+    riotIdGameName: "Player1",
+    position: "",
+    isActivePlayer: true,
+  });
+
+  // Allies (ORDER team)
+  ctx.allyTeam.forEach((ally, i) => {
+    players.push({
+      championName: ally.champion,
+      team: "ORDER",
+      level: ctx.champion.level, // approximate: use active player level
+      kills: 0,
+      deaths: 0,
+      assists: 0,
+      items: [],
+      summonerSpells: ["Flash", "Mark"],
+      riotIdGameName: `Ally${i + 1}`,
+      position: "",
+      isActivePlayer: false,
+    });
+  });
+
+  // Enemies (CHAOS team)
+  ctx.enemyTeam.forEach((enemy, i) => {
+    const enemyItems = enemy.items.map((item) => ({
+      id: resolveItemId(item.name, itemNameIndex),
+      name: item.name,
+    }));
+    players.push({
+      championName: enemy.champion,
+      team: "CHAOS",
+      level: ctx.champion.level, // approximate: use active player level
+      kills: 0,
+      deaths: 0,
+      assists: 0,
+      items: enemyItems,
+      summonerSpells: ["Flash", "Mark"],
+      riotIdGameName: `Enemy${i + 1}`,
+      position: "",
+      isActivePlayer: false,
+    });
+  });
+
+  return {
+    label: old.label,
+    index: old.index,
+    timestamp: old.timestamp,
+    model: old.model,
+    category: old.category ?? "common",
+
+    gameState: {
+      status: "connected",
+      activePlayer: {
+        championName: ctx.champion.name,
+        level: ctx.champion.level,
+        currentGold: ctx.currentGold,
+        runes: {
+          keystone: "Unknown",
+          primaryTree: "Unknown",
+          secondaryTree: "Unknown",
+        },
+        stats,
+      },
+      players,
+      gameMode: ctx.gameMode,
+      gameTime: ctx.gameTime,
+    },
+
+    gameModeId: resolveGameModeId(ctx.gameMode),
+    chosenAugments: ctx.currentAugments.map((a) => a.name),
+
+    query: old.query,
+    response: old.response,
+    error: old.error,
+    expectedReferences: old.expectedReferences,
+
+    scorerContext: {
+      items: ctx.currentItems.map((i) => i.name),
+      gold: ctx.currentGold,
+      champion: ctx.champion.name,
+      gameTime: formatGameTime(ctx.gameTime),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function main(): Promise<void> {
+  console.log("Loading game data...");
+  const gameData = await fetchAndCache();
+  console.log(
+    `Loaded ${gameData.champions.size} champions, ${gameData.items.size} items\n`
+  );
+
+  const itemNameIndex = buildItemNameIndex(gameData.items);
+
+  // Read input fixtures
+  const files = readdirSync(INPUT_DIR).filter((f) => f.endsWith(".json"));
+  if (files.length === 0) {
+    console.error(`No fixture files found in ${INPUT_DIR}`);
+    process.exit(1);
+  }
+
+  mkdirSync(OUTPUT_DIR, { recursive: true });
+
+  let totalConverted = 0;
+  let totalWarnings = 0;
+
+  for (const file of files) {
+    const inputPath = join(INPUT_DIR, file);
+    const raw = readFileSync(inputPath, "utf-8");
+    const oldFixtures: OldFixture[] = JSON.parse(raw);
+
+    console.log(`Converting ${file} (${oldFixtures.length} entries)...`);
+
+    const newFixtures: MultiTurnFixture[] = [];
+    for (const old of oldFixtures) {
+      const champion = gameData.champions.get(
+        old.context.champion.name.toLowerCase()
+      );
+      if (!champion) totalWarnings++;
+
+      newFixtures.push(convertFixture(old, gameData.champions, itemNameIndex));
+    }
+
+    const outputPath = join(OUTPUT_DIR, file);
+    writeFileSync(outputPath, JSON.stringify(newFixtures, null, 2));
+    console.log(`  -> ${outputPath} (${newFixtures.length} entries)\n`);
+    totalConverted += newFixtures.length;
+  }
+
+  console.log(
+    `Done. Converted ${totalConverted} fixtures across ${files.length} files.`
+  );
+  if (totalWarnings > 0) {
+    console.log(
+      `${totalWarnings} warning(s) — some champions were not found in game data.`
+    );
+  }
+}
+
+main().catch((err) => {
+  console.error("Fatal error:", err);
+  process.exit(1);
+});

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -19,6 +19,8 @@ import { DataBrowser } from "./components/DataBrowser";
 import {
   createModeRegistry,
   aramMayhemMode,
+  aramMode,
+  classicMode,
   buildEffectiveGameState,
 } from "./lib/mode";
 import { addSelectedAugment } from "./lib/mode/augment-selection";
@@ -28,6 +30,8 @@ import type { GameState } from "./lib/game-state/types";
 
 const registry = createModeRegistry();
 registry.register(aramMayhemMode);
+registry.register(aramMode);
+registry.register(classicMode);
 
 function App() {
   const engineRef = useRef<ReactiveEngine | null>(null);

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -172,11 +172,15 @@ function App() {
     prevGameModeRef.current = mode;
   }, [data, gameState]);
 
+  const detectedMode = useMemo(() => {
+    if (!data || gameState.status !== "connected") return null;
+    return registry.detect(gameState.gameMode);
+  }, [data, gameState.status, gameState.gameMode]);
+
   const effectiveState = useMemo(() => {
     if (!data || gameState.status !== "connected") {
       return buildEffectiveGameState(gameState, null);
     }
-    const detectedMode = registry.detect(gameState.gameMode);
     let modeContext = detectedMode
       ? detectedMode.buildContext(gameState, data)
       : null;
@@ -195,12 +199,7 @@ function App() {
     }
 
     return buildEffectiveGameState(gameState, modeContext);
-  }, [gameState, data, selectedAugments]);
-
-  const detectedMode = useMemo(() => {
-    if (!data || gameState.status !== "connected") return null;
-    return registry.detect(gameState.gameMode);
-  }, [data, gameState.status, gameState.gameMode]);
+  }, [gameState, data, selectedAugments, detectedMode]);
 
   const augmentSelection = {
     selectedAugments,

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import "./App.css";
 import { useState, useCallback, useEffect, useRef, useMemo } from "react";
+import { CoachingProvider } from "./hooks/useCoachingContext";
 import { useGameData } from "./hooks/useGameData";
 import { useGameLifecycle } from "./hooks/useGameLifecycle";
 import { useLiveGameState } from "./hooks/useLiveGameState";
@@ -196,6 +197,11 @@ function App() {
     return buildEffectiveGameState(gameState, modeContext);
   }, [gameState, data, selectedAugments]);
 
+  const detectedMode = useMemo(() => {
+    if (!data || gameState.status !== "connected") return null;
+    return registry.detect(gameState.gameMode);
+  }, [data, gameState.status, gameState.gameMode]);
+
   const augmentSelection = {
     selectedAugments,
     select: selectAugment,
@@ -261,11 +267,17 @@ function App() {
         </div>
       </div>
       {data && (
-        <DataBrowser
-          data={data}
-          effectiveState={effectiveState}
-          augmentSelection={augmentSelection}
-        />
+        <CoachingProvider
+          mode={detectedMode}
+          liveGameState={liveGame}
+          gameData={data}
+        >
+          <DataBrowser
+            data={data}
+            effectiveState={effectiveState}
+            augmentSelection={augmentSelection}
+          />
+        </CoachingProvider>
       )}
     </main>
   );

--- a/src/components/CoachingInput.tsx
+++ b/src/components/CoachingInput.tsx
@@ -1,13 +1,17 @@
 import { useState, useCallback, useRef, useEffect } from "react";
-import type {
-  CoachingResponse,
-  CoachingContext,
-  CoachingExchange,
-  CoachingQuery,
-  CoachingItem,
-} from "../lib/ai/types";
+import type { CoachingResponse, CoachingQuery } from "../lib/ai/types";
 import type { LoadedGameData } from "../lib/data-ingest";
-import { getCoachingResponse } from "../lib/ai/recommendation-engine";
+import type { GameState } from "../lib/game-state/types";
+import type { ConversationSession } from "../lib/ai/conversation-session";
+import { useCoachingMode } from "../hooks/useCoachingContext";
+import { useLiveGameState } from "../hooks/useLiveGameState";
+import { getMultiTurnCoachingResponse } from "../lib/ai/recommendation-engine";
+import { createConversationSession } from "../lib/ai/conversation-session";
+import { buildGameSystemPrompt } from "../lib/ai/prompts";
+import {
+  takeGameSnapshot,
+  formatStateSnapshot,
+} from "../lib/ai/state-formatter";
 import { playerIntent$, manualInput$ } from "../lib/reactive";
 import { augmentOffer$, augmentPicked$ } from "../lib/reactive/gep-bridge";
 import { createAugmentCoachingController } from "../lib/ai/augment-coaching";
@@ -17,7 +21,6 @@ const reactiveLog = getLogger("coaching:reactive");
 const proactiveLog = getLogger("coaching:proactive");
 
 interface CoachingInputProps {
-  context: CoachingContext | null;
   gameData: LoadedGameData;
 }
 
@@ -46,34 +49,67 @@ function extractAugmentOptions(
   return options.length > 0 ? options : undefined;
 }
 
-export function CoachingInput({ context, gameData }: CoachingInputProps) {
+export function CoachingInput({ gameData }: CoachingInputProps) {
+  const liveGameState = useLiveGameState();
+  const { mode, enemyStats } = useCoachingMode();
   const [loading, setLoading] = useState(false);
   const [latestExchange, setLatestExchange] = useState<{
     question: string;
     response: CoachingResponse;
   } | null>(null);
-  const [exchanges, setExchanges] = useState<CoachingExchange[]>([]);
-  const [chosenAugments, setChosenAugments] = useState<CoachingItem[]>([]);
+  const [chosenAugments, setChosenAugments] = useState<string[]>([]);
   const [error, setError] = useState<string | null>(null);
 
-  const contextRef = useRef(context);
-  const exchangesRef = useRef(exchanges);
+  // Refs for stable access in callbacks
+  const liveGameStateRef = useRef(liveGameState);
   const gameDataRef = useRef(gameData);
+  const modeRef = useRef(mode);
+  const enemyStatsRef = useRef(enemyStats);
   const chosenAugmentsRef = useRef(chosenAugments);
-  contextRef.current = context;
-  exchangesRef.current = exchanges;
+  const sessionRef = useRef<ConversationSession | null>(null);
+
+  liveGameStateRef.current = liveGameState;
   gameDataRef.current = gameData;
+  modeRef.current = mode;
+  enemyStatsRef.current = enemyStats;
   chosenAugmentsRef.current = chosenAugments;
 
   const apiKey =
     import.meta.env.VITE_OPENROUTER_API_KEY ??
     import.meta.env.VITE_OPENAI_API_KEY;
 
+  // Create/reset conversation session when mode changes (new game detected)
+  useEffect(() => {
+    if (!mode || !liveGameState.activePlayer) {
+      sessionRef.current = null;
+      return;
+    }
+
+    // Build the game state for the system prompt
+    const gameState: GameState = {
+      status: "connected",
+      activePlayer: liveGameState.activePlayer,
+      players: liveGameState.players,
+      gameMode: liveGameState.gameMode,
+      gameTime: liveGameState.gameTime,
+    };
+
+    const systemPrompt = buildGameSystemPrompt(mode, gameData, gameState);
+    sessionRef.current = createConversationSession(systemPrompt);
+    setChosenAugments([]);
+    setLatestExchange(null);
+    setError(null);
+
+    reactiveLog.info(
+      `Conversation session created for ${mode.displayName} | ${liveGameState.activePlayer.championName}`
+    );
+  }, [mode, gameData, liveGameState.activePlayer?.championName]);
+
   const submitQuestion = useCallback(
     async (question: string, options?: { signal?: AbortSignal }) => {
-      if (!contextRef.current || !apiKey || !question.trim()) {
-        const reason = !contextRef.current
-          ? "no context"
+      if (!sessionRef.current || !apiKey || !question.trim()) {
+        const reason = !sessionRef.current
+          ? "no session"
           : !apiKey
             ? "no API key"
             : "empty question";
@@ -81,6 +117,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
         return;
       }
 
+      // Track augment selections from voice input ("I chose X")
       const selectionPattern =
         /i (?:chose|picked|took|selected|went with)\s+(.+)/i;
       const selectionMatch = question.match(selectionPattern);
@@ -90,21 +127,13 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           .filter((m) => m.type === "augment");
         if (mentioned.length > 0) {
           const newAugmentName = mentioned[0].name;
-          const augmentData = gameDataRef.current.augments.get(
-            newAugmentName.toLowerCase()
-          );
-          const newAugment: CoachingItem = {
-            name: newAugmentName,
-            description: augmentData?.description ?? "",
-            sets: augmentData?.sets,
-          };
-          const alreadySelected = chosenAugmentsRef.current.some(
-            (a) => a.name === newAugment.name
-          );
-          if (!alreadySelected) {
-            const next = [...chosenAugmentsRef.current, newAugment];
+          if (!chosenAugmentsRef.current.includes(newAugmentName)) {
+            const next = [...chosenAugmentsRef.current, newAugmentName];
             chosenAugmentsRef.current = next;
             setChosenAugments(next);
+            const augmentData = gameDataRef.current.augments.get(
+              newAugmentName.toLowerCase()
+            );
             if (augmentData) {
               manualInput$.next({ type: "augment", augment: augmentData });
             }
@@ -118,61 +147,78 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
       setLoading(true);
       setError(null);
 
+      // Build state snapshot from current game state
+      const snapshot = takeGameSnapshot(
+        liveGameStateRef.current,
+        enemyStatsRef.current,
+        gameDataRef.current,
+        chosenAugmentsRef.current
+      );
+      const stateText = snapshot ? formatStateSnapshot(snapshot) : "";
+
+      // Build the question text, appending augment options if detected
       const augmentOptions = extractAugmentOptions(
         question,
         gameDataRef.current
       );
+      let questionText = question;
+      if (augmentOptions && augmentOptions.length > 0) {
+        const augmentLines = augmentOptions.map(
+          (opt) => `- **${opt.name}** [${opt.tier}]: ${opt.description}`
+        );
+        questionText = `${question}\n\nAugment options:\n${augmentLines.join("\n")}`;
+      }
 
-      const contextWithAugments = {
-        ...contextRef.current,
-        currentAugments:
-          chosenAugmentsRef.current.length > 0
-            ? chosenAugmentsRef.current
-            : contextRef.current.currentAugments,
-      };
+      // Add user message to conversation session
+      sessionRef.current.addUserMessage(stateText, questionText);
 
-      reactiveLog.info(`Coaching query: "${question}"`);
+      reactiveLog.info(
+        `Coaching query: "${question}" | ${sessionRef.current.messages.length} messages in thread`
+      );
 
-      // Determine if this is an augment/shard offer or a voice/reactive query.
-      // Auto-generated augment queries always start with this prefix.
+      // Determine source for overlay routing
       const isAugmentQuery = question.startsWith(
         "I'm being offered these augments:"
       );
       const source = isAugmentQuery ? "augment" : "reactive";
 
-      // Only notify coaching strip for voice/reactive queries
       if (source === "reactive") {
         window.electronAPI?.sendCoachingRequest();
       }
 
       try {
-        const response = await getCoachingResponse(
-          contextWithAugments,
-          {
-            question,
-            history: exchangesRef.current,
-            augmentOptions,
-          },
+        const response = await getMultiTurnCoachingResponse(
+          sessionRef.current,
           apiKey,
           { signal: options?.signal }
         );
-        setLatestExchange({ question, response });
-        setExchanges((prev) => [
-          ...prev,
-          { question, answer: response.answer },
-        ]);
 
-        // Relay to overlay — tagged with source so badges and strip
-        // only display their respective responses
+        // Record assistant response in the session
+        sessionRef.current.addAssistantMessage(JSON.stringify(response));
+
+        setLatestExchange({ question, response });
+
+        // Relay to overlay
         window.electronAPI?.sendCoachingResponse({ ...response, source });
       } catch (err) {
-        // Aborted requests are expected — player picked an augment before
-        // the coaching response arrived, so the in-flight request was cancelled
         if (err instanceof Error && err.name === "AbortError") {
+          // Cancelled — remove the orphaned user message from the session
+          // The next turn's snapshot will reflect whatever choice was made
           reactiveLog.debug(
-            "Coaching request cancelled — player picked before response arrived"
+            "Coaching request cancelled — removing orphaned message"
           );
+          try {
+            sessionRef.current.removeLastUserMessage();
+          } catch {
+            // Session may have been reset between cancel and this handler
+          }
         } else {
+          // Remove the failed user message so the session stays clean
+          try {
+            sessionRef.current.removeLastUserMessage();
+          } catch {
+            // Ignore if session was reset
+          }
           const msg = err instanceof Error ? err.message : "Request failed";
           reactiveLog.error(`Coaching error: ${msg}`);
           setError(msg);
@@ -193,8 +239,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
     return () => sub.unsubscribe();
   }, [submitQuestion]);
 
-  // GEP augment coaching controller — handles debouncing, cancellation,
-  // and all three staleness scenarios (see augment-coaching.ts for details).
+  // GEP augment coaching controller
   useEffect(() => {
     const ctrl = createAugmentCoachingController(
       augmentOffer$,
@@ -208,18 +253,13 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
           await submitQuestion(question, { signal });
         },
         onPicked: (name) => {
-          if (chosenAugmentsRef.current.some((a) => a.name === name)) return;
+          if (chosenAugmentsRef.current.includes(name)) return;
+          const next = [...chosenAugmentsRef.current, name];
+          chosenAugmentsRef.current = next;
+          setChosenAugments(next);
           const augmentData = gameDataRef.current.augments.get(
             name.toLowerCase()
           );
-          const newAugment: CoachingItem = {
-            name,
-            description: augmentData?.description ?? "",
-            sets: augmentData?.sets,
-          };
-          const next = [...chosenAugmentsRef.current, newAugment];
-          chosenAugmentsRef.current = next;
-          setChosenAugments(next);
           if (augmentData) {
             manualInput$.next({ type: "augment", augment: augmentData });
           }
@@ -250,7 +290,7 @@ export function CoachingInput({ context, gameData }: CoachingInputProps) {
     );
   }
 
-  if (!context) {
+  if (!liveGameState.activePlayer) {
     return null;
   }
 

--- a/src/components/CoachingInput.tsx
+++ b/src/components/CoachingInput.tsx
@@ -3,7 +3,7 @@ import type { CoachingResponse, CoachingQuery } from "../lib/ai/types";
 import type { LoadedGameData } from "../lib/data-ingest";
 import type { GameState } from "../lib/game-state/types";
 import type { ConversationSession } from "../lib/ai/conversation-session";
-import { useCoachingMode } from "../hooks/useCoachingContext";
+import { useCoachingContext } from "../hooks/useCoachingContext";
 import { useLiveGameState } from "../hooks/useLiveGameState";
 import { getMultiTurnCoachingResponse } from "../lib/ai/recommendation-engine";
 import { createConversationSession } from "../lib/ai/conversation-session";
@@ -51,7 +51,7 @@ function extractAugmentOptions(
 
 export function CoachingInput({ gameData }: CoachingInputProps) {
   const liveGameState = useLiveGameState();
-  const { mode, enemyStats } = useCoachingMode();
+  const { mode, enemyStats } = useCoachingContext();
   const [loading, setLoading] = useState(false);
   const [latestExchange, setLatestExchange] = useState<{
     question: string;

--- a/src/components/GameStateView.tsx
+++ b/src/components/GameStateView.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import type { EffectiveGameState, EffectivePlayer } from "../lib/mode";
 import type { Augment, AramOverrides } from "../lib/data-ingest/types";
 import type { LoadedGameData } from "../lib/data-ingest";
@@ -6,8 +5,6 @@ import { checkAugmentAvailability } from "../lib/mode/augment-availability";
 import { formatGameTime, formatModifier } from "../lib/format";
 import { AugmentSlots } from "./AugmentSlots";
 import { CoachingInput } from "./CoachingInput";
-import { assembleContext } from "../lib/ai/context-assembler";
-import { useLiveGameState } from "../hooks/useLiveGameState";
 
 interface AugmentSelectionActions {
   selectedAugments: Augment[];
@@ -29,13 +26,6 @@ export function GameStateView({
   modeAugments,
   augmentSelection,
 }: GameStateViewProps) {
-  const liveGame = useLiveGameState();
-
-  const coachingContext = useMemo(
-    () => assembleContext(liveGame, gameData),
-    [liveGame, gameData]
-  );
-
   if (state.status === "disconnected") {
     return (
       <div className="game-status">
@@ -101,7 +91,7 @@ export function GameStateView({
 
       {/* Middle: Coaching (flex-grow, takes available space) */}
       <div className="game-view-coaching">
-        <CoachingInput context={coachingContext} gameData={gameData} />
+        <CoachingInput gameData={gameData} />
       </div>
 
       {/* Bottom: Teams + details (scrollable) */}

--- a/src/hooks/useCoachingContext.tsx
+++ b/src/hooks/useCoachingContext.tsx
@@ -1,0 +1,78 @@
+/**
+ * React context provider for coaching-related data.
+ *
+ * Provides the detected game mode and computed enemy stats to any
+ * component in the tree, avoiding prop drilling through DataBrowser
+ * and GameStateView.
+ */
+
+import { createContext, useContext, useMemo } from "react";
+import type { ReactNode } from "react";
+import type { GameMode } from "../lib/mode/types";
+import type { ComputedStats } from "../lib/ai/enemy-stats";
+import type { LoadedGameData } from "../lib/data-ingest";
+import type { LiveGameState } from "../lib/reactive/types";
+import { computeEnemyStats } from "../lib/ai/enemy-stats";
+
+interface CoachingContextValue {
+  mode: GameMode | null;
+  enemyStats: Map<string, ComputedStats>;
+}
+
+const CoachingCtx = createContext<CoachingContextValue>({
+  mode: null,
+  enemyStats: new Map(),
+});
+
+interface CoachingProviderProps {
+  mode: GameMode | null;
+  liveGameState: LiveGameState;
+  gameData: LoadedGameData | null;
+  children: ReactNode;
+}
+
+export function CoachingProvider({
+  mode,
+  liveGameState,
+  gameData,
+  children,
+}: CoachingProviderProps) {
+  const enemyStats = useMemo(() => {
+    if (!gameData || !liveGameState.activePlayer) {
+      return new Map<string, ComputedStats>();
+    }
+
+    const activePlayerInfo = liveGameState.players.find(
+      (p) => p.isActivePlayer
+    );
+    if (!activePlayerInfo) return new Map<string, ComputedStats>();
+
+    const activeTeam = activePlayerInfo.team;
+    const enemies = liveGameState.players.filter((p) => p.team !== activeTeam);
+    const stats = new Map<string, ComputedStats>();
+
+    for (const enemy of enemies) {
+      const champion = gameData.champions.get(enemy.championName.toLowerCase());
+      if (!champion) continue;
+
+      const items = enemy.items
+        .map((i) => gameData.items.get(i.id))
+        .filter((item) => item != null);
+
+      stats.set(
+        enemy.championName,
+        computeEnemyStats(champion.stats, enemy.level, items)
+      );
+    }
+
+    return stats;
+  }, [gameData, liveGameState.players, liveGameState.activePlayer]);
+
+  const value = useMemo(() => ({ mode, enemyStats }), [mode, enemyStats]);
+
+  return <CoachingCtx.Provider value={value}>{children}</CoachingCtx.Provider>;
+}
+
+export function useCoachingMode(): CoachingContextValue {
+  return useContext(CoachingCtx);
+}

--- a/src/hooks/useCoachingContext.tsx
+++ b/src/hooks/useCoachingContext.tsx
@@ -73,6 +73,6 @@ export function CoachingProvider({
   return <CoachingCtx.Provider value={value}>{children}</CoachingCtx.Provider>;
 }
 
-export function useCoachingMode(): CoachingContextValue {
+export function useCoachingContext(): CoachingContextValue {
   return useContext(CoachingCtx);
 }

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -20,11 +20,23 @@ config({ path: resolve(__dirname, "../../../.env"), override: true });
 import { evalite } from "evalite";
 import { createScorer } from "evalite";
 import { createOpenAI } from "@ai-sdk/openai";
-import { generateText, Output } from "ai";
-import { readFileSync } from "fs";
+import { generateText, Output, type ModelMessage } from "ai";
+import { readFileSync, existsSync } from "fs";
 import { coachingResponseSchema } from "./schemas";
-import { buildSystemPrompt, buildUserPrompt } from "./prompts";
+import {
+  buildSystemPrompt,
+  buildUserPrompt,
+  buildGameSystemPrompt,
+} from "./prompts";
+import { formatStateSnapshot, takeGameSnapshot } from "./state-formatter";
+import { createConversationSession } from "./conversation-session";
+import { computeEnemyStats } from "./enemy-stats";
+import { aramMayhemMode, aramMode, classicMode } from "../mode";
+import type { GameMode } from "../mode/types";
 import type { CoachingContext, CoachingQuery } from "./types";
+import type { GameState } from "../game-state/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { LiveGameState } from "../reactive/types";
 import { scoreItemAwareness } from "./scorers/item-awareness";
 import { scoreAugmentRerollAccuracy } from "./scorers/augment-reroll-accuracy";
 import { scoreBrevity, scoreDecisiveness } from "./scorers/response-format";
@@ -270,7 +282,7 @@ const RANKING_SCORERS = [
 ];
 const ALL_SCORERS = [...GATE_SCORERS, ...RANKING_SCORERS];
 
-// --- Register evals ---
+// --- Register single-turn evals ---
 
 for (const model of models) {
   for (const [category, inputs] of inputsByCategory) {
@@ -310,4 +322,217 @@ for (const model of models) {
       ],
     });
   }
+}
+
+// --- Multi-turn eval types and registration ---
+
+interface MultiTurnFixture {
+  label: string;
+  index: number;
+  timestamp: string;
+  model: string;
+  category: string;
+  gameState: GameState;
+  gameModeId: "aram-mayhem" | "aram" | "classic";
+  chosenAugments: string[];
+  query: {
+    question: string;
+    history?: Array<{ question: string; answer: string }>;
+    augmentOptions?: Array<{
+      name: string;
+      description: string;
+      tier: string;
+      sets?: string[];
+    }>;
+  };
+  response: {
+    answer: string;
+    latencyMs: number;
+    tokensIn: number;
+    tokensOut: number;
+  } | null;
+  error: string | null;
+  expectedReferences?: string[];
+  scorerContext: {
+    items: string[];
+    gold: number;
+    champion: string;
+    gameTime: string;
+  };
+}
+
+interface MultiTurnEvalInput extends EvalInput {
+  messages: ModelMessage[];
+}
+
+const MODE_MAP: Record<string, GameMode> = {
+  "aram-mayhem": aramMayhemMode,
+  aram: aramMode,
+  classic: classicMode,
+};
+
+const multiTurnFixturesDir = resolve("fixtures/coaching-sessions-v2");
+
+if (existsSync(multiTurnFixturesDir)) {
+  // Wrap in async IIFE so we can await loadGameData()
+  void (async () => {
+    const { loadGameData } = await import("../data-ingest");
+    const gameData = await loadGameData();
+
+    const mtFixtureFiles = readdirSync(multiTurnFixturesDir).filter((f) =>
+      f.endsWith(".json")
+    );
+    const mtFixtures: MultiTurnFixture[] = mtFixtureFiles.flatMap((file) =>
+      JSON.parse(readFileSync(resolve(multiTurnFixturesDir, file), "utf-8"))
+    );
+
+    const validMtFixtures = mtFixtures.filter(
+      (f) => f.error === null && f.query.question.length > 5
+    );
+
+    function buildMultiTurnInput(
+      f: MultiTurnFixture,
+      gameData: LoadedGameData
+    ): MultiTurnEvalInput {
+      const mode = MODE_MAP[f.gameModeId];
+      if (!mode) {
+        throw new Error(`Unknown gameModeId: ${f.gameModeId}`);
+      }
+
+      // Build the system prompt using real function
+      const systemPrompt = buildGameSystemPrompt(mode, gameData, f.gameState);
+
+      // Compute enemy stats for each enemy player
+      const activePlayerInfo = f.gameState.players.find(
+        (p) => p.isActivePlayer
+      );
+      const activeTeam = activePlayerInfo?.team ?? "ORDER";
+      const enemyPlayers = f.gameState.players.filter(
+        (p) => p.team !== activeTeam
+      );
+
+      const enemyStats = new Map<
+        string,
+        ReturnType<typeof computeEnemyStats>
+      >();
+      for (const enemy of enemyPlayers) {
+        const champData = gameData.champions.get(
+          enemy.championName.toLowerCase()
+        );
+        if (champData) {
+          const enemyItems = enemy.items
+            .map((item) => gameData.items.get(item.id))
+            .filter((item): item is NonNullable<typeof item> => item != null);
+          enemyStats.set(
+            enemy.championName,
+            computeEnemyStats(champData.stats, enemy.level, enemyItems)
+          );
+        }
+      }
+
+      // Build LiveGameState from GameState
+      const liveGameState: LiveGameState = {
+        activePlayer: f.gameState.activePlayer,
+        players: f.gameState.players,
+        gameMode: f.gameState.gameMode,
+        lcuGameMode:
+          f.gameModeId === "aram-mayhem" ? "KIWI" : f.gameState.gameMode,
+        gameTime: f.gameState.gameTime,
+        champSelect: null,
+        eogStats: null,
+      };
+
+      // Build snapshot and format it
+      const snapshot = takeGameSnapshot(
+        liveGameState,
+        enemyStats,
+        gameData,
+        f.chosenAugments
+      );
+      const stateText = snapshot ? formatStateSnapshot(snapshot) : "";
+
+      // Build conversation session with history
+      const session = createConversationSession(systemPrompt);
+
+      if (f.query.history) {
+        for (const exchange of f.query.history) {
+          session.addUserMessage(stateText, exchange.question);
+          session.addAssistantMessage(exchange.answer);
+        }
+      }
+
+      // Add current question
+      session.addUserMessage(stateText, f.query.question);
+
+      return {
+        label: f.label,
+        category: f.category,
+        question: f.query.question,
+        champion: f.scorerContext.champion,
+        gameTime: f.scorerContext.gameTime,
+        items: f.scorerContext.items,
+        gold: f.scorerContext.gold,
+        systemPrompt: session.systemPrompt,
+        userPrompt: "", // not used in multi-turn — messages carry the content
+        history: f.query.history ?? [],
+        expectedReferences: f.expectedReferences,
+        messages: [...session.messages],
+      };
+    }
+
+    // Group multi-turn inputs by category
+    const mtInputsByCategory = new Map<string, MultiTurnEvalInput[]>();
+    for (const f of validMtFixtures) {
+      const input = buildMultiTurnInput(f, gameData);
+      const categoryLabel = CATEGORY_LABELS[input.category] ?? input.category;
+      const list = mtInputsByCategory.get(categoryLabel) ?? [];
+      list.push(input);
+      mtInputsByCategory.set(categoryLabel, list);
+    }
+
+    // Register multi-turn evals
+    for (const model of models) {
+      for (const [category, inputs] of mtInputsByCategory) {
+        if (inputs.length === 0) continue;
+
+        evalite(`${model.name} / ${category} [multi-turn]`, {
+          data: () => inputs.map((input) => ({ input })),
+
+          task: async (input: MultiTurnEvalInput): Promise<EvalOutput> => {
+            const result = await generateText({
+              model: getModel(model),
+              system: input.systemPrompt,
+              messages: input.messages as ModelMessage[],
+              output: Output.object({ schema: coachingResponseSchema }),
+              maxOutputTokens: 4096,
+            });
+
+            return result.output;
+          },
+
+          scorers: ALL_SCORERS,
+
+          columns: (result) => [
+            { label: "Category", value: `${category} [MT]` },
+            {
+              label: "Champion",
+              value: `${result.input.champion} @${result.input.gameTime}`,
+            },
+            {
+              label: "Question",
+              value: result.input.question.substring(0, 45),
+            },
+            {
+              label: "Context",
+              value: `${result.input.items.length} items, ${result.input.gold}g`,
+            },
+          ],
+        });
+      }
+    }
+  })();
+} else {
+  console.log(
+    "Multi-turn fixtures not found at fixtures/coaching-sessions-v2/ — skipping multi-turn evals"
+  );
 }

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -495,7 +495,7 @@ if (existsSync(multiTurnFixturesDir)) {
           const result = await generateText({
             model: getModel(model),
             system: input.systemPrompt,
-            messages: input.messages as ModelMessage[],
+            messages: input.messages,
             output: Output.object({ schema: coachingResponseSchema }),
             maxOutputTokens: 4096,
           });

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -175,7 +175,7 @@ interface ModelCandidate {
 // Models to evaluate across providers and tiers.
 // Comment/uncomment to control which models run.
 const models: ModelCandidate[] = [
-  { name: "GPT 5.4 mini", id: "openai/gpt-5.4-mini", provider: "openrouter" },
+  { name: "GPT 5.4 mini", id: "gpt-5.4-mini", provider: "openai" },
   // { name: "GPT 5.4", id: "openai/gpt-5.4", provider: "openrouter" },
   // { name: "Gemini 2.5 Pro", id: "google/gemini-2.5-pro", provider: "openrouter" },
   // { name: "Claude Sonnet 4.6", id: "anthropic/claude-sonnet-4.6", provider: "openrouter" },
@@ -374,163 +374,155 @@ const MODE_MAP: Record<string, GameMode> = {
 const multiTurnFixturesDir = resolve("fixtures/coaching-sessions-v2");
 
 if (existsSync(multiTurnFixturesDir)) {
-  // Wrap in async IIFE so we can await loadGameData()
-  void (async () => {
-    const { loadGameData } = await import("../data-ingest");
-    const gameData = await loadGameData();
+  const { loadGameData } = await import("../data-ingest");
+  const gameData = await loadGameData();
 
-    const mtFixtureFiles = readdirSync(multiTurnFixturesDir).filter((f) =>
-      f.endsWith(".json")
+  const mtFixtureFiles = readdirSync(multiTurnFixturesDir).filter((f) =>
+    f.endsWith(".json")
+  );
+  const mtFixtures: MultiTurnFixture[] = mtFixtureFiles.flatMap((file) =>
+    JSON.parse(readFileSync(resolve(multiTurnFixturesDir, file), "utf-8"))
+  );
+
+  const validMtFixtures = mtFixtures.filter(
+    (f) => f.error === null && f.query.question.length > 5
+  );
+
+  function buildMultiTurnInput(
+    f: MultiTurnFixture,
+    gameData: LoadedGameData
+  ): MultiTurnEvalInput {
+    const mode = MODE_MAP[f.gameModeId];
+    if (!mode) {
+      throw new Error(`Unknown gameModeId: ${f.gameModeId}`);
+    }
+
+    // Build the system prompt using real function
+    const systemPrompt = buildGameSystemPrompt(mode, gameData, f.gameState);
+
+    // Compute enemy stats for each enemy player
+    const activePlayerInfo = f.gameState.players.find((p) => p.isActivePlayer);
+    const activeTeam = activePlayerInfo?.team ?? "ORDER";
+    const enemyPlayers = f.gameState.players.filter(
+      (p) => p.team !== activeTeam
     );
-    const mtFixtures: MultiTurnFixture[] = mtFixtureFiles.flatMap((file) =>
-      JSON.parse(readFileSync(resolve(multiTurnFixturesDir, file), "utf-8"))
-    );
 
-    const validMtFixtures = mtFixtures.filter(
-      (f) => f.error === null && f.query.question.length > 5
-    );
-
-    function buildMultiTurnInput(
-      f: MultiTurnFixture,
-      gameData: LoadedGameData
-    ): MultiTurnEvalInput {
-      const mode = MODE_MAP[f.gameModeId];
-      if (!mode) {
-        throw new Error(`Unknown gameModeId: ${f.gameModeId}`);
-      }
-
-      // Build the system prompt using real function
-      const systemPrompt = buildGameSystemPrompt(mode, gameData, f.gameState);
-
-      // Compute enemy stats for each enemy player
-      const activePlayerInfo = f.gameState.players.find(
-        (p) => p.isActivePlayer
+    const enemyStats = new Map<string, ReturnType<typeof computeEnemyStats>>();
+    for (const enemy of enemyPlayers) {
+      const champData = gameData.champions.get(
+        enemy.championName.toLowerCase()
       );
-      const activeTeam = activePlayerInfo?.team ?? "ORDER";
-      const enemyPlayers = f.gameState.players.filter(
-        (p) => p.team !== activeTeam
-      );
-
-      const enemyStats = new Map<
-        string,
-        ReturnType<typeof computeEnemyStats>
-      >();
-      for (const enemy of enemyPlayers) {
-        const champData = gameData.champions.get(
-          enemy.championName.toLowerCase()
+      if (champData) {
+        const enemyItems = enemy.items
+          .map((item) => gameData.items.get(item.id))
+          .filter((item): item is NonNullable<typeof item> => item != null);
+        enemyStats.set(
+          enemy.championName,
+          computeEnemyStats(champData.stats, enemy.level, enemyItems)
         );
-        if (champData) {
-          const enemyItems = enemy.items
-            .map((item) => gameData.items.get(item.id))
-            .filter((item): item is NonNullable<typeof item> => item != null);
-          enemyStats.set(
-            enemy.championName,
-            computeEnemyStats(champData.stats, enemy.level, enemyItems)
-          );
-        }
       }
-
-      // Build LiveGameState from GameState
-      const liveGameState: LiveGameState = {
-        activePlayer: f.gameState.activePlayer,
-        players: f.gameState.players,
-        gameMode: f.gameState.gameMode,
-        lcuGameMode:
-          f.gameModeId === "aram-mayhem" ? "KIWI" : f.gameState.gameMode,
-        gameTime: f.gameState.gameTime,
-        champSelect: null,
-        eogStats: null,
-      };
-
-      // Build snapshot and format it
-      const snapshot = takeGameSnapshot(
-        liveGameState,
-        enemyStats,
-        gameData,
-        f.chosenAugments
-      );
-      const stateText = snapshot ? formatStateSnapshot(snapshot) : "";
-
-      // Build conversation session with history
-      const session = createConversationSession(systemPrompt);
-
-      if (f.query.history) {
-        for (const exchange of f.query.history) {
-          session.addUserMessage(stateText, exchange.question);
-          session.addAssistantMessage(exchange.answer);
-        }
-      }
-
-      // Add current question
-      session.addUserMessage(stateText, f.query.question);
-
-      return {
-        label: f.label,
-        category: f.category,
-        question: f.query.question,
-        champion: f.scorerContext.champion,
-        gameTime: f.scorerContext.gameTime,
-        items: f.scorerContext.items,
-        gold: f.scorerContext.gold,
-        systemPrompt: session.systemPrompt,
-        userPrompt: "", // not used in multi-turn — messages carry the content
-        history: f.query.history ?? [],
-        expectedReferences: f.expectedReferences,
-        messages: [...session.messages],
-      };
     }
 
-    // Group multi-turn inputs by category
-    const mtInputsByCategory = new Map<string, MultiTurnEvalInput[]>();
-    for (const f of validMtFixtures) {
-      const input = buildMultiTurnInput(f, gameData);
-      const categoryLabel = CATEGORY_LABELS[input.category] ?? input.category;
-      const list = mtInputsByCategory.get(categoryLabel) ?? [];
-      list.push(input);
-      mtInputsByCategory.set(categoryLabel, list);
+    // Build LiveGameState from GameState
+    const liveGameState: LiveGameState = {
+      activePlayer: f.gameState.activePlayer,
+      players: f.gameState.players,
+      gameMode: f.gameState.gameMode,
+      lcuGameMode:
+        f.gameModeId === "aram-mayhem" ? "KIWI" : f.gameState.gameMode,
+      gameTime: f.gameState.gameTime,
+      champSelect: null,
+      eogStats: null,
+    };
+
+    // Build snapshot and format it
+    const snapshot = takeGameSnapshot(
+      liveGameState,
+      enemyStats,
+      gameData,
+      f.chosenAugments
+    );
+    const stateText = snapshot ? formatStateSnapshot(snapshot) : "";
+
+    // Build conversation session with history
+    const session = createConversationSession(systemPrompt);
+
+    if (f.query.history) {
+      for (const exchange of f.query.history) {
+        session.addUserMessage(stateText, exchange.question);
+        session.addAssistantMessage(exchange.answer);
+      }
     }
 
-    // Register multi-turn evals
-    for (const model of models) {
-      for (const [category, inputs] of mtInputsByCategory) {
-        if (inputs.length === 0) continue;
+    // Add current question
+    session.addUserMessage(stateText, f.query.question);
 
-        evalite(`${model.name} / ${category} [multi-turn]`, {
-          data: () => inputs.map((input) => ({ input })),
+    return {
+      label: f.label,
+      category: f.category,
+      question: f.query.question,
+      champion: f.scorerContext.champion,
+      gameTime: f.scorerContext.gameTime,
+      items: f.scorerContext.items,
+      gold: f.scorerContext.gold,
+      systemPrompt: session.systemPrompt,
+      userPrompt: "", // not used in multi-turn — messages carry the content
+      history: f.query.history ?? [],
+      expectedReferences: f.expectedReferences,
+      messages: [...session.messages],
+    };
+  }
 
-          task: async (input: MultiTurnEvalInput): Promise<EvalOutput> => {
-            const result = await generateText({
-              model: getModel(model),
-              system: input.systemPrompt,
-              messages: input.messages as ModelMessage[],
-              output: Output.object({ schema: coachingResponseSchema }),
-              maxOutputTokens: 4096,
-            });
+  // Group multi-turn inputs by category
+  const mtInputsByCategory = new Map<string, MultiTurnEvalInput[]>();
+  for (const f of validMtFixtures) {
+    const input = buildMultiTurnInput(f, gameData);
+    const categoryLabel = CATEGORY_LABELS[input.category] ?? input.category;
+    const list = mtInputsByCategory.get(categoryLabel) ?? [];
+    list.push(input);
+    mtInputsByCategory.set(categoryLabel, list);
+  }
 
-            return result.output;
+  // Register multi-turn evals
+  for (const model of models) {
+    for (const [category, inputs] of mtInputsByCategory) {
+      if (inputs.length === 0) continue;
+
+      evalite(`${model.name} / ${category} [multi-turn]`, {
+        data: () => inputs.map((input) => ({ input })),
+
+        task: async (input: MultiTurnEvalInput): Promise<EvalOutput> => {
+          const result = await generateText({
+            model: getModel(model),
+            system: input.systemPrompt,
+            messages: input.messages as ModelMessage[],
+            output: Output.object({ schema: coachingResponseSchema }),
+            maxOutputTokens: 4096,
+          });
+
+          return result.output;
+        },
+
+        scorers: ALL_SCORERS,
+
+        columns: (result) => [
+          { label: "Category", value: `${category} [MT]` },
+          {
+            label: "Champion",
+            value: `${result.input.champion} @${result.input.gameTime}`,
           },
-
-          scorers: ALL_SCORERS,
-
-          columns: (result) => [
-            { label: "Category", value: `${category} [MT]` },
-            {
-              label: "Champion",
-              value: `${result.input.champion} @${result.input.gameTime}`,
-            },
-            {
-              label: "Question",
-              value: result.input.question.substring(0, 45),
-            },
-            {
-              label: "Context",
-              value: `${result.input.items.length} items, ${result.input.gold}g`,
-            },
-          ],
-        });
-      }
+          {
+            label: "Question",
+            value: result.input.question.substring(0, 45),
+          },
+          {
+            label: "Context",
+            value: `${result.input.items.length} items, ${result.input.gold}g`,
+          },
+        ],
+      });
     }
-  })();
+  }
 } else {
   console.log(
     "Multi-turn fixtures not found at fixtures/coaching-sessions-v2/ — skipping multi-turn evals"

--- a/src/lib/ai/conversation-session.test.ts
+++ b/src/lib/ai/conversation-session.test.ts
@@ -1,0 +1,125 @@
+import { describe, it, expect } from "vitest";
+import { createConversationSession } from "./conversation-session";
+
+describe("createConversationSession", () => {
+  const SYSTEM_PROMPT = "You are a coaching AI.";
+
+  it("starts with empty messages", () => {
+    const session = createConversationSession(SYSTEM_PROMPT);
+    expect(session.messages).toEqual([]);
+  });
+
+  it("preserves the system prompt", () => {
+    const session = createConversationSession(SYSTEM_PROMPT);
+    expect(session.systemPrompt).toBe(SYSTEM_PROMPT);
+  });
+
+  it("adds a user message with state snapshot and question", () => {
+    const session = createConversationSession(SYSTEM_PROMPT);
+    session.addUserMessage("Level: 5\nGold: 1200", "What should I buy?");
+
+    expect(session.messages).toHaveLength(1);
+    expect(session.messages[0].role).toBe("user");
+    expect(session.messages[0].content).toBe(
+      "[Game State]\nLevel: 5\nGold: 1200\n\n[Question]\nWhat should I buy?"
+    );
+  });
+
+  it("adds an assistant message", () => {
+    const session = createConversationSession(SYSTEM_PROMPT);
+    session.addUserMessage("Level: 5", "What should I buy?");
+    session.addAssistantMessage('{"answer":"Buy Rabadon\'s."}');
+
+    expect(session.messages).toHaveLength(2);
+    expect(session.messages[1].role).toBe("assistant");
+    expect(session.messages[1].content).toBe('{"answer":"Buy Rabadon\'s."}');
+  });
+
+  it("grows the message array across multiple turns", () => {
+    const session = createConversationSession(SYSTEM_PROMPT);
+
+    session.addUserMessage("State 1", "Question 1");
+    session.addAssistantMessage("Answer 1");
+    session.addUserMessage("State 2", "Question 2");
+    session.addAssistantMessage("Answer 2");
+    session.addUserMessage("State 3", "Question 3");
+
+    expect(session.messages).toHaveLength(5);
+    expect(session.messages[0].role).toBe("user");
+    expect(session.messages[1].role).toBe("assistant");
+    expect(session.messages[2].role).toBe("user");
+    expect(session.messages[3].role).toBe("assistant");
+    expect(session.messages[4].role).toBe("user");
+  });
+
+  describe("removeLastUserMessage", () => {
+    it("removes the last message when it is a user message", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State", "Question");
+      session.removeLastUserMessage();
+
+      expect(session.messages).toHaveLength(0);
+    });
+
+    it("removes only the last user message, preserving earlier messages", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State 1", "Q1");
+      session.addAssistantMessage("A1");
+      session.addUserMessage("State 2", "Q2");
+
+      session.removeLastUserMessage();
+
+      expect(session.messages).toHaveLength(2);
+      expect(session.messages[0].role).toBe("user");
+      expect(session.messages[1].role).toBe("assistant");
+    });
+
+    it("throws if the last message is not a user message", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State", "Q");
+      session.addAssistantMessage("A");
+
+      expect(() => session.removeLastUserMessage()).toThrow(
+        'Last message has role "assistant", expected "user"'
+      );
+    });
+
+    it("throws if messages array is empty", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+
+      expect(() => session.removeLastUserMessage()).toThrow(
+        "Cannot remove from empty message array"
+      );
+    });
+  });
+
+  describe("reset", () => {
+    it("clears all messages", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State", "Q");
+      session.addAssistantMessage("A");
+
+      session.reset();
+
+      expect(session.messages).toHaveLength(0);
+    });
+
+    it("preserves the system prompt after reset", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State", "Q");
+      session.reset();
+
+      expect(session.systemPrompt).toBe(SYSTEM_PROMPT);
+    });
+
+    it("allows new messages after reset", () => {
+      const session = createConversationSession(SYSTEM_PROMPT);
+      session.addUserMessage("State 1", "Q1");
+      session.reset();
+      session.addUserMessage("State 2", "Q2");
+
+      expect(session.messages).toHaveLength(1);
+      expect(session.messages[0].content).toContain("State 2");
+    });
+  });
+});

--- a/src/lib/ai/conversation-session.ts
+++ b/src/lib/ai/conversation-session.ts
@@ -1,0 +1,71 @@
+/**
+ * Manages the multi-turn conversation message array for a game session.
+ *
+ * Each user message includes a full game state snapshot (not a diff),
+ * re-anchoring the LLM to ground truth every turn. The system prompt is
+ * set once at session creation and never changes.
+ *
+ * Usage:
+ *   const session = createConversationSession(systemPrompt);
+ *   session.addUserMessage(stateSnapshot, question);
+ *   // ... call LLM with session.systemPrompt + session.messages ...
+ *   session.addAssistantMessage(responseJson);
+ */
+
+import type { ModelMessage } from "ai";
+
+export interface ConversationSession {
+  readonly systemPrompt: string;
+  readonly messages: readonly ModelMessage[];
+  addUserMessage(stateSnapshot: string, question: string): void;
+  addAssistantMessage(responseText: string): void;
+  removeLastUserMessage(): void;
+  reset(): void;
+}
+
+export function createConversationSession(
+  systemPrompt: string
+): ConversationSession {
+  const messages: ModelMessage[] = [];
+
+  return {
+    get systemPrompt() {
+      return systemPrompt;
+    },
+
+    get messages(): readonly ModelMessage[] {
+      return messages;
+    },
+
+    addUserMessage(stateSnapshot: string, question: string): void {
+      messages.push({
+        role: "user",
+        content: `[Game State]\n${stateSnapshot}\n\n[Question]\n${question}`,
+      });
+    },
+
+    addAssistantMessage(responseText: string): void {
+      messages.push({
+        role: "assistant",
+        content: responseText,
+      });
+    },
+
+    removeLastUserMessage(): void {
+      if (messages.length === 0) {
+        throw new Error("Cannot remove from empty message array");
+      }
+      const last = messages[messages.length - 1];
+      if (last.role !== "user") {
+        throw new Error(
+          `Last message has role "${last.role}", expected "user"`
+        );
+      }
+      messages.pop();
+    },
+
+    reset(): void {
+      messages.length = 0;
+    },
+  };
+}

--- a/src/lib/ai/enemy-stats-reactive.test.ts
+++ b/src/lib/ai/enemy-stats-reactive.test.ts
@@ -1,0 +1,285 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { BehaviorSubject } from "rxjs";
+import { createEnemyStatsStream } from "./enemy-stats-reactive";
+import type { LiveGameState } from "../reactive/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { Champion, Item } from "../data-ingest/types";
+import type { Subscription } from "rxjs";
+
+let subscription: Subscription | null = null;
+
+afterEach(() => {
+  subscription?.unsubscribe();
+  subscription = null;
+});
+
+function createDefaultLiveGameState(): LiveGameState {
+  return {
+    activePlayer: null,
+    players: [],
+    gameMode: "ARAM",
+    lcuGameMode: "ARAM",
+    gameTime: 0,
+    champSelect: null,
+    eogStats: null,
+  };
+}
+
+function createGameData(): LoadedGameData {
+  const champions = new Map<string, Champion>([
+    [
+      "zed",
+      {
+        id: "Zed",
+        key: 238,
+        name: "Zed",
+        title: "the Master of Shadows",
+        tags: ["Assassin"],
+        partype: "Energy",
+        stats: {
+          hp: 654,
+          hpperlevel: 99,
+          mp: 200,
+          mpperlevel: 0,
+          movespeed: 345,
+          armor: 32,
+          armorperlevel: 4.7,
+          spellblock: 32,
+          spellblockperlevel: 2.05,
+          attackrange: 125,
+          hpregen: 7,
+          hpregenperlevel: 0.65,
+          mpregen: 50,
+          mpregenperlevel: 0,
+          attackdamage: 63,
+          attackdamageperlevel: 3.4,
+          attackspeed: 0.651,
+          attackspeedperlevel: 3.3,
+        },
+        image: "",
+      },
+    ],
+  ]);
+
+  const items = new Map<number, Item>([
+    [
+      6693,
+      {
+        id: 6693,
+        name: "Duskblade of Draktharr",
+        description: "AD assassin item",
+        plaintext: "Grants AD and lethality",
+        gold: { base: 800, total: 2800, sell: 1960, purchasable: true },
+        tags: [],
+        stats: { FlatPhysicalDamageMod: 60 },
+        image: "",
+        mode: "standard",
+      },
+    ],
+  ]);
+
+  return {
+    version: "16.6.1",
+    champions,
+    items,
+    runes: [],
+    augments: new Map(),
+    augmentSets: [],
+    dictionary: {
+      allNames: [],
+      champions: [],
+      items: [],
+      augments: [],
+      search: () => [],
+      findInText: () => [],
+    },
+  };
+}
+
+function createActivePlayerStub() {
+  return {
+    championName: "Ahri",
+    level: 10,
+    currentGold: 0,
+    runes: {
+      keystone: "Electrocute",
+      primaryTree: "Domination",
+      secondaryTree: "Sorcery",
+    },
+    stats: {
+      abilityPower: 0,
+      armor: 0,
+      attackDamage: 0,
+      attackSpeed: 0,
+      abilityHaste: 0,
+      critChance: 0,
+      magicResist: 0,
+      moveSpeed: 0,
+      maxHealth: 0,
+      currentHealth: 0,
+    },
+  };
+}
+
+describe("createEnemyStatsStream", () => {
+  it("emits empty map when no active player", () => {
+    const liveState$ = new BehaviorSubject<LiveGameState>(
+      createDefaultLiveGameState()
+    );
+    const { enemyStats$, subscription: sub } = createEnemyStatsStream(
+      liveState$,
+      createGameData()
+    );
+    subscription = sub;
+
+    expect(enemyStats$.getValue().size).toBe(0);
+  });
+
+  it("computes enemy stats when game state has enemies", () => {
+    const state = createDefaultLiveGameState();
+    state.activePlayer = createActivePlayerStub();
+    state.players = [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Player1",
+        position: "",
+        isActivePlayer: true,
+      },
+      {
+        championName: "Zed",
+        team: "CHAOS",
+        level: 11,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [{ id: 6693, name: "Duskblade of Draktharr" }],
+        summonerSpells: ["Flash", "Ignite"],
+        riotIdGameName: "Enemy1",
+        position: "",
+        isActivePlayer: false,
+      },
+    ];
+
+    const liveState$ = new BehaviorSubject<LiveGameState>(state);
+    const { enemyStats$, subscription: sub } = createEnemyStatsStream(
+      liveState$,
+      createGameData()
+    );
+    subscription = sub;
+
+    const stats = enemyStats$.getValue();
+    expect(stats.size).toBe(1);
+    expect(stats.has("Zed")).toBe(true);
+
+    const zedStats = stats.get("Zed")!;
+    // Zed base AD (63) + level 11 scaling + Duskblade (60 flat AD)
+    expect(zedStats.attackDamage).toBeGreaterThan(63 + 60);
+    expect(zedStats.armor).toBeGreaterThan(32);
+  });
+
+  it("recomputes when game state updates", () => {
+    const state = createDefaultLiveGameState();
+    state.activePlayer = createActivePlayerStub();
+    state.players = [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Player1",
+        position: "",
+        isActivePlayer: true,
+      },
+      {
+        championName: "Zed",
+        team: "CHAOS",
+        level: 5,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [],
+        summonerSpells: ["Flash", "Ignite"],
+        riotIdGameName: "Enemy1",
+        position: "",
+        isActivePlayer: false,
+      },
+    ];
+
+    const liveState$ = new BehaviorSubject<LiveGameState>(state);
+    const { enemyStats$, subscription: sub } = createEnemyStatsStream(
+      liveState$,
+      createGameData()
+    );
+    subscription = sub;
+
+    const statsLevel5 = enemyStats$.getValue().get("Zed")!;
+
+    // Update: Zed leveled up and bought an item
+    const updated = { ...state };
+    updated.players = [
+      state.players[0],
+      {
+        ...state.players[1],
+        level: 11,
+        items: [{ id: 6693, name: "Duskblade of Draktharr" }],
+      },
+    ];
+    liveState$.next(updated);
+
+    const statsLevel11 = enemyStats$.getValue().get("Zed")!;
+    expect(statsLevel11.attackDamage).toBeGreaterThan(statsLevel5.attackDamage);
+  });
+
+  it("skips enemies with unknown champion data", () => {
+    const state = createDefaultLiveGameState();
+    state.activePlayer = createActivePlayerStub();
+    state.players = [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Player1",
+        position: "",
+        isActivePlayer: true,
+      },
+      {
+        championName: "UnknownChamp",
+        team: "CHAOS",
+        level: 5,
+        kills: 0,
+        deaths: 0,
+        assists: 0,
+        items: [],
+        summonerSpells: ["Flash", "Ignite"],
+        riotIdGameName: "Enemy1",
+        position: "",
+        isActivePlayer: false,
+      },
+    ];
+
+    const liveState$ = new BehaviorSubject<LiveGameState>(state);
+    const { enemyStats$, subscription: sub } = createEnemyStatsStream(
+      liveState$,
+      createGameData()
+    );
+    subscription = sub;
+
+    expect(enemyStats$.getValue().size).toBe(0);
+  });
+});

--- a/src/lib/ai/enemy-stats-reactive.ts
+++ b/src/lib/ai/enemy-stats-reactive.ts
@@ -1,0 +1,56 @@
+/**
+ * Reactive enemy stat computation.
+ *
+ * Subscribes to liveGameState$ and recomputes approximate enemy stats
+ * on every game state update. Stats are stored in memory and read at
+ * question time — no computation needed in the coaching pipeline.
+ */
+
+import { BehaviorSubject, type Subscription } from "rxjs";
+import type { LiveGameState } from "../reactive/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { ComputedStats } from "./enemy-stats";
+import { computeEnemyStats } from "./enemy-stats";
+
+export function createEnemyStatsStream(
+  liveGameState$: BehaviorSubject<LiveGameState>,
+  gameData: LoadedGameData
+): {
+  enemyStats$: BehaviorSubject<Map<string, ComputedStats>>;
+  subscription: Subscription;
+} {
+  const enemyStats$ = new BehaviorSubject<Map<string, ComputedStats>>(
+    new Map()
+  );
+
+  const subscription = liveGameState$.subscribe((state) => {
+    const activePlayerInfo = state.players.find((p) => p.isActivePlayer);
+    if (!activePlayerInfo) {
+      enemyStats$.next(new Map());
+      return;
+    }
+
+    const activeTeam = activePlayerInfo.team;
+    const enemies = state.players.filter((p) => p.team !== activeTeam);
+    const stats = new Map<string, ComputedStats>();
+
+    for (const enemy of enemies) {
+      const champion = gameData.champions.get(enemy.championName.toLowerCase());
+      if (!champion) continue;
+
+      // Resolve item objects from game data for stat computation
+      const items = enemy.items
+        .map((i) => gameData.items.get(i.id))
+        .filter((item) => item != null);
+
+      stats.set(
+        enemy.championName,
+        computeEnemyStats(champion.stats, enemy.level, items)
+      );
+    }
+
+    enemyStats$.next(stats);
+  });
+
+  return { enemyStats$, subscription };
+}

--- a/src/lib/ai/enemy-stats.test.ts
+++ b/src/lib/ai/enemy-stats.test.ts
@@ -1,0 +1,157 @@
+import { describe, it, expect } from "vitest";
+import { computeEnemyStats } from "./enemy-stats";
+import type { ChampionStats } from "../data-ingest/types";
+import type { Item } from "../data-ingest/types";
+
+/** Ahri's base stats from Data Dragon (patch 14.x reference) */
+function createAhriStats(): ChampionStats {
+  return {
+    hp: 590,
+    hpperlevel: 96,
+    mp: 418,
+    mpperlevel: 25,
+    movespeed: 330,
+    armor: 21,
+    armorperlevel: 4.7,
+    spellblock: 30,
+    spellblockperlevel: 1.3,
+    attackrange: 550,
+    hpregen: 2.5,
+    hpregenperlevel: 0.6,
+    mpregen: 8,
+    mpregenperlevel: 0.8,
+    attackdamage: 53,
+    attackdamageperlevel: 3,
+    attackspeed: 0.668,
+    attackspeedperlevel: 2,
+  };
+}
+
+function createItem(stats: Record<string, number> = {}): Item {
+  return {
+    id: 1000,
+    name: "Test Item",
+    description: "",
+    plaintext: "",
+    gold: { base: 0, total: 0, sell: 0, purchasable: true },
+    tags: [],
+    stats,
+    image: "",
+    mode: "standard",
+  };
+}
+
+describe("computeEnemyStats", () => {
+  it("returns base stats at level 1 with no items", () => {
+    const stats = computeEnemyStats(createAhriStats(), 1, []);
+
+    // At level 1, scale factor = 0, so stats = base values
+    expect(stats.attackDamage).toBe(53);
+    expect(stats.armor).toBe(21);
+    expect(stats.magicResist).toBe(30);
+    expect(stats.maxHealth).toBe(590);
+    expect(stats.moveSpeed).toBe(330);
+    expect(stats.abilityPower).toBe(0); // No base AP on any champion
+    expect(stats.attackSpeed).toBe(0.668);
+  });
+
+  it("applies per-level scaling correctly at level 18", () => {
+    const stats = computeEnemyStats(createAhriStats(), 18, []);
+
+    // Scale factor at level 18: 17 * (0.7025 + 0.0175 * 17) = 17 * 0.9998 ≈ 16.9966
+    const scale = 17 * (0.7025 + 0.0175 * 17);
+
+    expect(stats.attackDamage).toBe(Math.round(53 + 3 * scale));
+    expect(stats.armor).toBe(Math.round(21 + 4.7 * scale));
+    expect(stats.magicResist).toBe(Math.round(30 + 1.3 * scale));
+    expect(stats.maxHealth).toBe(Math.round(590 + 96 * scale));
+  });
+
+  it("adds flat item stat bonuses", () => {
+    const items = [
+      createItem({ FlatArmorMod: 50 }),
+      createItem({ FlatPhysicalDamageMod: 40 }),
+    ];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    expect(stats.armor).toBe(21 + 50);
+    expect(stats.attackDamage).toBe(53 + 40);
+  });
+
+  it("stacks multiple flat bonuses additively", () => {
+    const items = [
+      createItem({ FlatArmorMod: 30 }),
+      createItem({ FlatArmorMod: 20 }),
+      createItem({ FlatSpellBlockMod: 40 }),
+    ];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    expect(stats.armor).toBe(21 + 30 + 20);
+    expect(stats.magicResist).toBe(30 + 40);
+  });
+
+  it("applies percent attack speed multiplicatively on base", () => {
+    // PercentAttackSpeedMod of 0.35 = 35% bonus AS
+    const items = [createItem({ PercentAttackSpeedMod: 0.35 })];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    // At level 1: base AS * (1 + 0 per-level + 0.35 item)
+    const expected = 0.668 * (1 + 0.35);
+    expect(stats.attackSpeed).toBeCloseTo(expected, 2);
+  });
+
+  it("combines per-level and item attack speed bonuses", () => {
+    const items = [createItem({ PercentAttackSpeedMod: 0.25 })];
+    const stats = computeEnemyStats(createAhriStats(), 10, items);
+
+    // Scale factor at level 10
+    const scale = 9 * (0.7025 + 0.0175 * 9);
+    const perLevelPercent = 2 * scale; // attackspeedperlevel = 2
+    const expected = 0.668 * (1 + perLevelPercent / 100 + 0.25);
+    expect(stats.attackSpeed).toBeCloseTo(expected, 2);
+  });
+
+  it("applies flat and percent move speed correctly", () => {
+    const items = [
+      createItem({ FlatMovementSpeedMod: 45 }),
+      createItem({ PercentMovementSpeedMod: 0.07 }),
+    ];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    // (base + flat) * (1 + percent)
+    const expected = (330 + 45) * (1 + 0.07);
+    expect(stats.moveSpeed).toBe(Math.round(expected));
+  });
+
+  it("computes ability power from items only", () => {
+    const items = [
+      createItem({ FlatMagicDamageMod: 120 }),
+      createItem({ FlatMagicDamageMod: 80 }),
+    ];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    expect(stats.abilityPower).toBe(200);
+  });
+
+  it("handles empty items array", () => {
+    const stats = computeEnemyStats(createAhriStats(), 5, []);
+    expect(stats.attackDamage).toBeGreaterThan(53); // Scaled up from base
+    expect(stats.abilityPower).toBe(0);
+  });
+
+  it("handles items with no recognized stat keys", () => {
+    const items = [createItem({ UnknownStat: 999 })];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    // Should be same as no items
+    expect(stats.attackDamage).toBe(53);
+    expect(stats.armor).toBe(21);
+  });
+
+  it("handles items with mixed recognized and unrecognized stats", () => {
+    const items = [createItem({ FlatArmorMod: 50, SomeWeirdStat: 123 })];
+    const stats = computeEnemyStats(createAhriStats(), 1, items);
+
+    expect(stats.armor).toBe(71); // 21 + 50
+  });
+});

--- a/src/lib/ai/enemy-stats.ts
+++ b/src/lib/ai/enemy-stats.ts
@@ -1,0 +1,118 @@
+/**
+ * Compute approximate enemy champion stats from base stats, per-level
+ * growth, and item bonuses.
+ *
+ * Uses Riot's official per-level scaling formula:
+ *   stat = base + (growth × (level-1) × (0.7025 + 0.0175 × (level-1)))
+ *
+ * Item flat bonuses are summed directly. Percent bonuses (attack speed,
+ * move speed) are applied multiplicatively on the base.
+ *
+ * Limitations: does not capture temporary buffs (Baron, elixirs, ability
+ * steroids, stacking passives like Cho'Gath R).
+ */
+
+import type { ChampionStats } from "../data-ingest/types";
+import type { Item } from "../data-ingest/types";
+
+export interface ComputedStats {
+  attackDamage: number;
+  abilityPower: number;
+  armor: number;
+  magicResist: number;
+  maxHealth: number;
+  moveSpeed: number;
+  attackSpeed: number;
+}
+
+/**
+ * Mapping from DDragon item stat keys to ComputedStats fields.
+ * "flat" bonuses are added directly; "percent" bonuses are stored
+ * as decimals in DDragon (e.g., 0.35 = 35%) and applied multiplicatively.
+ */
+const ITEM_STAT_MAP: Record<
+  string,
+  { field: keyof ComputedStats; mode: "flat" | "percent" }
+> = {
+  FlatPhysicalDamageMod: { field: "attackDamage", mode: "flat" },
+  FlatMagicDamageMod: { field: "abilityPower", mode: "flat" },
+  FlatArmorMod: { field: "armor", mode: "flat" },
+  FlatSpellBlockMod: { field: "magicResist", mode: "flat" },
+  FlatHPPoolMod: { field: "maxHealth", mode: "flat" },
+  FlatMovementSpeedMod: { field: "moveSpeed", mode: "flat" },
+  PercentAttackSpeedMod: { field: "attackSpeed", mode: "percent" },
+  PercentMovementSpeedMod: { field: "moveSpeed", mode: "percent" },
+};
+
+/** Riot's per-level scaling factor */
+function levelScaleFactor(level: number): number {
+  return (level - 1) * (0.7025 + 0.0175 * (level - 1));
+}
+
+export function computeEnemyStats(
+  champion: ChampionStats,
+  level: number,
+  items: Item[]
+): ComputedStats {
+  const scale = levelScaleFactor(level);
+
+  // Base + per-level growth
+  const baseAD = champion.attackdamage + champion.attackdamageperlevel * scale;
+  const baseArmor = champion.armor + champion.armorperlevel * scale;
+  const baseMR = champion.spellblock + champion.spellblockperlevel * scale;
+  const baseHP = champion.hp + champion.hpperlevel * scale;
+  const baseMS = champion.movespeed;
+  // Attack speed scales differently: base × (1 + bonus%)
+  // The per-level bonus is a percent stored as a whole number (e.g., 3.5 = 3.5%)
+  const baseAS = champion.attackspeed;
+  const asPerLevelPercent = champion.attackspeedperlevel * scale;
+
+  // Accumulate flat and percent bonuses from items
+  const flatBonuses: Record<keyof ComputedStats, number> = {
+    attackDamage: 0,
+    abilityPower: 0,
+    armor: 0,
+    magicResist: 0,
+    maxHealth: 0,
+    moveSpeed: 0,
+    attackSpeed: 0,
+  };
+
+  const percentBonuses: Record<keyof ComputedStats, number> = {
+    attackDamage: 0,
+    abilityPower: 0,
+    armor: 0,
+    magicResist: 0,
+    maxHealth: 0,
+    moveSpeed: 0,
+    attackSpeed: 0,
+  };
+
+  for (const item of items) {
+    for (const [key, value] of Object.entries(item.stats)) {
+      const mapping = ITEM_STAT_MAP[key];
+      if (!mapping) continue;
+      if (mapping.mode === "flat") {
+        flatBonuses[mapping.field] += value;
+      } else {
+        percentBonuses[mapping.field] += value;
+      }
+    }
+  }
+
+  // Combine: base + flat bonuses, then apply percent bonuses where relevant
+  const totalAS =
+    baseAS * (1 + asPerLevelPercent / 100 + percentBonuses.attackSpeed);
+  const totalMS =
+    (baseMS + flatBonuses.moveSpeed) * (1 + percentBonuses.moveSpeed);
+
+  return {
+    attackDamage: Math.round(baseAD + flatBonuses.attackDamage),
+    abilityPower: Math.round(flatBonuses.abilityPower),
+    armor: Math.round(baseArmor + flatBonuses.armor),
+    magicResist: Math.round(baseMR + flatBonuses.magicResist),
+    maxHealth: Math.round(baseHP + flatBonuses.maxHealth),
+    moveSpeed: Math.round(totalMS),
+    attackSpeed: Math.round(totalAS * 1000) / 1000,
+  };
+}

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -1,6 +1,14 @@
 import { describe, it, expect } from "vitest";
-import { buildSystemPrompt, buildUserPrompt } from "./prompts";
+import {
+  buildSystemPrompt,
+  buildUserPrompt,
+  buildGameSystemPrompt,
+} from "./prompts";
 import type { CoachingContext, CoachingQuery } from "./types";
+import type { GameMode, ModeContext } from "../mode/types";
+import type { GameState } from "../game-state/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { Champion } from "../data-ingest/types";
 
 function createContext(
   overrides: Partial<CoachingContext> = {}
@@ -387,5 +395,351 @@ describe("buildUserPrompt", () => {
       const prompt = buildUserPrompt(ctx, { question: "What should I do?" });
       expect(prompt).not.toContain("Set Progress");
     });
+  });
+});
+
+// --- buildGameSystemPrompt tests ---
+
+function createStubMode(overrides: Partial<GameMode> = {}): GameMode {
+  return {
+    id: "test-mode",
+    displayName: "Test Mode",
+    decisionTypes: ["item-purchase", "open-ended-coaching"],
+    augmentSelectionLevels: [],
+    matches: () => false,
+    buildContext: () => ({}) as ModeContext,
+    ...overrides,
+  };
+}
+
+function createGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    status: "connected",
+    activePlayer: {
+      championName: "Ahri",
+      level: 10,
+      currentGold: 2500,
+      runes: {
+        keystone: "Electrocute",
+        primaryTree: "Domination",
+        secondaryTree: "Sorcery",
+      },
+      stats: {
+        abilityPower: 200,
+        armor: 60,
+        attackDamage: 80,
+        attackSpeed: 0.8,
+        abilityHaste: 30,
+        critChance: 0,
+        magicResist: 40,
+        moveSpeed: 350,
+        maxHealth: 1800,
+        currentHealth: 1500,
+      },
+    },
+    players: [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 5,
+        deaths: 2,
+        assists: 8,
+        items: [],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Player1",
+        position: "",
+        isActivePlayer: true,
+      },
+      {
+        championName: "Garen",
+        team: "ORDER",
+        level: 9,
+        kills: 3,
+        deaths: 4,
+        assists: 6,
+        items: [],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Ally1",
+        position: "",
+        isActivePlayer: false,
+      },
+      {
+        championName: "Zed",
+        team: "CHAOS",
+        level: 11,
+        kills: 8,
+        deaths: 1,
+        assists: 3,
+        items: [],
+        summonerSpells: ["Flash", "Ignite"],
+        riotIdGameName: "Enemy1",
+        position: "",
+        isActivePlayer: false,
+      },
+    ],
+    gameMode: "ARAM",
+    gameTime: 600,
+    ...overrides,
+  };
+}
+
+function createStubGameData(): LoadedGameData {
+  const champions = new Map<string, Champion>([
+    [
+      "ahri",
+      {
+        id: "Ahri",
+        key: 103,
+        name: "Ahri",
+        title: "the Nine-Tailed Fox",
+        tags: ["Mage", "Assassin"],
+        partype: "Mana",
+        stats: {
+          hp: 590,
+          hpperlevel: 96,
+          mp: 418,
+          mpperlevel: 25,
+          movespeed: 330,
+          armor: 21,
+          armorperlevel: 4.7,
+          spellblock: 30,
+          spellblockperlevel: 1.3,
+          attackrange: 550,
+          hpregen: 2.5,
+          hpregenperlevel: 0.6,
+          mpregen: 8,
+          mpregenperlevel: 0.8,
+          attackdamage: 53,
+          attackdamageperlevel: 3,
+          attackspeed: 0.668,
+          attackspeedperlevel: 2,
+        },
+        image: "",
+        aramOverrides: { dmgDealt: 0.95, dmgTaken: 1.05 },
+        abilities: {
+          passive: {
+            name: "Essence Theft",
+            description: "Ahri heals when hitting enemies with abilities.",
+          },
+          spells: [
+            {
+              id: "AhriQ",
+              name: "Orb of Deception",
+              description: "Throws and pulls back an orb.",
+              maxRank: 5,
+              cooldowns: [7, 7, 7, 7, 7],
+              costs: [60, 70, 80, 90, 100],
+              range: [880, 880, 880, 880, 880],
+            },
+          ],
+        },
+      },
+    ],
+    [
+      "garen",
+      {
+        id: "Garen",
+        key: 86,
+        name: "Garen",
+        title: "The Might of Demacia",
+        tags: ["Fighter", "Tank"],
+        partype: "None",
+        stats: {} as Champion["stats"],
+        image: "",
+      },
+    ],
+    [
+      "zed",
+      {
+        id: "Zed",
+        key: 238,
+        name: "Zed",
+        title: "the Master of Shadows",
+        tags: ["Assassin"],
+        partype: "Energy",
+        stats: {} as Champion["stats"],
+        image: "",
+      },
+    ],
+  ]);
+
+  return {
+    version: "16.6.1",
+    champions,
+    items: new Map(),
+    runes: [],
+    augments: new Map(),
+    augmentSets: [],
+    dictionary: {
+      allNames: [],
+      champions: [],
+      items: [],
+      augments: [],
+      search: () => [],
+      findInText: () => [],
+    },
+  };
+}
+
+describe("buildGameSystemPrompt", () => {
+  it("includes coaching persona and rules", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("expert League of Legends coaching AI");
+    expect(prompt).toContain("ITEM AWARENESS");
+    expect(prompt).toContain("GOLD AWARENESS");
+    expect(prompt).toContain("RESPONSE RULES");
+  });
+
+  it("includes state snapshot format instructions", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("[Game State]");
+  });
+
+  it("includes proactive awareness instruction", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("PROACTIVE AWARENESS");
+  });
+
+  it("includes augment rules when mode has augment-selection", () => {
+    const mode = createStubMode({
+      decisionTypes: [
+        "augment-selection",
+        "item-purchase",
+        "open-ended-coaching",
+      ],
+    });
+    const prompt = buildGameSystemPrompt(
+      mode,
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("AUGMENT SELECTION RULES");
+    expect(prompt).toContain("re-roll");
+  });
+
+  it("excludes augment rules when mode lacks augment-selection", () => {
+    const mode = createStubMode({
+      decisionTypes: ["item-purchase", "open-ended-coaching"],
+    });
+    const prompt = buildGameSystemPrompt(
+      mode,
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).not.toContain("AUGMENT SELECTION RULES");
+  });
+
+  it("includes game mode display name", () => {
+    const mode = createStubMode({ displayName: "ARAM Mayhem" });
+    const prompt = buildGameSystemPrompt(
+      mode,
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("GAME MODE: ARAM Mayhem");
+  });
+
+  it("includes player champion name and abilities", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Ahri");
+    expect(prompt).toContain("the Nine-Tailed Fox");
+    expect(prompt).toContain("Essence Theft");
+    expect(prompt).toContain("Orb of Deception");
+  });
+
+  it("includes champion tags and range type", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Ranged (550)");
+    expect(prompt).toContain("Mage, Assassin");
+  });
+
+  it("includes rune setup", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Electrocute (Domination / Sorcery)");
+  });
+
+  it("includes balance overrides for ARAM-family modes", () => {
+    const aramMode = createStubMode({
+      matches: (gm) => gm === "ARAM",
+    });
+    const prompt = buildGameSystemPrompt(
+      aramMode,
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Balance Overrides");
+    expect(prompt).toContain("Damage dealt: -5%");
+    expect(prompt).toContain("Damage taken: +5%");
+  });
+
+  it("excludes balance overrides for non-ARAM modes", () => {
+    const classicMode = createStubMode({
+      matches: () => false,
+    });
+    const prompt = buildGameSystemPrompt(
+      classicMode,
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).not.toContain("Balance Overrides");
+  });
+
+  it("includes all champions with tags in match roster", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Match Roster");
+    expect(prompt).toContain("Ahri (Mage/Assassin)");
+    expect(prompt).toContain("Garen (Fighter/Tank)");
+    expect(prompt).toContain("Zed (Assassin)");
+  });
+
+  it("separates ally and enemy teams in roster", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain("Ally Team:");
+    expect(prompt).toContain("Enemy Team:");
+  });
+
+  it("does not include gold, items, level, or KDA", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    // These are dynamic and belong in state snapshots, not system prompt
+    expect(prompt).not.toContain("Gold:");
+    expect(prompt).not.toContain("KDA:");
+    expect(prompt).not.toContain("Level 10");
   });
 });

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -1,5 +1,9 @@
 import type { CoachingContext, CoachingQuery } from "./types";
-import { formatGameTime } from "../format";
+import type { GameMode } from "../mode/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { AramOverrides, Champion } from "../data-ingest/types";
+import type { GameState } from "../game-state/types";
+import { formatGameTime, formatModifier } from "../format";
 import { GAME_MODE_MAYHEM, GAME_MODE_ARAM } from "../mode/types";
 
 export function buildSystemPrompt(context: {
@@ -226,4 +230,227 @@ function computeSetProgress(
   }
 
   return lines.length > 0 ? lines.join("\n") : null;
+}
+
+// ---------------------------------------------------------------------------
+// Multi-turn system prompt (set once per game session)
+// ---------------------------------------------------------------------------
+
+/**
+ * Build a comprehensive system prompt for a multi-turn game session.
+ *
+ * Contains everything that doesn't change mid-game: coaching rules, static
+ * game data (champion abilities, base stats, runes), all 10 champion names
+ * and tags, mode-specific rules, and balance overrides.
+ *
+ * Uses the GameMode interface for all conditional logic — no hardcoded
+ * mode strings.
+ */
+export function buildGameSystemPrompt(
+  mode: GameMode,
+  gameData: LoadedGameData,
+  gameState: GameState
+): string {
+  const sections: string[] = [];
+
+  // --- Coaching persona and rules ---
+  sections.push(
+    "You are an expert League of Legends coaching AI. Prioritize the game data provided in this prompt over your general knowledge — item stats, augment effects, and champion abilities change frequently."
+  );
+  sections.push("");
+  sections.push(
+    "ITEM AWARENESS: Do not recommend purchasing items already listed in the player's inventory."
+  );
+  sections.push(
+    "GOLD AWARENESS: The gold amount shown is the player's exact current gold. Use it to determine what they can afford. Do not hedge with 'if you can buy' when the gold amount is visible."
+  );
+  sections.push(
+    "ITEM RECOMMENDATIONS: Always name the full target item you're building toward AND the immediate component to buy. Example: 'Build toward Rabadon's Deathcap — buy Needlessly Large Rod next (1250g).' Players think in terms of completed items, not components."
+  );
+  sections.push("");
+  sections.push("RESPONSE RULES:");
+  sections.push("- Be extremely concise. Sacrifice grammar for concision.");
+  sections.push(
+    "- Lead with your top recommendation. Mention alternatives only when the situation genuinely supports different playstyles."
+  );
+  sections.push("- Never explain what the player already knows.");
+
+  // --- State snapshot format instructions ---
+  sections.push("");
+  sections.push(
+    "CONVERSATION FORMAT: Each question will be preceded by a [Game State] block showing the current state of the game. This snapshot is authoritative — use it as ground truth for your recommendations."
+  );
+
+  // --- Opportunistic coaching ---
+  sections.push("");
+  sections.push(
+    "PROACTIVE AWARENESS: If you notice a significant concern in the game state (build gaps, missing resistances against the enemy team composition, unusually high gold without recent purchases), mention it briefly at the end of your response."
+  );
+
+  // --- Augment rules (conditional on mode) ---
+  if (mode.decisionTypes.includes("augment-selection")) {
+    sections.push("");
+    sections.push("AUGMENT SELECTION RULES:");
+    sections.push(
+      "- Augments are NOT items. They are permanent passive bonuses."
+    );
+    sections.push(
+      "- 3 cards shown, each with its own single-use re-roll button."
+    );
+    sections.push(
+      "- Round 1: Recommend the best card. Tell player to re-roll the other two."
+    );
+    sections.push(
+      "- Round 2: 2 new cards replace the re-rolled ones. Only the kept card still has its re-roll."
+    );
+    sections.push(
+      "  - If a new card is better: re-roll the kept card (its re-roll is still unused)."
+    );
+    sections.push(
+      "  - If the kept card is still best: take it. No re-rolls remain on the others."
+    );
+    sections.push(
+      "- Round 3 (only if kept card was re-rolled): Pick the best of the 3 final cards. No re-rolls remain."
+    );
+    sections.push("- A card whose re-roll was used CANNOT be re-rolled again.");
+    sections.push(
+      "- If an augment upgrades a specific item, only recommend it if the player already owns that item."
+    );
+    sections.push(
+      "- Use the augment descriptions provided in the prompt, not your general knowledge."
+    );
+  }
+
+  // --- Game mode ---
+  sections.push("");
+  sections.push(`GAME MODE: ${mode.displayName}`);
+
+  // --- Player champion static data ---
+  if (gameState.activePlayer) {
+    const championKey = gameState.activePlayer.championName.toLowerCase();
+    const champion = gameData.champions.get(championKey);
+
+    sections.push("");
+    sections.push("## Player Champion");
+
+    if (champion) {
+      sections.push(formatChampionProfile(champion));
+
+      if (champion.abilities) {
+        sections.push("");
+        sections.push("### Abilities");
+        sections.push(formatAbilitiesForPrompt(champion.abilities));
+      }
+
+      // Balance overrides — included when the mode handles ARAM-family games
+      const isAramFamily =
+        mode.matches(GAME_MODE_ARAM) || mode.matches(GAME_MODE_MAYHEM);
+      if (champion.aramOverrides && isAramFamily) {
+        const overrides = formatBalanceOverridesForPrompt(
+          champion.aramOverrides
+        );
+        if (overrides) {
+          sections.push("");
+          sections.push(`### Balance Overrides\n${overrides}`);
+        }
+      }
+    } else {
+      sections.push(
+        `${gameState.activePlayer.championName} (no champion data available)`
+      );
+    }
+
+    // Runes
+    const runes = gameState.activePlayer.runes;
+    sections.push("");
+    sections.push(
+      `Runes: ${runes.keystone} (${runes.primaryTree} / ${runes.secondaryTree})`
+    );
+  }
+
+  // --- All champions in the match ---
+  if (gameState.players.length > 0) {
+    sections.push("");
+    sections.push("## Match Roster");
+
+    const activeTeam =
+      gameState.players.find((p) => p.isActivePlayer)?.team ?? "ORDER";
+
+    const allies = gameState.players.filter((p) => p.team === activeTeam);
+    const enemies = gameState.players.filter((p) => p.team !== activeTeam);
+
+    if (allies.length > 0) {
+      const allyList = allies
+        .map((p) => {
+          const champ = gameData.champions.get(p.championName.toLowerCase());
+          const tags = champ?.tags.join("/") ?? "unknown";
+          return `${p.championName} (${tags})`;
+        })
+        .join(", ");
+      sections.push(`Ally Team: ${allyList}`);
+    }
+
+    if (enemies.length > 0) {
+      const enemyList = enemies
+        .map((p) => {
+          const champ = gameData.champions.get(p.championName.toLowerCase());
+          const tags = champ?.tags.join("/") ?? "unknown";
+          return `${p.championName} (${tags})`;
+        })
+        .join(", ");
+      sections.push(`Enemy Team: ${enemyList}`);
+    }
+  }
+
+  return sections.join("\n");
+}
+
+function formatChampionProfile(champion: Champion): string {
+  const s = champion.stats;
+  const rangeType =
+    s.attackrange <= 300 ? "Melee" : `Ranged (${s.attackrange})`;
+
+  return [
+    `${champion.name} — ${champion.title}`,
+    `${rangeType} | ${champion.tags.join(", ")} | ${champion.partype || "No resource"}`,
+  ].join("\n");
+}
+
+function formatAbilitiesForPrompt(
+  abilities: NonNullable<Champion["abilities"]>
+): string {
+  const parts: string[] = [];
+  parts.push(
+    `Passive: ${abilities.passive.name} — ${abilities.passive.description}`
+  );
+  for (const spell of abilities.spells) {
+    parts.push(`${spell.name} — ${spell.description}`);
+  }
+  return parts.join("\n");
+}
+
+function formatBalanceOverridesForPrompt(
+  overrides: AramOverrides
+): string | null {
+  const parts: string[] = [];
+  if (overrides.dmgDealt !== 1) {
+    parts.push(`Damage dealt: ${formatModifier(overrides.dmgDealt)}`);
+  }
+  if (overrides.dmgTaken !== 1) {
+    parts.push(`Damage taken: ${formatModifier(overrides.dmgTaken)}`);
+  }
+  if (overrides.healing != null && overrides.healing !== 1) {
+    parts.push(`Healing: ${formatModifier(overrides.healing)}`);
+  }
+  if (overrides.shielding != null && overrides.shielding !== 1) {
+    parts.push(`Shielding: ${formatModifier(overrides.shielding)}`);
+  }
+  if (overrides.tenacity != null && overrides.tenacity !== 1) {
+    parts.push(`Tenacity: ${formatModifier(overrides.tenacity)}`);
+  }
+  if (overrides.abilityHaste != null && overrides.abilityHaste !== 0) {
+    parts.push(`Ability Haste: +${overrides.abilityHaste}`);
+  }
+  if (parts.length === 0) return null;
+  return parts.join(", ");
 }

--- a/src/lib/ai/recommendation-engine.test.ts
+++ b/src/lib/ai/recommendation-engine.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { getMultiTurnCoachingResponse } from "./recommendation-engine";
+import { createConversationSession } from "./conversation-session";
+
+// Mock the ai module to intercept generateText calls
+vi.mock("ai", async () => {
+  const actual = await vi.importActual("ai");
+  return {
+    ...actual,
+    generateText: vi.fn(),
+  };
+});
+
+// Mock model-config to avoid needing a real API key
+vi.mock("./model-config", () => ({
+  createCoachingModel: () => "mock-model",
+  MODEL_CONFIG: { id: "test-model", name: "Test" },
+}));
+
+import { generateText } from "ai";
+
+const mockGenerateText = vi.mocked(generateText);
+
+describe("getMultiTurnCoachingResponse", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("calls generateText with system prompt and messages from session", async () => {
+    const session = createConversationSession("You are a coach.");
+    session.addUserMessage("Level: 5, Gold: 1200", "What should I buy?");
+
+    mockGenerateText.mockResolvedValueOnce({
+      output: {
+        answer: "Buy Rabadon's Deathcap.",
+        recommendations: [
+          { name: "Rabadon's Deathcap", reasoning: "High AP scaling" },
+        ],
+      },
+      usage: { inputTokens: 100, outputTokens: 50 },
+    } as never);
+
+    const response = await getMultiTurnCoachingResponse(
+      session,
+      "test-api-key"
+    );
+
+    expect(mockGenerateText).toHaveBeenCalledOnce();
+    const callArgs = mockGenerateText.mock.calls[0][0];
+    expect(callArgs.system).toBe("You are a coach.");
+    expect(callArgs).not.toHaveProperty("prompt");
+
+    const messages = callArgs.messages;
+    expect(messages).toBeDefined();
+    expect(messages).toHaveLength(1);
+    expect(messages?.[0].role).toBe("user");
+    expect(messages?.[0].content).toContain("What should I buy?");
+
+    expect(response.answer).toBe("Buy Rabadon's Deathcap.");
+    expect(response.recommendations).toHaveLength(1);
+  });
+
+  it("passes abort signal when provided", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State", "Question");
+
+    const controller = new AbortController();
+
+    mockGenerateText.mockResolvedValueOnce({
+      output: {
+        answer: "Answer",
+        recommendations: [],
+      },
+      usage: { inputTokens: 50, outputTokens: 20 },
+    } as never);
+
+    await getMultiTurnCoachingResponse(session, "test-key", {
+      signal: controller.signal,
+    });
+
+    const callArgs = mockGenerateText.mock.calls[0][0];
+    expect(callArgs.abortSignal).toBe(controller.signal);
+  });
+
+  it("includes conversation history across multiple turns", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State 1", "First question");
+    session.addAssistantMessage('{"answer":"First answer"}');
+    session.addUserMessage("State 2", "Follow-up question");
+
+    mockGenerateText.mockResolvedValueOnce({
+      output: {
+        answer: "Follow-up answer",
+        recommendations: [],
+      },
+      usage: { inputTokens: 200, outputTokens: 30 },
+    } as never);
+
+    await getMultiTurnCoachingResponse(session, "test-key");
+
+    const callArgs = mockGenerateText.mock.calls[0][0];
+    const messages = callArgs.messages;
+    expect(messages).toBeDefined();
+    expect(messages).toHaveLength(3);
+    expect(messages?.[0].role).toBe("user");
+    expect(messages?.[1].role).toBe("assistant");
+    expect(messages?.[2].role).toBe("user");
+  });
+});

--- a/src/lib/ai/recommendation-engine.ts
+++ b/src/lib/ai/recommendation-engine.ts
@@ -1,5 +1,6 @@
-import { generateText, Output } from "ai";
+import { generateText, Output, type ModelMessage } from "ai";
 import type { CoachingContext, CoachingQuery, CoachingResponse } from "./types";
+import type { ConversationSession } from "./conversation-session";
 import { createCoachingModel, MODEL_CONFIG } from "./model-config";
 import { buildSystemPrompt, buildUserPrompt } from "./prompts";
 import { coachingResponseSchema } from "./schemas";
@@ -68,6 +69,58 @@ export async function getCoachingResponse(
       elapsedMs,
       error: err instanceof Error ? err.message : String(err),
       stack: err instanceof Error ? err.stack : undefined,
+    });
+    throw err;
+  }
+}
+
+/**
+ * Multi-turn coaching response using a conversation session.
+ *
+ * Uses the session's system prompt and message array instead of
+ * rebuilding context from scratch on each call.
+ */
+export async function getMultiTurnCoachingResponse(
+  session: ConversationSession,
+  apiKey: string,
+  options?: { signal?: AbortSignal }
+): Promise<CoachingResponse> {
+  coachingLog.info(
+    `Multi-turn request: ${session.messages.length} messages in thread`,
+    { model: MODEL_CONFIG.id }
+  );
+
+  const startMs = Date.now();
+  const model = createCoachingModel(apiKey);
+
+  try {
+    const result = await generateText({
+      model,
+      system: session.systemPrompt,
+      messages: [...session.messages] as ModelMessage[],
+      output: Output.object({ schema: coachingResponseSchema }),
+      maxOutputTokens: 1024,
+      ...(options?.signal ? { abortSignal: options.signal } : {}),
+    });
+
+    const elapsedMs = Date.now() - startMs;
+    const usage = result.usage;
+    const recs = result.output.recommendations;
+
+    coachingLog.info(
+      `Response (${elapsedMs}ms): ${usage.inputTokens ?? "?"}in/${usage.outputTokens ?? "?"}out`,
+      {
+        answer: result.output.answer,
+        recommendations: recs.map((r) => r.name),
+      }
+    );
+
+    return result.output;
+  } catch (err) {
+    const elapsedMs = Date.now() - startMs;
+    coachingLog.error("Multi-turn request failed", {
+      elapsedMs,
+      error: err instanceof Error ? err.message : String(err),
     });
     throw err;
   }

--- a/src/lib/ai/recommendation-engine.ts
+++ b/src/lib/ai/recommendation-engine.ts
@@ -1,4 +1,4 @@
-import { generateText, Output, type ModelMessage } from "ai";
+import { generateText, Output } from "ai";
 import type { CoachingContext, CoachingQuery, CoachingResponse } from "./types";
 import type { ConversationSession } from "./conversation-session";
 import { createCoachingModel, MODEL_CONFIG } from "./model-config";
@@ -97,7 +97,7 @@ export async function getMultiTurnCoachingResponse(
     const result = await generateText({
       model,
       system: session.systemPrompt,
-      messages: [...session.messages] as ModelMessage[],
+      messages: [...session.messages],
       output: Output.object({ schema: coachingResponseSchema }),
       maxOutputTokens: 1024,
       ...(options?.signal ? { abortSignal: options.signal } : {}),

--- a/src/lib/ai/state-formatter.test.ts
+++ b/src/lib/ai/state-formatter.test.ts
@@ -118,7 +118,7 @@ describe("formatStateSnapshot", () => {
   it("includes player stats from API", () => {
     const output = formatStateSnapshot(createSnapshot());
     expect(output).toContain(
-      "Stats: 200 AP, 80 AD, 60 Armor, 40 MR, 30 AH, 350 MS, 1800 HP"
+      "Stats: 200 AP, 80 AD, 60 Armor, 40 MR, 30 AH, 0.80 AS, 0% Crit, 350 MS, 1800 HP"
     );
   });
 

--- a/src/lib/ai/state-formatter.test.ts
+++ b/src/lib/ai/state-formatter.test.ts
@@ -1,0 +1,356 @@
+import { describe, it, expect } from "vitest";
+import {
+  formatStateSnapshot,
+  takeGameSnapshot,
+  type GameSnapshot,
+} from "./state-formatter";
+import type { ActivePlayerStats } from "../game-state/types";
+import type { LiveGameState } from "../reactive/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { Item } from "../data-ingest/types";
+import type { ComputedStats } from "./enemy-stats";
+
+function createPlayerStats(): ActivePlayerStats {
+  return {
+    abilityPower: 200,
+    attackDamage: 80,
+    attackSpeed: 0.8,
+    armor: 60,
+    magicResist: 40,
+    abilityHaste: 30,
+    critChance: 0,
+    moveSpeed: 350,
+    maxHealth: 1800,
+    currentHealth: 1500,
+  };
+}
+
+function createSnapshot(overrides: Partial<GameSnapshot> = {}): GameSnapshot {
+  return {
+    player: {
+      championName: "Ahri",
+      level: 10,
+      kda: { kills: 5, deaths: 2, assists: 8 },
+      items: [
+        {
+          name: "Rabadon's Deathcap",
+          description: "Greatly increases Ability Power",
+        },
+        { name: "Zhonya's Hourglass", description: "" },
+      ],
+      gold: 1250,
+      stats: createPlayerStats(),
+      augments: [],
+    },
+    allies: ["Garen", "Lux", "Jinx"],
+    enemies: [
+      {
+        championName: "Zed",
+        level: 11,
+        kda: { kills: 8, deaths: 1, assists: 3 },
+        items: ["Duskblade of Draktharr", "Edge of Night"],
+        stats: {
+          attackDamage: 180,
+          abilityPower: 0,
+          armor: 75,
+          magicResist: 42,
+          maxHealth: 2000,
+          moveSpeed: 380,
+          attackSpeed: 1.1,
+        },
+      },
+      {
+        championName: "Sona",
+        level: 8,
+        kda: { kills: 1, deaths: 5, assists: 12 },
+        items: ["Ardent Censer"],
+        stats: {
+          attackDamage: 55,
+          abilityPower: 120,
+          armor: 35,
+          magicResist: 38,
+          maxHealth: 1400,
+          moveSpeed: 340,
+          attackSpeed: 0.7,
+        },
+      },
+    ],
+    gameTime: 600,
+    ...overrides,
+  };
+}
+
+describe("formatStateSnapshot", () => {
+  it("includes player champion name and level", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain("Player Champion: Ahri (Level 10)");
+  });
+
+  it("includes KDA", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain("KDA: 5/2/8");
+  });
+
+  it("includes items with descriptions when available", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain(
+      "Rabadon's Deathcap (Greatly increases Ability Power)"
+    );
+    // Item without description shows just name
+    expect(output).toContain("Zhonya's Hourglass");
+    expect(output).not.toContain("Zhonya's Hourglass ()");
+  });
+
+  it("shows 'none' when player has no items", () => {
+    const snapshot = createSnapshot();
+    snapshot.player.items = [];
+    const output = formatStateSnapshot(snapshot);
+    expect(output).toContain("Items: none");
+  });
+
+  it("includes gold floored to integer", () => {
+    const snapshot = createSnapshot();
+    snapshot.player.gold = 1250.7;
+    const output = formatStateSnapshot(snapshot);
+    expect(output).toContain("Gold: 1250");
+  });
+
+  it("includes player stats from API", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain(
+      "Stats: 200 AP, 80 AD, 60 Armor, 40 MR, 30 AH, 350 MS, 1800 HP"
+    );
+  });
+
+  it("includes augments when present", () => {
+    const snapshot = createSnapshot();
+    snapshot.player.augments = ["Jeweled Gauntlet", "Ethereal Blades"];
+    const output = formatStateSnapshot(snapshot);
+    expect(output).toContain("Augments: Jeweled Gauntlet, Ethereal Blades");
+  });
+
+  it("omits augments line when empty", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).not.toContain("Augments:");
+  });
+
+  it("includes ally team", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain("Ally Team: Garen, Lux, Jinx");
+  });
+
+  it("includes enemy team with stats and items", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain("Enemy Team:");
+    expect(output).toContain(
+      "- Zed (Level 11, 8/1/3): 180 AD, 0 AP, 75 Armor, 42 MR, 380 MS, 2000 HP — Duskblade of Draktharr, Edge of Night"
+    );
+    expect(output).toContain(
+      "- Sona (Level 8, 1/5/12): 55 AD, 120 AP, 35 Armor, 38 MR, 340 MS, 1400 HP — Ardent Censer"
+    );
+  });
+
+  it("shows 'no items' for enemies without items", () => {
+    const snapshot = createSnapshot();
+    snapshot.enemies[0].items = [];
+    const output = formatStateSnapshot(snapshot);
+    expect(output).toContain("no items");
+  });
+
+  it("formats enemy without computed stats gracefully", () => {
+    const snapshot = createSnapshot();
+    snapshot.enemies[0].stats = null;
+    const output = formatStateSnapshot(snapshot);
+    expect(output).toContain(
+      "- Zed (Level 11, 8/1/3): Duskblade of Draktharr, Edge of Night"
+    );
+  });
+});
+
+describe("takeGameSnapshot", () => {
+  function createLiveGameState(): LiveGameState {
+    return {
+      activePlayer: {
+        championName: "Ahri",
+        level: 10,
+        currentGold: 2500,
+        runes: {
+          keystone: "Electrocute",
+          primaryTree: "Domination",
+          secondaryTree: "Sorcery",
+        },
+        stats: createPlayerStats(),
+      },
+      players: [
+        {
+          championName: "Ahri",
+          team: "ORDER",
+          level: 10,
+          kills: 5,
+          deaths: 2,
+          assists: 8,
+          items: [{ id: 3089, name: "Rabadon's Deathcap" }],
+          summonerSpells: ["Flash", "Mark"],
+          riotIdGameName: "Player1",
+          position: "",
+          isActivePlayer: true,
+        },
+        {
+          championName: "Garen",
+          team: "ORDER",
+          level: 9,
+          kills: 3,
+          deaths: 4,
+          assists: 6,
+          items: [],
+          summonerSpells: ["Flash", "Mark"],
+          riotIdGameName: "Ally1",
+          position: "",
+          isActivePlayer: false,
+        },
+        {
+          championName: "Zed",
+          team: "CHAOS",
+          level: 11,
+          kills: 8,
+          deaths: 1,
+          assists: 3,
+          items: [{ id: 6693, name: "Duskblade of Draktharr" }],
+          summonerSpells: ["Flash", "Ignite"],
+          riotIdGameName: "Enemy1",
+          position: "",
+          isActivePlayer: false,
+        },
+      ],
+      gameMode: "ARAM",
+      lcuGameMode: "ARAM",
+      gameTime: 600,
+      champSelect: null,
+      eogStats: null,
+    };
+  }
+
+  function createGameData(): LoadedGameData {
+    const items = new Map<number, Item>([
+      [
+        3089,
+        {
+          id: 3089,
+          name: "Rabadon's Deathcap",
+          description: "<stats>AP</stats>",
+          plaintext: "Greatly increases Ability Power",
+          gold: { base: 1100, total: 3600, sell: 2520, purchasable: true },
+          tags: [],
+          stats: {},
+          image: "",
+          mode: "standard",
+        },
+      ],
+    ]);
+
+    return {
+      version: "16.6.1",
+      champions: new Map(),
+      items,
+      runes: [],
+      augments: new Map(),
+      augmentSets: [],
+      dictionary: {
+        allNames: [],
+        champions: [],
+        items: [],
+        augments: [],
+        search: () => [],
+        findInText: () => [],
+      },
+    };
+  }
+
+  it("returns null when no active player", () => {
+    const state = createLiveGameState();
+    state.activePlayer = null;
+    const snapshot = takeGameSnapshot(state, new Map(), createGameData());
+    expect(snapshot).toBeNull();
+  });
+
+  it("builds player snapshot from active player", () => {
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      new Map(),
+      createGameData()
+    );
+    expect(snapshot).not.toBeNull();
+    expect(snapshot!.player.championName).toBe("Ahri");
+    expect(snapshot!.player.level).toBe(10);
+    expect(snapshot!.player.gold).toBe(2500);
+    expect(snapshot!.player.kda).toEqual({ kills: 5, deaths: 2, assists: 8 });
+  });
+
+  it("uses plaintext for item descriptions", () => {
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      new Map(),
+      createGameData()
+    );
+    expect(snapshot!.player.items[0].description).toBe(
+      "Greatly increases Ability Power"
+    );
+  });
+
+  it("separates allies and enemies by team", () => {
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      new Map(),
+      createGameData()
+    );
+    expect(snapshot!.allies).toEqual(["Garen"]);
+    expect(snapshot!.enemies).toHaveLength(1);
+    expect(snapshot!.enemies[0].championName).toBe("Zed");
+  });
+
+  it("includes computed enemy stats when available", () => {
+    const enemyStats = new Map<string, ComputedStats>([
+      [
+        "Zed",
+        {
+          attackDamage: 180,
+          abilityPower: 0,
+          armor: 75,
+          magicResist: 42,
+          maxHealth: 2000,
+          moveSpeed: 380,
+          attackSpeed: 1.1,
+        },
+      ],
+    ]);
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      enemyStats,
+      createGameData()
+    );
+    expect(snapshot!.enemies[0].stats).not.toBeNull();
+    expect(snapshot!.enemies[0].stats!.attackDamage).toBe(180);
+  });
+
+  it("sets null stats for enemies without computed stats", () => {
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      new Map(),
+      createGameData()
+    );
+    expect(snapshot!.enemies[0].stats).toBeNull();
+  });
+
+  it("includes chosen augments", () => {
+    const snapshot = takeGameSnapshot(
+      createLiveGameState(),
+      new Map(),
+      createGameData(),
+      ["Jeweled Gauntlet", "Ethereal Blades"]
+    );
+    expect(snapshot!.player.augments).toEqual([
+      "Jeweled Gauntlet",
+      "Ethereal Blades",
+    ]);
+  });
+});

--- a/src/lib/ai/state-formatter.test.ts
+++ b/src/lib/ai/state-formatter.test.ts
@@ -81,6 +81,11 @@ function createSnapshot(overrides: Partial<GameSnapshot> = {}): GameSnapshot {
 }
 
 describe("formatStateSnapshot", () => {
+  it("includes game time", () => {
+    const output = formatStateSnapshot(createSnapshot());
+    expect(output).toContain("Game Time: 10:00");
+  });
+
   it("includes player champion name and level", () => {
     const output = formatStateSnapshot(createSnapshot());
     expect(output).toContain("Player Champion: Ahri (Level 10)");
@@ -143,10 +148,10 @@ describe("formatStateSnapshot", () => {
     const output = formatStateSnapshot(createSnapshot());
     expect(output).toContain("Enemy Team:");
     expect(output).toContain(
-      "- Zed (Level 11, 8/1/3): 180 AD, 0 AP, 75 Armor, 42 MR, 380 MS, 2000 HP — Duskblade of Draktharr, Edge of Night"
+      "- Zed (Level 11, 8/1/3): 180 AD, 0 AP, 75 Armor, 42 MR, 1.10 AS, 380 MS, 2000 HP — Duskblade of Draktharr, Edge of Night"
     );
     expect(output).toContain(
-      "- Sona (Level 8, 1/5/12): 55 AD, 120 AP, 35 Armor, 38 MR, 340 MS, 1400 HP — Ardent Censer"
+      "- Sona (Level 8, 1/5/12): 55 AD, 120 AP, 35 Armor, 38 MR, 0.70 AS, 340 MS, 1400 HP — Ardent Censer"
     );
   });
 

--- a/src/lib/ai/state-formatter.ts
+++ b/src/lib/ai/state-formatter.ts
@@ -155,6 +155,8 @@ function formatPlayerStats(stats: ActivePlayerStats): string {
     `${Math.round(stats.armor)} Armor`,
     `${Math.round(stats.magicResist)} MR`,
     `${Math.round(stats.abilityHaste)} AH`,
+    `${stats.attackSpeed.toFixed(2)} AS`,
+    `${Math.round(stats.critChance * 100)}% Crit`,
     `${Math.round(stats.moveSpeed)} MS`,
     `${Math.round(stats.maxHealth)} HP`,
   ];

--- a/src/lib/ai/state-formatter.ts
+++ b/src/lib/ai/state-formatter.ts
@@ -1,0 +1,181 @@
+/**
+ * Formats game state snapshots for inclusion in LLM conversation messages.
+ *
+ * Every user message includes a full snapshot (not a diff), re-anchoring
+ * the LLM to ground truth each turn. Uses neutral POV throughout.
+ */
+
+import type { ActivePlayerStats } from "../game-state/types";
+import type { LiveGameState } from "../reactive/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { ComputedStats } from "./enemy-stats";
+
+export interface PlayerSnapshot {
+  championName: string;
+  level: number;
+  kda: { kills: number; deaths: number; assists: number };
+  items: Array<{ name: string; description: string }>;
+  gold: number;
+  stats: ActivePlayerStats;
+  augments: string[];
+}
+
+export interface EnemySnapshot {
+  championName: string;
+  level: number;
+  kda: { kills: number; deaths: number; assists: number };
+  items: string[];
+  stats: ComputedStats | null;
+}
+
+export interface GameSnapshot {
+  player: PlayerSnapshot;
+  allies: string[];
+  enemies: EnemySnapshot[];
+  gameTime: number;
+}
+
+/**
+ * Build a GameSnapshot from live game state and computed enemy stats.
+ *
+ * The player's stats come from the Riot API (exact values including
+ * buffs and runes). Enemy stats are computed approximations.
+ */
+export function takeGameSnapshot(
+  liveGameState: LiveGameState,
+  enemyStats: Map<string, ComputedStats>,
+  gameData: LoadedGameData,
+  chosenAugments: string[] = []
+): GameSnapshot | null {
+  if (!liveGameState.activePlayer) return null;
+
+  const active = liveGameState.activePlayer;
+  const activePlayerInfo = liveGameState.players.find((p) => p.isActivePlayer);
+  const activeTeam = activePlayerInfo?.team ?? "ORDER";
+
+  const playerItems = (activePlayerInfo?.items ?? []).map((item) => {
+    const itemData = gameData.items.get(item.id);
+    return {
+      name: item.name,
+      description: itemData?.plaintext ?? "",
+    };
+  });
+
+  const player: PlayerSnapshot = {
+    championName: active.championName,
+    level: active.level,
+    kda: {
+      kills: activePlayerInfo?.kills ?? 0,
+      deaths: activePlayerInfo?.deaths ?? 0,
+      assists: activePlayerInfo?.assists ?? 0,
+    },
+    items: playerItems,
+    gold: active.currentGold,
+    stats: active.stats,
+    augments: chosenAugments,
+  };
+
+  const allies: string[] = [];
+  const enemies: EnemySnapshot[] = [];
+
+  for (const p of liveGameState.players) {
+    if (p.isActivePlayer) continue;
+
+    if (p.team === activeTeam) {
+      allies.push(p.championName);
+    } else {
+      enemies.push({
+        championName: p.championName,
+        level: p.level,
+        kda: { kills: p.kills, deaths: p.deaths, assists: p.assists },
+        items: p.items.map((i) => i.name),
+        stats: enemyStats.get(p.championName) ?? null,
+      });
+    }
+  }
+
+  return {
+    player,
+    allies,
+    enemies,
+    gameTime: liveGameState.gameTime,
+  };
+}
+
+/** Format a full game state snapshot as text for the LLM. */
+export function formatStateSnapshot(snapshot: GameSnapshot): string {
+  const sections: string[] = [];
+
+  // Player champion
+  const p = snapshot.player;
+  const kda = `${p.kda.kills}/${p.kda.deaths}/${p.kda.assists}`;
+  sections.push(`Player Champion: ${p.championName} (Level ${p.level})`);
+  sections.push(`KDA: ${kda}`);
+
+  // Player items
+  if (p.items.length > 0) {
+    const itemList = p.items
+      .map((i) => (i.description ? `${i.name} (${i.description})` : i.name))
+      .join(", ");
+    sections.push(`Items: ${itemList}`);
+  } else {
+    sections.push("Items: none");
+  }
+
+  sections.push(`Gold: ${Math.floor(p.gold)}`);
+
+  // Player stats (exact from API)
+  sections.push(formatPlayerStats(p.stats));
+
+  // Augments
+  if (p.augments.length > 0) {
+    sections.push(`Augments: ${p.augments.join(", ")}`);
+  }
+
+  // Ally team
+  if (snapshot.allies.length > 0) {
+    sections.push(`\nAlly Team: ${snapshot.allies.join(", ")}`);
+  }
+
+  // Enemy team
+  if (snapshot.enemies.length > 0) {
+    sections.push("\nEnemy Team:");
+    for (const enemy of snapshot.enemies) {
+      sections.push(formatEnemyLine(enemy));
+    }
+  }
+
+  return sections.join("\n");
+}
+
+function formatPlayerStats(stats: ActivePlayerStats): string {
+  const parts = [
+    `${Math.round(stats.abilityPower)} AP`,
+    `${Math.round(stats.attackDamage)} AD`,
+    `${Math.round(stats.armor)} Armor`,
+    `${Math.round(stats.magicResist)} MR`,
+    `${Math.round(stats.abilityHaste)} AH`,
+    `${Math.round(stats.moveSpeed)} MS`,
+    `${Math.round(stats.maxHealth)} HP`,
+  ];
+  return `Stats: ${parts.join(", ")}`;
+}
+
+function formatEnemyLine(enemy: EnemySnapshot): string {
+  const kda = `${enemy.kda.kills}/${enemy.kda.deaths}/${enemy.kda.assists}`;
+  const items = enemy.items.length > 0 ? enemy.items.join(", ") : "no items";
+
+  if (enemy.stats) {
+    const stats = [
+      `${enemy.stats.attackDamage} AD`,
+      `${enemy.stats.abilityPower} AP`,
+      `${enemy.stats.armor} Armor`,
+      `${enemy.stats.magicResist} MR`,
+      `${enemy.stats.moveSpeed} MS`,
+      `${enemy.stats.maxHealth} HP`,
+    ].join(", ");
+    return `- ${enemy.championName} (Level ${enemy.level}, ${kda}): ${stats} — ${items}`;
+  }
+
+  return `- ${enemy.championName} (Level ${enemy.level}, ${kda}): ${items}`;
+}

--- a/src/lib/ai/state-formatter.ts
+++ b/src/lib/ai/state-formatter.ts
@@ -106,6 +106,11 @@ export function takeGameSnapshot(
 export function formatStateSnapshot(snapshot: GameSnapshot): string {
   const sections: string[] = [];
 
+  sections.push(
+    `Game Time: ${Math.floor(snapshot.gameTime / 60)}:${String(Math.floor(snapshot.gameTime) % 60).padStart(2, "0")}`
+  );
+  sections.push("");
+
   // Player champion
   const p = snapshot.player;
   const kda = `${p.kda.kills}/${p.kda.deaths}/${p.kda.assists}`;
@@ -173,6 +178,7 @@ function formatEnemyLine(enemy: EnemySnapshot): string {
       `${enemy.stats.abilityPower} AP`,
       `${enemy.stats.armor} Armor`,
       `${enemy.stats.magicResist} MR`,
+      `${enemy.stats.attackSpeed.toFixed(2)} AS`,
       `${enemy.stats.moveSpeed} MS`,
       `${enemy.stats.maxHealth} HP`,
     ].join(", ");

--- a/src/lib/mode/aram-mayhem.test.ts
+++ b/src/lib/mode/aram-mayhem.test.ts
@@ -243,8 +243,12 @@ describe("aramMayhemMode", () => {
   });
 
   describe("matches", () => {
-    it("matches ARAM game mode", () => {
-      expect(aramMayhemMode.matches("ARAM")).toBe(true);
+    it("matches KIWI (Mayhem) game mode", () => {
+      expect(aramMayhemMode.matches("KIWI")).toBe(true);
+    });
+
+    it("does not match straight ARAM", () => {
+      expect(aramMayhemMode.matches("ARAM")).toBe(false);
     });
 
     it("does not match other game modes", () => {

--- a/src/lib/mode/aram.test.ts
+++ b/src/lib/mode/aram.test.ts
@@ -1,0 +1,217 @@
+import { describe, it, expect } from "vitest";
+import { aramMode } from "./aram";
+import type { GameState } from "../game-state/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { Augment, AugmentSet, Champion, Item } from "../data-ingest/types";
+
+function createGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    status: "connected",
+    activePlayer: {
+      championName: "Ahri",
+      level: 10,
+      currentGold: 2500,
+      runes: {
+        keystone: "Electrocute",
+        primaryTree: "Domination",
+        secondaryTree: "Sorcery",
+      },
+      stats: {
+        abilityPower: 200,
+        armor: 60,
+        attackDamage: 80,
+        attackSpeed: 0.8,
+        abilityHaste: 30,
+        critChance: 0,
+        magicResist: 40,
+        moveSpeed: 350,
+        maxHealth: 1800,
+        currentHealth: 1500,
+      },
+    },
+    players: [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 5,
+        deaths: 2,
+        assists: 8,
+        items: [{ id: 3089, name: "Rabadon's Deathcap" }],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Player1",
+        position: "",
+        isActivePlayer: true,
+      },
+      {
+        championName: "Garen",
+        team: "CHAOS",
+        level: 9,
+        kills: 3,
+        deaths: 4,
+        assists: 6,
+        items: [{ id: 3075, name: "Thornmail" }],
+        summonerSpells: ["Flash", "Mark"],
+        riotIdGameName: "Enemy1",
+        position: "",
+        isActivePlayer: false,
+      },
+    ],
+    gameMode: "ARAM",
+    gameTime: 600,
+    ...overrides,
+  };
+}
+
+function createGameData(): LoadedGameData {
+  const champions = new Map<string, Champion>([
+    [
+      "ahri",
+      {
+        id: "Ahri",
+        key: 103,
+        name: "Ahri",
+        title: "the Nine-Tailed Fox",
+        tags: ["Mage", "Assassin"],
+        partype: "Mana",
+        stats: {} as Champion["stats"],
+        image: "",
+        aramOverrides: { dmgDealt: 1.0, dmgTaken: 0.95 },
+      },
+    ],
+    [
+      "garen",
+      {
+        id: "Garen",
+        key: 86,
+        name: "Garen",
+        title: "The Might of Demacia",
+        tags: ["Fighter", "Tank"],
+        partype: "None",
+        stats: {} as Champion["stats"],
+        image: "",
+        aramOverrides: { dmgDealt: 1.05, dmgTaken: 1.05 },
+      },
+    ],
+  ]);
+
+  const items = new Map<number, Item>([
+    [
+      328001,
+      {
+        id: 328001,
+        name: "ARAM Boots",
+        description: "ARAM variant",
+        plaintext: "",
+        gold: { base: 300, total: 300, sell: 210, purchasable: true },
+        tags: [],
+        stats: {},
+        image: "",
+        mode: "aram",
+      },
+    ],
+  ]);
+
+  const augments = new Map<string, Augment>([
+    [
+      "typhoon",
+      {
+        name: "Typhoon",
+        description: "Storm damage",
+        tier: "Silver",
+        sets: ["Firecracker"],
+        mode: "mayhem",
+      },
+    ],
+  ]);
+
+  const augmentSets: AugmentSet[] = [
+    {
+      name: "Firecracker",
+      bonuses: [
+        { threshold: 2, description: "Firecrackers bounce to 2 enemies" },
+      ],
+    },
+  ];
+
+  return {
+    version: "16.6.1",
+    champions,
+    items,
+    runes: [],
+    augments,
+    augmentSets,
+    dictionary: {
+      allNames: [],
+      champions: [],
+      items: [],
+      augments: [],
+      search: () => [],
+      findInText: () => [],
+    },
+  };
+}
+
+describe("aramMode", () => {
+  it("has correct id and display name", () => {
+    expect(aramMode.id).toBe("aram");
+    expect(aramMode.displayName).toBe("ARAM");
+  });
+
+  it("declares item-purchase and open-ended-coaching decision types only", () => {
+    expect(aramMode.decisionTypes).toContain("item-purchase");
+    expect(aramMode.decisionTypes).toContain("open-ended-coaching");
+    expect(aramMode.decisionTypes).not.toContain("augment-selection");
+  });
+
+  it("has no augment selection levels", () => {
+    expect(aramMode.augmentSelectionLevels).toEqual([]);
+  });
+
+  describe("matches", () => {
+    it("matches ARAM game mode", () => {
+      expect(aramMode.matches("ARAM")).toBe(true);
+    });
+
+    it("does not match KIWI (Mayhem)", () => {
+      expect(aramMode.matches("KIWI")).toBe(false);
+    });
+
+    it("does not match other game modes", () => {
+      expect(aramMode.matches("CLASSIC")).toBe(false);
+      expect(aramMode.matches("CHERRY")).toBe(false);
+    });
+  });
+
+  describe("buildContext", () => {
+    it("includes balance overrides from champion data", () => {
+      const ctx = aramMode.buildContext(createGameState(), createGameData());
+      const ahri = ctx.playerContexts.get("Player1");
+      expect(ahri!.balanceOverrides).toEqual({
+        dmgDealt: 1.0,
+        dmgTaken: 0.95,
+      });
+    });
+
+    it("returns empty augment maps", () => {
+      const ctx = aramMode.buildContext(createGameState(), createGameData());
+      expect(ctx.modeAugments.size).toBe(0);
+    });
+
+    it("returns empty augment sets", () => {
+      const ctx = aramMode.buildContext(createGameState(), createGameData());
+      expect(ctx.augmentSets).toEqual([]);
+    });
+
+    it("filters items to ARAM mode", () => {
+      const ctx = aramMode.buildContext(createGameState(), createGameData());
+      expect(ctx.modeItems.size).toBe(1);
+      expect(ctx.modeItems.has(328001)).toBe(true);
+    });
+
+    it("references itself as the mode", () => {
+      const ctx = aramMode.buildContext(createGameState(), createGameData());
+      expect(ctx.mode).toBe(aramMode);
+    });
+  });
+});

--- a/src/lib/mode/aram.ts
+++ b/src/lib/mode/aram.ts
@@ -7,14 +7,9 @@
 
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
-import type {
-  GameMode,
-  ModeContext,
-  PlayerModeContext,
-  TeamComposition,
-} from "./types";
+import type { GameMode, ModeContext, PlayerModeContext } from "./types";
 import { GAME_MODE_ARAM } from "./types";
-import { filterItemsByMode } from "./utils";
+import { filterItemsByMode, buildTeamComposition } from "./utils";
 
 export const aramMode: GameMode = {
   id: "aram",
@@ -68,13 +63,3 @@ export const aramMode: GameMode = {
     };
   },
 };
-
-function buildTeamComposition(players: PlayerModeContext[]): TeamComposition {
-  const classCounts: Record<string, number> = {};
-  for (const player of players) {
-    for (const tag of player.tags) {
-      classCounts[tag] = (classCounts[tag] ?? 0) + 1;
-    }
-  }
-  return { players, classCounts };
-}

--- a/src/lib/mode/aram.ts
+++ b/src/lib/mode/aram.ts
@@ -7,6 +7,7 @@
 
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
+import type { Augment } from "../data-ingest/types";
 import type { GameMode, ModeContext, PlayerModeContext } from "./types";
 import { GAME_MODE_ARAM } from "./types";
 import { filterItemsByMode, buildTeamComposition } from "./utils";
@@ -56,7 +57,7 @@ export const aramMode: GameMode = {
       mode: aramMode,
       playerContexts,
       modeItems: filterItemsByMode(gameData.items, "aram"),
-      modeAugments: new Map(), // No augments in straight ARAM
+      modeAugments: new Map<string, Augment>(),
       augmentSets: [], // No sets in straight ARAM
       allyTeamComp: buildTeamComposition(allyPlayers),
       enemyTeamComp: buildTeamComposition(enemyPlayers),

--- a/src/lib/mode/aram.ts
+++ b/src/lib/mode/aram.ts
@@ -1,3 +1,10 @@
+/**
+ * Straight ARAM mode — no augments, no sets, but has balance overrides.
+ *
+ * Matches the "ARAM" game mode string from the Live Client Data API.
+ * Distinct from ARAM Mayhem (KIWI) which adds augments and sets.
+ */
+
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
 import type {
@@ -6,22 +13,21 @@ import type {
   PlayerModeContext,
   TeamComposition,
 } from "./types";
-import { GAME_MODE_MAYHEM } from "./types";
-import { filterItemsByMode, filterAugmentsByMode } from "./utils";
+import { GAME_MODE_ARAM } from "./types";
+import { filterItemsByMode } from "./utils";
 
-export const aramMayhemMode: GameMode = {
-  id: "aram-mayhem",
-  displayName: "ARAM Mayhem",
-  decisionTypes: ["augment-selection", "item-purchase", "open-ended-coaching"],
-  augmentSelectionLevels: [1, 7, 11, 15],
+export const aramMode: GameMode = {
+  id: "aram",
+  displayName: "ARAM",
+  decisionTypes: ["item-purchase", "open-ended-coaching"],
+  augmentSelectionLevels: [],
 
   matches(gameMode: string): boolean {
-    return gameMode === GAME_MODE_MAYHEM;
+    return gameMode === GAME_MODE_ARAM;
   },
 
   buildContext(gameState: GameState, gameData: LoadedGameData): ModeContext {
     const activePlayer = gameState.players.find((p) => p.isActivePlayer);
-    // Default to ORDER if no active player (spectator/loading edge case)
     const activeTeam = activePlayer?.team ?? "ORDER";
 
     const playerContexts = new Map<string, PlayerModeContext>();
@@ -52,11 +58,11 @@ export const aramMayhemMode: GameMode = {
     }
 
     return {
-      mode: aramMayhemMode,
+      mode: aramMode,
       playerContexts,
       modeItems: filterItemsByMode(gameData.items, "aram"),
-      modeAugments: filterAugmentsByMode(gameData.augments, "mayhem"),
-      augmentSets: gameData.augmentSets,
+      modeAugments: new Map(), // No augments in straight ARAM
+      augmentSets: [], // No sets in straight ARAM
       allyTeamComp: buildTeamComposition(allyPlayers),
       enemyTeamComp: buildTeamComposition(enemyPlayers),
     };

--- a/src/lib/mode/classic.test.ts
+++ b/src/lib/mode/classic.test.ts
@@ -1,0 +1,208 @@
+import { describe, it, expect } from "vitest";
+import { classicMode } from "./classic";
+import type { GameState } from "../game-state/types";
+import type { LoadedGameData } from "../data-ingest";
+import type { Champion, Item } from "../data-ingest/types";
+
+function createGameState(overrides: Partial<GameState> = {}): GameState {
+  return {
+    status: "connected",
+    activePlayer: {
+      championName: "Ahri",
+      level: 10,
+      currentGold: 2500,
+      runes: {
+        keystone: "Electrocute",
+        primaryTree: "Domination",
+        secondaryTree: "Sorcery",
+      },
+      stats: {
+        abilityPower: 200,
+        armor: 60,
+        attackDamage: 80,
+        attackSpeed: 0.8,
+        abilityHaste: 30,
+        critChance: 0,
+        magicResist: 40,
+        moveSpeed: 350,
+        maxHealth: 1800,
+        currentHealth: 1500,
+      },
+    },
+    players: [
+      {
+        championName: "Ahri",
+        team: "ORDER",
+        level: 10,
+        kills: 5,
+        deaths: 2,
+        assists: 8,
+        items: [{ id: 3089, name: "Rabadon's Deathcap" }],
+        summonerSpells: ["Flash", "Ignite"],
+        riotIdGameName: "Player1",
+        position: "MIDDLE",
+        isActivePlayer: true,
+      },
+      {
+        championName: "Garen",
+        team: "CHAOS",
+        level: 9,
+        kills: 3,
+        deaths: 4,
+        assists: 6,
+        items: [{ id: 3075, name: "Thornmail" }],
+        summonerSpells: ["Flash", "Teleport"],
+        riotIdGameName: "Enemy1",
+        position: "TOP",
+        isActivePlayer: false,
+      },
+    ],
+    gameMode: "CLASSIC",
+    gameTime: 900,
+    ...overrides,
+  };
+}
+
+function createGameData(): LoadedGameData {
+  const champions = new Map<string, Champion>([
+    [
+      "ahri",
+      {
+        id: "Ahri",
+        key: 103,
+        name: "Ahri",
+        title: "the Nine-Tailed Fox",
+        tags: ["Mage", "Assassin"],
+        partype: "Mana",
+        stats: {} as Champion["stats"],
+        image: "",
+        aramOverrides: { dmgDealt: 1.0, dmgTaken: 0.95 },
+      },
+    ],
+    [
+      "garen",
+      {
+        id: "Garen",
+        key: 86,
+        name: "Garen",
+        title: "The Might of Demacia",
+        tags: ["Fighter", "Tank"],
+        partype: "None",
+        stats: {} as Champion["stats"],
+        image: "",
+        aramOverrides: { dmgDealt: 1.05, dmgTaken: 1.05 },
+      },
+    ],
+  ]);
+
+  const items = new Map<number, Item>([
+    [
+      3089,
+      {
+        id: 3089,
+        name: "Rabadon's Deathcap",
+        description: "AP",
+        plaintext: "",
+        gold: { base: 1100, total: 3600, sell: 2520, purchasable: true },
+        tags: [],
+        stats: {},
+        image: "",
+        mode: "standard",
+      },
+    ],
+    [
+      328001,
+      {
+        id: 328001,
+        name: "ARAM Boots",
+        description: "ARAM variant",
+        plaintext: "",
+        gold: { base: 300, total: 300, sell: 210, purchasable: true },
+        tags: [],
+        stats: {},
+        image: "",
+        mode: "aram",
+      },
+    ],
+  ]);
+
+  return {
+    version: "16.6.1",
+    champions,
+    items,
+    runes: [],
+    augments: new Map(),
+    augmentSets: [],
+    dictionary: {
+      allNames: [],
+      champions: [],
+      items: [],
+      augments: [],
+      search: () => [],
+      findInText: () => [],
+    },
+  };
+}
+
+describe("classicMode", () => {
+  it("has correct id and display name", () => {
+    expect(classicMode.id).toBe("classic");
+    expect(classicMode.displayName).toBe("Classic");
+  });
+
+  it("declares item-purchase and open-ended-coaching decision types only", () => {
+    expect(classicMode.decisionTypes).toContain("item-purchase");
+    expect(classicMode.decisionTypes).toContain("open-ended-coaching");
+    expect(classicMode.decisionTypes).not.toContain("augment-selection");
+  });
+
+  it("has no augment selection levels", () => {
+    expect(classicMode.augmentSelectionLevels).toEqual([]);
+  });
+
+  describe("matches", () => {
+    it("matches CLASSIC game mode", () => {
+      expect(classicMode.matches("CLASSIC")).toBe(true);
+    });
+
+    it("does not match ARAM or KIWI", () => {
+      expect(classicMode.matches("ARAM")).toBe(false);
+      expect(classicMode.matches("KIWI")).toBe(false);
+    });
+
+    it("does not match other game modes", () => {
+      expect(classicMode.matches("CHERRY")).toBe(false);
+      expect(classicMode.matches("")).toBe(false);
+    });
+  });
+
+  describe("buildContext", () => {
+    it("sets null balance overrides for all players", () => {
+      const ctx = classicMode.buildContext(createGameState(), createGameData());
+      for (const [, player] of ctx.playerContexts) {
+        expect(player.balanceOverrides).toBeNull();
+      }
+    });
+
+    it("returns empty augment maps", () => {
+      const ctx = classicMode.buildContext(createGameState(), createGameData());
+      expect(ctx.modeAugments.size).toBe(0);
+    });
+
+    it("returns empty augment sets", () => {
+      const ctx = classicMode.buildContext(createGameState(), createGameData());
+      expect(ctx.augmentSets).toEqual([]);
+    });
+
+    it("filters items to standard mode", () => {
+      const ctx = classicMode.buildContext(createGameState(), createGameData());
+      expect(ctx.modeItems.has(3089)).toBe(true);
+      expect(ctx.modeItems.has(328001)).toBe(false);
+    });
+
+    it("references itself as the mode", () => {
+      const ctx = classicMode.buildContext(createGameState(), createGameData());
+      expect(ctx.mode).toBe(classicMode);
+    });
+  });
+});

--- a/src/lib/mode/classic.ts
+++ b/src/lib/mode/classic.ts
@@ -6,14 +6,9 @@
 
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
-import type {
-  GameMode,
-  ModeContext,
-  PlayerModeContext,
-  TeamComposition,
-} from "./types";
+import type { GameMode, ModeContext, PlayerModeContext } from "./types";
 import { GAME_MODE_CLASSIC } from "./types";
-import { filterItemsByMode } from "./utils";
+import { filterItemsByMode, buildTeamComposition } from "./utils";
 
 export const classicMode: GameMode = {
   id: "classic",
@@ -67,13 +62,3 @@ export const classicMode: GameMode = {
     };
   },
 };
-
-function buildTeamComposition(players: PlayerModeContext[]): TeamComposition {
-  const classCounts: Record<string, number> = {};
-  for (const player of players) {
-    for (const tag of player.tags) {
-      classCounts[tag] = (classCounts[tag] ?? 0) + 1;
-    }
-  }
-  return { players, classCounts };
-}

--- a/src/lib/mode/classic.ts
+++ b/src/lib/mode/classic.ts
@@ -1,3 +1,9 @@
+/**
+ * Classic (Summoner's Rift) mode — items only, no augments, no balance overrides.
+ *
+ * Matches the "CLASSIC" game mode string from the Live Client Data API.
+ */
+
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
 import type {
@@ -6,22 +12,21 @@ import type {
   PlayerModeContext,
   TeamComposition,
 } from "./types";
-import { GAME_MODE_MAYHEM } from "./types";
-import { filterItemsByMode, filterAugmentsByMode } from "./utils";
+import { GAME_MODE_CLASSIC } from "./types";
+import { filterItemsByMode } from "./utils";
 
-export const aramMayhemMode: GameMode = {
-  id: "aram-mayhem",
-  displayName: "ARAM Mayhem",
-  decisionTypes: ["augment-selection", "item-purchase", "open-ended-coaching"],
-  augmentSelectionLevels: [1, 7, 11, 15],
+export const classicMode: GameMode = {
+  id: "classic",
+  displayName: "Classic",
+  decisionTypes: ["item-purchase", "open-ended-coaching"],
+  augmentSelectionLevels: [],
 
   matches(gameMode: string): boolean {
-    return gameMode === GAME_MODE_MAYHEM;
+    return gameMode === GAME_MODE_CLASSIC;
   },
 
   buildContext(gameState: GameState, gameData: LoadedGameData): ModeContext {
     const activePlayer = gameState.players.find((p) => p.isActivePlayer);
-    // Default to ORDER if no active player (spectator/loading edge case)
     const activeTeam = activePlayer?.team ?? "ORDER";
 
     const playerContexts = new Map<string, PlayerModeContext>();
@@ -37,7 +42,7 @@ export const aramMayhemMode: GameMode = {
         championName: player.championName,
         team: player.team,
         tags: champion?.tags ?? [],
-        balanceOverrides: champion?.aramOverrides ?? null,
+        balanceOverrides: null, // No balance overrides on Summoner's Rift
         selectedAugments: [],
         setProgress: [],
       };
@@ -52,11 +57,11 @@ export const aramMayhemMode: GameMode = {
     }
 
     return {
-      mode: aramMayhemMode,
+      mode: classicMode,
       playerContexts,
-      modeItems: filterItemsByMode(gameData.items, "aram"),
-      modeAugments: filterAugmentsByMode(gameData.augments, "mayhem"),
-      augmentSets: gameData.augmentSets,
+      modeItems: filterItemsByMode(gameData.items, "standard"),
+      modeAugments: new Map(),
+      augmentSets: [],
       allyTeamComp: buildTeamComposition(allyPlayers),
       enemyTeamComp: buildTeamComposition(enemyPlayers),
     };

--- a/src/lib/mode/classic.ts
+++ b/src/lib/mode/classic.ts
@@ -6,6 +6,7 @@
 
 import type { GameState } from "../game-state/types";
 import type { LoadedGameData } from "../data-ingest";
+import type { Augment } from "../data-ingest/types";
 import type { GameMode, ModeContext, PlayerModeContext } from "./types";
 import { GAME_MODE_CLASSIC } from "./types";
 import { filterItemsByMode, buildTeamComposition } from "./utils";
@@ -55,7 +56,7 @@ export const classicMode: GameMode = {
       mode: classicMode,
       playerContexts,
       modeItems: filterItemsByMode(gameData.items, "standard"),
-      modeAugments: new Map(),
+      modeAugments: new Map<string, Augment>(),
       augmentSets: [],
       allyTeamComp: buildTeamComposition(allyPlayers),
       enemyTeamComp: buildTeamComposition(enemyPlayers),

--- a/src/lib/mode/index.ts
+++ b/src/lib/mode/index.ts
@@ -9,9 +9,16 @@ export type {
   SetProgress,
   TeamComposition,
 } from "./types";
-export { GAME_MODE_MAYHEM, GAME_MODE_ARAM, GAME_MODE_ARENA } from "./types";
+export {
+  GAME_MODE_MAYHEM,
+  GAME_MODE_ARAM,
+  GAME_MODE_ARENA,
+  GAME_MODE_CLASSIC,
+} from "./types";
 export { createModeRegistry } from "./registry";
 export { aramMayhemMode } from "./aram-mayhem";
+export { aramMode } from "./aram";
+export { classicMode } from "./classic";
 export { buildEffectiveGameState } from "./effective-state";
 export { checkAugmentAvailability } from "./augment-availability";
 export type { AugmentAvailability } from "./augment-availability";

--- a/src/lib/mode/types.ts
+++ b/src/lib/mode/types.ts
@@ -17,12 +17,13 @@ import type {
  *
  * The `lcuGameMode` field in LiveGameState is set from the LCU WebSocket
  * session, while `gameMode` comes from the Live Client Data API. For Mayhem
- * games, both return "KIWI". The "ARAM" fallback in mode detection exists
- * for defensive compatibility in case Riot changes the string in a future patch.
+ * games, both return "KIWI". Straight ARAM returns "ARAM". Each has its own
+ * GameMode implementation — aramMayhemMode matches "KIWI", aramMode matches "ARAM".
  */
 export const GAME_MODE_MAYHEM = "KIWI";
 export const GAME_MODE_ARAM = "ARAM";
 export const GAME_MODE_ARENA = "CHERRY";
+export const GAME_MODE_CLASSIC = "CLASSIC";
 import type {
   ActivePlayerRunes,
   ActivePlayerStats,

--- a/src/lib/mode/utils.ts
+++ b/src/lib/mode/utils.ts
@@ -1,4 +1,5 @@
 import type { Augment, Item } from "../data-ingest/types";
+import type { PlayerModeContext, TeamComposition } from "./types";
 
 export function filterItemsByMode(
   items: Map<number, Item>,
@@ -20,4 +21,16 @@ export function filterAugmentsByMode(
     if (augment.mode === mode) filtered.set(key, augment);
   }
   return filtered;
+}
+
+export function buildTeamComposition(
+  players: PlayerModeContext[]
+): TeamComposition {
+  const classCounts: Record<string, number> = {};
+  for (const player of players) {
+    for (const tag of player.tags) {
+      classCounts[tag] = (classCounts[tag] ?? 0) + 1;
+    }
+  }
+  return { players, classCounts };
 }


### PR DESCRIPTION
## Summary

Closes #68

Converts the coaching pipeline from single-turn LLM calls (full context rebuilt every time, history pasted as text) to a real multi-turn conversation architecture with tiered context delivery.

- **Multi-turn conversation**: real `system` + `messages` array via Vercel AI SDK, not pasted history. The LLM sees its own prior responses as assistant messages.
- **Full state snapshots each turn**: every user message includes the complete game state, re-anchoring the LLM to ground truth (research shows LLMs degrade tracking accumulated diffs).
- **Mode-aware system prompt**: set once per game session with coaching rules, champion abilities, runes, team roster, and mode-specific rules. Uses `GameMode` interface throughout — no hardcoded mode strings.
- **Enemy stat computation**: approximate combat stats (AD, AP, armor, MR, HP, MS, AS) from base stats + per-level growth + item bonuses, computed reactively on every game state poll.
- **Three game modes**: ARAM Mayhem (existing, narrowed to KIWI), straight ARAM (balance overrides, no augments), Classic/Summoner's Rift (no overrides, no augments).
- **Context provider**: `CoachingProvider` provides mode and enemy stats via React context, eliminating prop drilling.
- **Eval validation**: multi-turn eval pipeline runs alongside existing single-turn evals using the same real functions (`buildGameSystemPrompt`, `formatStateSnapshot`, `createConversationSession`). 99% score, no regression.

## New modules

- `src/lib/ai/enemy-stats.ts` — pure stat calculator
- `src/lib/ai/enemy-stats-reactive.ts` — reactive stream wrapper
- `src/lib/ai/conversation-session.ts` — message array manager
- `src/lib/ai/state-formatter.ts` — game state snapshot formatter
- `src/lib/mode/aram.ts` — straight ARAM mode
- `src/lib/mode/classic.ts` — Classic/SR mode
- `src/hooks/useCoachingContext.tsx` — React context provider
- `scripts/convert-fixtures-multiturn.ts` — fixture conversion tool
- `fixtures/coaching-sessions-v2/` — raw format eval fixtures

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Session-based multi-turn coaching with persistent conversation context, proactive coaching behavior, enhanced mode-driven guidance (Classic & ARAM).
  * Improved enemy stat estimation and richer live-game snapshots for more accurate advice.

* **Tests**
  * Expanded test coverage for multi-turn sessions, enemy stat calculations, state formatting, and mode logic.

* **Documentation**
  * Added a design document detailing the multi-turn conversation pattern and message formatting.

* **Chores**
  * Added fixture conversion tooling, many new coaching-session fixtures, and a helper npm script.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->