### PR TITLE
Add multi-turn eval scorers for state awareness, pivot explanation, and gold-aware recommendations

### DIFF
--- a/docs/gold-aware-item-recommendations.md
+++ b/docs/gold-aware-item-recommendations.md
@@ -1,0 +1,29 @@
+# Gold-Aware Item Recommendations
+
+## Problem
+
+The coaching LLM's item recommendations have oscillated between three failure modes: hedging about gold ("if you can afford it"), recommending only components without naming the destination item, and sometimes ignoring gold entirely to suggest unaffordable items or unrelated alternatives.
+
+## Core Rule
+
+Every item recommendation — whether reactive (player asked) or proactive (LLM flagged a gap) — follows the same format:
+
+**Destination item first, then the actionable component.**
+
+- **Can afford a component:** "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now."
+- **Can't afford any component:** "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g."
+- **Multiple components, partial affordability:** Name the most expensive component the player can currently afford.
+- **Non-item questions that mention items** (e.g., "how do I deal with Katarina"): Just name the completed item. No component breakdown needed.
+
+## Key Decisions
+
+- Destination item always leads — it's the strategic decision
+- Component is the tactical detail, gated by current gold
+- Use the target gold threshold ("at 1250g"), not the gap ("in 150g")
+- Never recommend unrelated "filler" items just because the player can afford them
+- Never hedge with "if you can afford" — the app knows the player's gold
+- Same format for proactive and reactive recommendations
+
+## Prompt Changes Needed
+
+Update the ITEM RECOMMENDATIONS instruction in the system prompt to reflect the format and rules above, replacing the current example.

--- a/docs/plans/2026-04-05-eval-scorers-design.md
+++ b/docs/plans/2026-04-05-eval-scorers-design.md
@@ -1,0 +1,87 @@
+# Eval Scorers for Multi-Turn Conversation — Design
+
+Issue: #83
+
+## Scope
+
+### In scope
+
+1. **State Awareness (gate scorer)** — does the response reference
+   relevant game state information?
+   - Heavy healing on enemy team → mention grievous wounds
+   - 3+ AP enemies → mention MR or acknowledge AP-heavy comp
+   - Enemy team comp acknowledged in item recommendations
+   - Player's existing items referenced in reasoning
+   - Rules hardcoded in scorer. Fixture `scorerHints` declares which
+     rules apply per fixture.
+   - ~4-6 synthetic fixtures with item-related questions.
+
+2. **Pivot Explanation (ranking scorer)** — when the LLM changes its
+   recommendation from a prior turn, does it explain why?
+   - Pivot detection: rule-based, comparing current recommendations
+     against prior turn. Fixture `scorerHints` flags expected pivots
+     and prior recommendations.
+   - Explanation check: pattern-based, looking for causal language
+     ("because," "since," "now that," etc.) or references to game
+     state changes.
+   - Scoring: no pivot → 1.0, pivot + explanation → 1.0, pivot +
+     no explanation → 0.0, pivot expected but not detected → 0.5.
+   - ~3 synthetic fixtures: explained pivot, unexplained pivot,
+     consistent recommendation.
+
+3. **Gold-Aware Recommendations (gate scorer)** — does the item
+   recommendation follow the destination + component format?
+   - Response names a completed (destination) item.
+   - Response names a buildable component.
+   - If player can afford a component, mentions one they can afford.
+     If not, names the cheapest component with the gold threshold.
+   - No filler items recommended just to spend gold.
+   - ~4 synthetic fixtures: can afford, can't afford, multi-part
+     build path, non-item question (should not trigger).
+   - **Prompt change:** update ITEM RECOMMENDATIONS instruction in
+     `buildSystemPrompt()` and `buildGameSystemPrompt()` to match
+     the format in `docs/gold-aware-item-recommendations.md`.
+
+4. **Augment Re-Roll Accuracy — multi-turn fixtures**
+   - No scorer logic changes. Add fixtures testing cross-round
+     re-roll tracking.
+   - ~3 fixtures: round 1→2 tracking, "re-roll all" edge case,
+     player-ignored-advice scenario.
+
+5. **Conversational Continuity — multi-turn fixtures**
+   - No scorer logic changes. Add multi-turn fixtures to the
+     existing `synthetic-continuity.json`.
+   - ~3-4 fixtures covering self-consistency and augment history.
+
+### Deferred
+
+- **Proactive Concern Flagging** — deferred because proactive coaching
+  triggers (when/how the system surfaces concerns unprompted) aren't
+  designed yet. Building a scorer now would test a system that doesn't
+  exist, and the fixtures would be speculative. Pick this up when
+  proactive coaching has a real trigger mechanism.
+
+- **Build Coherence** — deferred because reliable automated scoring
+  requires domain knowledge about augment/item/stat anvil synergies,
+  especially in ARAM Mayhem where unconventional builds are a feature,
+  not a bug. An LLM-as-judge would false-negative on creative-but-
+  correct pivots. Revisit when we have better tooling or a curated
+  set of "known good/bad" build trajectories to calibrate against.
+
+## Architecture
+
+- All scorers in `src/lib/ai/scorers/`, following existing
+  `createScorer<EvalInput, EvalOutput>` pattern.
+- Gate scorers (State Awareness, Gold-Aware) added to `GATE_SCORERS`.
+- Ranking scorers (Pivot Explanation) added to `RANKING_SCORERS`.
+- New multi-turn fixtures in
+  `fixtures/coaching-sessions-v2/synthetic-multiturn-scorers.json`.
+- Updated continuity fixtures in existing
+  `fixtures/coaching-sessions-v2/synthetic-continuity.json`.
+- Fixture schema extended with optional `scorerHints` field carrying
+  per-fixture metadata for scorers.
+
+## Related
+
+- Gold-aware recommendation format: `docs/gold-aware-item-recommendations.md`
+- Creative ARAM Mayhem builds: #88

--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -557,6 +557,14 @@ The AI module (`src/lib/ai/`) uses Vercel AI SDK v6 with OpenAI's GPT-5.4 Mini f
 
 GPT-5.4 Mini was selected via PickAI discovery (see `scripts/discover-candidates.ts`). Selected for cost/speed balance suitable for real-time coaching during gameplay.
 
+### Eval pipeline — OpenRouter support
+
+The eval pipeline (`src/lib/ai/coaching.eval.ts`) supports both OpenAI direct and OpenRouter as providers. Key details:
+
+- **Env vars:** `VITE_OPENAI_API_KEY` / `OPENAI_API_KEY` for OpenAI direct, `VITE_OPENROUTER_API_KEY` / `OPENROUTER_API_KEY` for OpenRouter. At least one must be set.
+- **API compatibility:** AI SDK 5 (`@ai-sdk/openai` v3+) defaults to the OpenAI Responses API, which OpenRouter doesn't support. Use `.chat()` (e.g., `openrouter.chat(modelId)`) to force the Chat Completions API when routing through OpenRouter.
+- **Model IDs:** OpenRouter requires the `provider/model` format (e.g., `openai/gpt-5.4-mini`), while OpenAI direct uses just the model name (e.g., `gpt-5.4-mini`).
+
 ### Eval scorer patterns
 
 - **Gate scorers** return 0 or 1 (pass/fail). Used for non-negotiable requirements (item awareness, structured output, augment re-roll mechanics, state awareness, gold-aware format).

--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -556,3 +556,13 @@ The AI module (`src/lib/ai/`) uses Vercel AI SDK v6 with OpenAI's GPT-5.4 Mini f
 ### Model selection
 
 GPT-5.4 Mini was selected via PickAI discovery (see `scripts/discover-candidates.ts`). Selected for cost/speed balance suitable for real-time coaching during gameplay.
+
+### Eval scorer patterns
+
+- **Gate scorers** return 0 or 1 (pass/fail). Used for non-negotiable requirements (item awareness, structured output, augment re-roll mechanics, state awareness, gold-aware format).
+- **Ranking scorers** return 0-1 on a scale. Used for quality metrics (brevity, decisiveness, continuity, gold awareness, pivot explanation).
+- **`scorerHints`** — per-fixture metadata that tells scorers what to check. Added to `MultiTurnFixture` and `EvalInput`. Prevents false positives by only checking rules relevant to each fixture's scenario.
+- **State Awareness** scorer checks for keyword presence (GW items, MR items, enemy champion names, damage profile terms, owned items). All declared rules must pass for score=1.
+- **Pivot Explanation** scorer uses a hybrid approach: rule-based pivot detection (does the response still mention the prior recommendation?) + pattern matching for causal language (because, since, now that, etc.). When the prior item is mentioned alongside causal language, it's treated as a dismissal rather than a recommendation.
+- **Gold-Aware Recommendations** scorer checks format compliance (destination + component pattern), not item correctness. Uses regex for "build toward" and component verb patterns. Returns 1 if neither pattern matches (response may not be an item recommendation).
+- **Item recommendation format** in system prompt: "Build toward [destination]. You can get a [component] now/at [gold]g." Destination item always leads. Name the most expensive affordable component.

--- a/fixtures/coaching-sessions-v2/synthetic-continuity.json
+++ b/fixtures/coaching-sessions-v2/synthetic-continuity.json
@@ -1114,7 +1114,7 @@
         },
         {
           "question": "What about Thornmail?",
-          "answer": "Yes, build Thornmail. They have lots of healing with Soraka."
+          "answer": "Yes, build Thornmail. They have lots of healing with Viego's passive."
         },
         {
           "question": "Scopier Weapons, Goredrink, or Blunt Force?",
@@ -1134,7 +1134,7 @@
       "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
       "gold": 800,
       "champion": "Warwick",
-      "gameTime": "14:00"
+      "gameTime": "12:00"
     }
   },
   {
@@ -1385,7 +1385,7 @@
     "expectedReferences": ["Overflow", "healing", "sustain"],
     "scorerContext": {
       "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
-      "gold": 1200,
+      "gold": 800,
       "champion": "Warwick",
       "gameTime": "12:00"
     }
@@ -1624,7 +1624,7 @@
         },
         {
           "question": "What item should I build next?",
-          "answer": "Build Thornmail. They have Soraka and Aatrox \u2014 you need anti-heal."
+          "answer": "Build Thornmail. Viego has strong sustain \u2014 you need anti-heal."
         },
         {
           "question": "Recursion, Overflow, or Bread and Cheese?",
@@ -1654,9 +1654,9 @@
     "expectedReferences": ["tank", "Thornmail", "Outlaw"],
     "scorerContext": {
       "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
-      "gold": 900,
+      "gold": 800,
       "champion": "Warwick",
-      "gameTime": "13:00"
+      "gameTime": "12:00"
     }
   }
 ]

--- a/fixtures/coaching-sessions-v2/synthetic-continuity.json
+++ b/fixtures/coaching-sessions-v2/synthetic-continuity.json
@@ -875,5 +875,788 @@
       "champion": "Warwick",
       "gameTime": "16:00"
     }
+  },
+  {
+    "label": "SYNTHETIC: Self-consistency check after 5 exchanges",
+    "index": 3,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 720
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Overflow"],
+    "query": {
+      "question": "Should I still be building tank items?",
+      "history": [
+        {
+          "question": "What should I build?",
+          "answer": "Go full tank. Sunfire Aegis into Spirit Visage."
+        },
+        {
+          "question": "Recursion, Overflow, or Bread and Cheese?",
+          "answer": "Take Overflow. Healing synergizes with tank sustain."
+        },
+        {
+          "question": "What about Thornmail?",
+          "answer": "Yes, build Thornmail. They have lots of healing with Soraka."
+        },
+        {
+          "question": "Scopier Weapons, Goredrink, or Blunt Force?",
+          "answer": "Goredrink. 15% omnivamp is great on tank Warwick."
+        },
+        {
+          "question": "Am I doing enough damage?",
+          "answer": "Your damage is fine. Tank Warwick wins through sustain, not burst."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["tank", "Sunfire", "sustain"],
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 800,
+      "champion": "Warwick",
+      "gameTime": "14:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Augment history reference \u2014 why did you recommend Overflow?",
+    "index": 4,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 720
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Overflow"],
+    "query": {
+      "question": "You told me to take Overflow earlier. Why was that the right choice?",
+      "history": [
+        {
+          "question": "Pinball, Outlaw's Grit, or Big Brain?",
+          "answer": "Take Outlaw's Grit. Free resists on dashes for tank builds."
+        },
+        {
+          "question": "Recursion, Overflow, or Bread and Cheese?",
+          "answer": "Take Overflow. The healing amp synergizes with your tank sustain."
+        },
+        {
+          "question": "What item should I build?",
+          "answer": "Build Sunfire Aegis for armor into their AD-heavy comp."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["Overflow", "healing", "sustain"],
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 1200,
+      "champion": "Warwick",
+      "gameTime": "12:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Cross-topic consistency \u2014 augment choice references prior item advice",
+    "index": 5,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 11,
+        "currentGold": 800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 72,
+          "magicResist": 50,
+          "maxHealth": 1489,
+          "currentHealth": 1489,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            {
+              "id": 223111,
+              "name": "Mercury's Treads"
+            },
+            {
+              "id": 223748,
+              "name": "Titanic Hydra"
+            },
+            {
+              "id": 223068,
+              "name": "Sunfire Aegis"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Twitch",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Akshan",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aurora",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Kalista",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 226655,
+              "name": "Luden's Echo"
+            },
+            {
+              "id": 223020,
+              "name": "Sorcerer's Shoes"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223100,
+              "name": "Lich Bane"
+            },
+            {
+              "id": 223089,
+              "name": "Rabadon's Deathcap"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Viego",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 223031,
+              "name": "Infinity Edge"
+            },
+            {
+              "id": 3123,
+              "name": "Executioner's Calling"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 226696,
+              "name": "Axiom Arc"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 0,
+          "assists": 0,
+          "items": [
+            {
+              "id": 667666,
+              "name": "The Collector"
+            },
+            {
+              "id": 223006,
+              "name": "Berserker's Greaves"
+            }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 720
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Overflow"],
+    "query": {
+      "question": "I'm being offered these augments: Juiced, Scopier Weapons, Heartsteel Augment. Which should I pick?",
+      "history": [
+        {
+          "question": "Pinball, Outlaw's Grit, or Big Brain?",
+          "answer": "Take Outlaw's Grit. Free resists on dashes for tank builds."
+        },
+        {
+          "question": "What item should I build next?",
+          "answer": "Build Thornmail. They have Soraka and Aatrox \u2014 you need anti-heal."
+        },
+        {
+          "question": "Recursion, Overflow, or Bread and Cheese?",
+          "answer": "Take Overflow. Healing amp synergizes with your tank sustain and Thornmail's passive."
+        }
+      ],
+      "augmentOptions": [
+        {
+          "name": "Juiced",
+          "description": "Gain 25% attack speed.",
+          "tier": "Silver"
+        },
+        {
+          "name": "Scopier Weapons",
+          "description": "Gain 15% bonus attack range.",
+          "tier": "Silver"
+        },
+        {
+          "name": "Heartsteel Augment",
+          "description": "Gain Heartsteel's passive: charge up health on hit.",
+          "tier": "Gold"
+        }
+      ]
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["tank", "Thornmail", "Outlaw"],
+    "scorerContext": {
+      "items": ["Mercury's Treads", "Titanic Hydra", "Sunfire Aegis"],
+      "gold": 900,
+      "champion": "Warwick",
+      "gameTime": "13:00"
+    }
   }
 ]

--- a/fixtures/coaching-sessions-v2/synthetic-multiturn-scorers.json
+++ b/fixtures/coaching-sessions-v2/synthetic-multiturn-scorers.json
@@ -1,0 +1,3108 @@
+[
+  {
+    "label": "SYNTHETIC: State awareness — heavy healing enemy comp needs grievous wounds",
+    "index": 0,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 10,
+        "currentGold": 1500,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 72,
+          "abilityPower": 0,
+          "armor": 68,
+          "magicResist": 48,
+          "maxHealth": 1450,
+          "currentHealth": 1450,
+          "moveSpeed": 335,
+          "attackSpeed": 1.15,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 223153, "name": "Blade of the Ruined King" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 5,
+          "deaths": 2,
+          "assists": 3,
+          "items": [
+            { "id": 223031, "name": "Infinity Edge" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Soraka",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 1,
+          "deaths": 2,
+          "assists": 12,
+          "items": [
+            { "id": 226620, "name": "Moonstone Renewer" },
+            { "id": 223158, "name": "Redemption" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Yuumi",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 0,
+          "deaths": 1,
+          "assists": 14,
+          "items": [
+            { "id": 223504, "name": "Staff of Flowing Water" },
+            { "id": 223114, "name": "Forbidden Idol" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jhin",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            { "id": 223190, "name": "Locket of the Iron Solari" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 600
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Blade Waltz"],
+    "query": {
+      "question": "What item should I buy next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["grievous wounds", "anti-heal"],
+    "scorerHints": { "stateAwareness": ["grievous-wounds"] },
+    "scorerContext": {
+      "items": ["Blade of the Ruined King", "Berserker's Greaves"],
+      "gold": 1500,
+      "champion": "Warwick",
+      "gameTime": "10:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: State awareness — 3+ AP enemies need MR",
+    "index": 1,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Ashe",
+        "level": 11,
+        "currentGold": 2000,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 78,
+          "abilityPower": 0,
+          "armor": 55,
+          "magicResist": 38,
+          "maxHealth": 1280,
+          "currentHealth": 1280,
+          "moveSpeed": 325,
+          "attackSpeed": 1.2,
+          "abilityHaste": 0,
+          "critChance": 0.2
+        }
+      },
+      "players": [
+        {
+          "championName": "Ashe",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Leona",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 10,
+          "items": [
+            { "id": 223190, "name": "Locket of the Iron Solari" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ezreal",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223158, "name": "Manamune" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 12,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 7,
+          "deaths": 2,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" },
+            { "id": 223089, "name": "Rabadon's Deathcap" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Brand",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 8,
+          "items": [
+            { "id": 223116, "name": "Liandry's Torment" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 4,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 9,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 660
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Slow and Steady"],
+    "query": {
+      "question": "What should I build next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["magic resist", "MR"],
+    "scorerHints": { "stateAwareness": ["mr-needed"] },
+    "scorerContext": {
+      "items": ["Kraken Slayer", "Berserker's Greaves"],
+      "gold": 2000,
+      "champion": "Ashe",
+      "gameTime": "11:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: State awareness — enemy comp + existing items",
+    "index": 2,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Jinx",
+        "level": 12,
+        "currentGold": 1800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 95,
+          "abilityPower": 0,
+          "armor": 52,
+          "magicResist": 36,
+          "maxHealth": 1350,
+          "currentHealth": 1350,
+          "moveSpeed": 325,
+          "attackSpeed": 1.3,
+          "abilityHaste": 0,
+          "critChance": 0.6
+        }
+      },
+      "players": [
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 7,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 223031, "name": "Infinity Edge" },
+            { "id": 223006, "name": "Berserker's Greaves" },
+            { "id": 223046, "name": "Phantom Dancer" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Morgana",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 9,
+          "items": [
+            { "id": 223157, "name": "Zhonya's Hourglass" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 10,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Karma",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 11,
+          "items": [
+            { "id": 226620, "name": "Moonstone Renewer" },
+            { "id": 223504, "name": "Staff of Flowing Water" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Varus",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 6,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 8,
+          "deaths": 2,
+          "assists": 4,
+          "items": [
+            { "id": 226692, "name": "Eclipse" },
+            { "id": 223142, "name": "Youmuu's Ghostblade" },
+            { "id": 223158, "name": "Ionian Boots of Lucidity" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Talon",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 226692, "name": "Eclipse" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 3,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lulu",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 13,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 7,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "ARAM",
+      "gameTime": 720
+    },
+    "gameModeId": "aram",
+    "chosenAugments": [],
+    "query": {
+      "question": "What item do I need?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["armor", "AD"],
+    "scorerHints": { "stateAwareness": ["enemy-comp", "existing-items"] },
+    "scorerContext": {
+      "items": ["Infinity Edge", "Berserker's Greaves", "Phantom Dancer"],
+      "gold": 1800,
+      "champion": "Jinx",
+      "gameTime": "12:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: State awareness — combo healing + AP enemies",
+    "index": 3,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Maokai",
+        "level": 11,
+        "currentGold": 1200,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 55,
+          "abilityPower": 0,
+          "armor": 82,
+          "magicResist": 52,
+          "maxHealth": 1700,
+          "currentHealth": 1700,
+          "moveSpeed": 335,
+          "attackSpeed": 0.7,
+          "abilityHaste": 20,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 12,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223111, "name": "Mercury's Treads" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Janna",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 5,
+          "assists": 14,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Yasuo",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 3,
+          "items": [
+            { "id": 223031, "name": "Infinity Edge" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Soraka",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 15,
+          "items": [
+            { "id": 226620, "name": "Moonstone Renewer" },
+            { "id": 223158, "name": "Redemption" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 7,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" },
+            { "id": 223089, "name": "Rabadon's Deathcap" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Aatrox",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 226631, "name": "Goredrinker" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 2,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 660
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Juggernaut"],
+    "query": {
+      "question": "What should I buy?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["grievous wounds", "magic resist"],
+    "scorerHints": { "stateAwareness": ["grievous-wounds", "mr-needed"] },
+    "scorerContext": {
+      "items": ["Sunfire Aegis", "Mercury's Treads"],
+      "gold": 1200,
+      "champion": "Maokai",
+      "gameTime": "11:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: State awareness control — non-item question, no scorer hints",
+    "index": 4,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Ahri",
+        "level": 12,
+        "currentGold": 2000,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 53,
+          "abilityPower": 250,
+          "armor": 48,
+          "magicResist": 38,
+          "maxHealth": 1250,
+          "currentHealth": 1250,
+          "moveSpeed": 330,
+          "attackSpeed": 0.668,
+          "abilityHaste": 20,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 8,
+          "items": [
+            { "id": 223089, "name": "Rabadon's Deathcap" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 6,
+          "items": [
+            { "id": 223031, "name": "Infinity Edge" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 12,
+          "items": [
+            { "id": 223190, "name": "Locket of the Iron Solari" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Varus",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sett",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 8,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 7,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 226692, "name": "Eclipse" },
+            { "id": 223142, "name": "Youmuu's Ghostblade" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 10,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lux",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 8,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "ARAM",
+      "gameTime": 720
+    },
+    "gameModeId": "aram",
+    "chosenAugments": [],
+    "query": {
+      "question": "How should I position in teamfights?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "scorerContext": {
+      "items": ["Rabadon's Deathcap", "Sorcerer's Shoes"],
+      "gold": 2000,
+      "champion": "Ahri",
+      "gameTime": "12:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Pivot expected — enemy comp changed from AD to AP, Thornmail no longer ideal",
+    "index": 5,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Garen",
+        "level": 13,
+        "currentGold": 2500,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 75,
+          "abilityPower": 0,
+          "armor": 90,
+          "magicResist": 50,
+          "maxHealth": 1900,
+          "currentHealth": 1900,
+          "moveSpeed": 340,
+          "attackSpeed": 0.75,
+          "abilityHaste": 15,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 4,
+          "deaths": 5,
+          "assists": 8,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223111, "name": "Mercury's Treads" },
+            { "id": 223143, "name": "Randuin's Omen" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Ezreal",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 6,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223158, "name": "Manamune" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 3,
+          "deaths": 5,
+          "assists": 9,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 0,
+          "deaths": 6,
+          "assists": 15,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jhin",
+          "team": "ORDER",
+          "level": 13,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 6,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223094, "name": "Rapid Firecannon" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 14,
+          "kills": 8,
+          "deaths": 3,
+          "assists": 7,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223089, "name": "Rabadon's Deathcap" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 8,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" },
+            { "id": 224646, "name": "Stormsurge" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Brand",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 6,
+          "deaths": 5,
+          "assists": 9,
+          "items": [
+            { "id": 223116, "name": "Liandry's Torment" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 12,
+          "items": [
+            { "id": 223190, "name": "Locket of the Iron Solari" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 10,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 840
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Outlaw's Grit", "Holy Fire"],
+    "query": {
+      "question": "Same build?",
+      "history": [
+        {
+          "question": "What should I build next?",
+          "answer": "Build Thornmail. The enemy team has a lot of AD damage and healing from Aatrox and Draven's lifesteal."
+        },
+        {
+          "question": "Still going Thornmail?",
+          "answer": "Yes, Thornmail is still your best option against this AD-heavy healing comp."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["Thornmail", "MR", "magic resist"],
+    "scorerHints": {
+      "pivotExpected": true,
+      "priorRecommendation": "Thornmail"
+    },
+    "scorerContext": {
+      "items": ["Sunfire Aegis", "Mercury's Treads", "Randuin's Omen"],
+      "gold": 2500,
+      "champion": "Garen",
+      "gameTime": "14:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: No pivot expected — enemy comp unchanged, prior recommendation still valid",
+    "index": 6,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Jinx",
+        "level": 11,
+        "currentGold": 1200,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 82,
+          "abilityPower": 0,
+          "armor": 50,
+          "magicResist": 36,
+          "maxHealth": 1300,
+          "currentHealth": 1300,
+          "moveSpeed": 325,
+          "attackSpeed": 1.15,
+          "abilityHaste": 0,
+          "critChance": 0.2
+        }
+      },
+      "players": [
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 4,
+          "deaths": 5,
+          "assists": 6,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 10,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223111, "name": "Mercury's Treads" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Morgana",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 8,
+          "items": [
+            { "id": 223157, "name": "Zhonya's Hourglass" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 0,
+          "deaths": 5,
+          "assists": 13,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 7,
+          "deaths": 2,
+          "assists": 6,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223089, "name": "Rabadon's Deathcap" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 5,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Brand",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 8,
+          "items": [
+            { "id": 223116, "name": "Liandry's Torment" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 10,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "ARAM",
+      "gameTime": 660
+    },
+    "gameModeId": "aram",
+    "chosenAugments": [],
+    "query": {
+      "question": "Still building Spirit Visage?",
+      "history": [
+        {
+          "question": "What should I build for defense?",
+          "answer": "Build Spirit Visage. The enemy has 3 AP threats (Syndra, Vex, Brand) and you need MR badly."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["Spirit Visage", "MR"],
+    "scorerHints": {
+      "pivotExpected": false,
+      "priorRecommendation": "Spirit Visage"
+    },
+    "scorerContext": {
+      "items": ["Kraken Slayer", "Berserker's Greaves"],
+      "gold": 1200,
+      "champion": "Jinx",
+      "gameTime": "11:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Pivot from augment-driven build change — Goliath augment shifts build path",
+    "index": 7,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Vayne",
+        "level": 12,
+        "currentGold": 3000,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 85,
+          "abilityPower": 0,
+          "armor": 50,
+          "magicResist": 36,
+          "maxHealth": 1350,
+          "currentHealth": 1350,
+          "moveSpeed": 330,
+          "attackSpeed": 1.25,
+          "abilityHaste": 0,
+          "critChance": 0.2
+        }
+      },
+      "players": [
+        {
+          "championName": "Vayne",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" },
+            { "id": 223046, "name": "Phantom Dancer" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 10,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Brand",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 7,
+          "items": [
+            { "id": 223116, "name": "Liandry's Torment" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 11,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 12,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223111, "name": "Mercury's Treads" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jhin",
+          "team": "ORDER",
+          "level": 12,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 13,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" },
+            { "id": 223053, "name": "Sterak's Gage" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 6,
+          "deaths": 4,
+          "assists": 3,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lulu",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 14,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Malphite",
+          "team": "CHAOS",
+          "level": 12,
+          "kills": 2,
+          "deaths": 5,
+          "assists": 8,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223047, "name": "Plated Steelcaps" },
+            { "id": 223143, "name": "Randuin's Omen" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 780
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Slow and Steady", "Goliath"],
+    "query": {
+      "question": "What now?",
+      "history": [
+        {
+          "question": "What should I build after Phantom Dancer?",
+          "answer": "Build Infinity Edge next. You need the crit damage spike to shred through their tanky frontline."
+        },
+        {
+          "question": "Goliath, Bread and Cheese, or Flashy?",
+          "answer": "Take Goliath. The bonus health and size will give you survivability you desperately need as Vayne."
+        }
+      ],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "expectedReferences": ["Infinity Edge", "Goliath", "health"],
+    "scorerHints": {
+      "pivotExpected": true,
+      "priorRecommendation": "Infinity Edge"
+    },
+    "scorerContext": {
+      "items": ["Kraken Slayer", "Berserker's Greaves", "Phantom Dancer"],
+      "gold": 3000,
+      "champion": "Vayne",
+      "gameTime": "13:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Gold-aware — can afford NLR component",
+    "index": 8,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Lux",
+        "level": 9,
+        "currentGold": 1500,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 46,
+          "abilityPower": 40,
+          "armor": 42,
+          "magicResist": 34,
+          "maxHealth": 1050,
+          "currentHealth": 1050,
+          "moveSpeed": 330,
+          "attackSpeed": 0.625,
+          "abilityHaste": 10,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 6,
+          "items": [{ "id": 223020, "name": "Sorcerer's Shoes" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 9,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Varus",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Zed",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 6,
+          "deaths": 2,
+          "assists": 4,
+          "items": [
+            { "id": 226692, "name": "Eclipse" },
+            { "id": 223142, "name": "Youmuu's Ghostblade" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 9,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "ARAM",
+      "gameTime": 540
+    },
+    "gameModeId": "aram",
+    "chosenAugments": [],
+    "query": {
+      "question": "What item should I buy?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "scorerHints": { "goldAware": true },
+    "scorerContext": {
+      "items": ["Sorcerer's Shoes"],
+      "gold": 1500,
+      "champion": "Lux",
+      "gameTime": "9:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Gold-aware — can't afford any component",
+    "index": 9,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Lux",
+        "level": 7,
+        "currentGold": 200,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 43,
+          "abilityPower": 30,
+          "armor": 38,
+          "magicResist": 32,
+          "maxHealth": 950,
+          "currentHealth": 950,
+          "moveSpeed": 330,
+          "attackSpeed": 0.625,
+          "abilityHaste": 10,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 3,
+          "items": [{ "id": 223020, "name": "Sorcerer's Shoes" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Caitlyn",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 2,
+          "items": [
+            { "id": 223006, "name": "Berserker's Greaves" },
+            { "id": 223085, "name": "Runaan's Hurricane" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 5,
+          "assists": 6,
+          "items": [{ "id": 223068, "name": "Sunfire Aegis" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 5,
+          "items": [{ "id": 223114, "name": "Forbidden Idol" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 3,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 5,
+          "deaths": 1,
+          "assists": 4,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 6,
+          "deaths": 2,
+          "assists": 2,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 4,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "ARAM",
+      "gameTime": 420
+    },
+    "gameModeId": "aram",
+    "chosenAugments": [],
+    "query": {
+      "question": "What should I build next?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "scorerHints": { "goldAware": true },
+    "scorerContext": {
+      "items": ["Sorcerer's Shoes"],
+      "gold": 200,
+      "champion": "Lux",
+      "gameTime": "7:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Gold-aware — multi-component build path, can only afford cheapest",
+    "index": 10,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Caitlyn",
+        "level": 8,
+        "currentGold": 700,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 72,
+          "abilityPower": 0,
+          "armor": 48,
+          "magicResist": 34,
+          "maxHealth": 1100,
+          "currentHealth": 1100,
+          "moveSpeed": 325,
+          "attackSpeed": 1.0,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Caitlyn",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 3,
+          "deaths": 2,
+          "assists": 4,
+          "items": [{ "id": 223006, "name": "Berserker's Greaves" }],
+          "summonerSpells": ["Flash", "Heal"],
+          "riotIdGameName": "Player1",
+          "position": "BOTTOM",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 3,
+          "assists": 7,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Ally1",
+          "position": "UTILITY",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 4,
+          "deaths": 2,
+          "assists": 3,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Ally2",
+          "position": "MIDDLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lee Sin",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 226631, "name": "Goredrinker" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Smite"],
+          "riotIdGameName": "Ally3",
+          "position": "JUNGLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Teleport"],
+          "riotIdGameName": "Ally4",
+          "position": "TOP",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 4,
+          "deaths": 2,
+          "assists": 3,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Teleport"],
+          "riotIdGameName": "Enemy1",
+          "position": "TOP",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vi",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 5,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Smite"],
+          "riotIdGameName": "Enemy2",
+          "position": "JUNGLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 3,
+          "deaths": 2,
+          "assists": 4,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Enemy3",
+          "position": "MIDDLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 5,
+          "deaths": 2,
+          "assists": 2,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Heal"],
+          "riotIdGameName": "Enemy4",
+          "position": "BOTTOM",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Enemy5",
+          "position": "UTILITY",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "CLASSIC",
+      "gameTime": 900
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "What item should I buy?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "scorerHints": { "goldAware": true },
+    "scorerContext": {
+      "items": ["Berserker's Greaves"],
+      "gold": 700,
+      "champion": "Caitlyn",
+      "gameTime": "15:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Gold-aware control — non-item question, no gold hint",
+    "index": 11,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "common",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Zed",
+        "level": 10,
+        "currentGold": 2000,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 95,
+          "abilityPower": 0,
+          "armor": 55,
+          "magicResist": 38,
+          "maxHealth": 1200,
+          "currentHealth": 1200,
+          "moveSpeed": 345,
+          "attackSpeed": 0.75,
+          "abilityHaste": 15,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Zed",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 7,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 226692, "name": "Eclipse" },
+            { "id": 223142, "name": "Youmuu's Ghostblade" },
+            { "id": 223158, "name": "Ionian Boots of Lucidity" }
+          ],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Player1",
+          "position": "MIDDLE",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 3,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Teleport"],
+          "riotIdGameName": "Ally1",
+          "position": "TOP",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lee Sin",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 6,
+          "items": [
+            { "id": 226631, "name": "Goredrinker" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Smite"],
+          "riotIdGameName": "Ally2",
+          "position": "JUNGLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Heal"],
+          "riotIdGameName": "Ally3",
+          "position": "BOTTOM",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 10,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Ally4",
+          "position": "UTILITY",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Teleport"],
+          "riotIdGameName": "Enemy1",
+          "position": "TOP",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vi",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 6,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Smite"],
+          "riotIdGameName": "Enemy2",
+          "position": "JUNGLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Enemy3",
+          "position": "MIDDLE",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Miss Fortune",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Heal"],
+          "riotIdGameName": "Enemy4",
+          "position": "BOTTOM",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lulu",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 12,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Ignite"],
+          "riotIdGameName": "Enemy5",
+          "position": "UTILITY",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "CLASSIC",
+      "gameTime": 1200
+    },
+    "gameModeId": "classic",
+    "chosenAugments": [],
+    "query": {
+      "question": "How do I carry this game?",
+      "history": [],
+      "augmentOptions": []
+    },
+    "response": null,
+    "error": null,
+    "scorerContext": {
+      "items": ["Eclipse", "Youmuu's Ghostblade", "Ionian Boots of Lucidity"],
+      "gold": 2000,
+      "champion": "Zed",
+      "gameTime": "20:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Augment re-roll round 1 to round 2 tracking",
+    "index": 12,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Ashe",
+        "level": 8,
+        "currentGold": 900,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 68,
+          "abilityPower": 0,
+          "armor": 48,
+          "magicResist": 34,
+          "maxHealth": 1100,
+          "currentHealth": 1100,
+          "moveSpeed": 325,
+          "attackSpeed": 1.05,
+          "abilityHaste": 0,
+          "critChance": 0.2
+        }
+      },
+      "players": [
+        {
+          "championName": "Ashe",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 4,
+          "items": [{ "id": 223068, "name": "Sunfire Aegis" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 6,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 7,
+          "kills": 0,
+          "deaths": 4,
+          "assists": 9,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 3,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 4,
+          "deaths": 2,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 1,
+          "deaths": 3,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 2,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 5,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 7,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 7,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 480
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "I'm being offered these augments: From Beginning To End, Vampirism, Flashy. Which should I pick?",
+      "history": [
+        {
+          "question": "I'm being offered these augments: Get Excited!, Slow and Steady, From Beginning To End. Which should I pick?",
+          "answer": "Pick From Beginning to End. Re-roll the other two."
+        }
+      ],
+      "augmentOptions": ["From Beginning To End", "Vampirism", "Flashy"]
+    },
+    "response": null,
+    "error": null,
+    "scorerContext": {
+      "items": ["Kraken Slayer", "Berserker's Greaves"],
+      "gold": 900,
+      "champion": "Ashe",
+      "gameTime": "8:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Augment re-roll all edge case — all 3 re-rolled, entirely new options",
+    "index": 13,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Warwick",
+        "level": 9,
+        "currentGold": 800,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 65,
+          "abilityPower": 0,
+          "armor": 65,
+          "magicResist": 46,
+          "maxHealth": 1400,
+          "currentHealth": 1400,
+          "moveSpeed": 335,
+          "attackSpeed": 0.75,
+          "abilityHaste": 0,
+          "critChance": 0
+        }
+      },
+      "players": [
+        {
+          "championName": "Warwick",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 223748, "name": "Titanic Hydra" },
+            { "id": 223111, "name": "Mercury's Treads" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Lux",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 2,
+          "deaths": 4,
+          "assists": 6,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "ORDER",
+          "level": 8,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Garen",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 2,
+          "deaths": 3,
+          "assists": 4,
+          "items": [{ "id": 223068, "name": "Sunfire Aegis" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 5,
+          "deaths": 2,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 6,
+          "items": [{ "id": 226655, "name": "Luden's Echo" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 3,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 3,
+          "deaths": 4,
+          "assists": 4,
+          "items": [{ "id": 223078, "name": "Trinity Force" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Leona",
+          "team": "CHAOS",
+          "level": 8,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 9,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 540
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": [],
+    "query": {
+      "question": "New augments: Outlaw's Grit, Holy Fire, Demon's Dance. Which one?",
+      "history": [
+        {
+          "question": "I'm being offered Pinball, Bread and Cheese, and Recursion. Which should I pick?",
+          "answer": "Re-roll all three. None of these synergize well with Warwick's kit."
+        }
+      ],
+      "augmentOptions": ["Outlaw's Grit", "Holy Fire", "Demon's Dance"]
+    },
+    "response": null,
+    "error": null,
+    "scorerContext": {
+      "items": ["Titanic Hydra", "Mercury's Treads"],
+      "gold": 800,
+      "champion": "Warwick",
+      "gameTime": "9:00"
+    }
+  },
+  {
+    "label": "SYNTHETIC: Augment re-roll — player ignored advice, chose different augment",
+    "index": 14,
+    "timestamp": "2026-04-05T00:00:00Z",
+    "model": "synthetic",
+    "category": "mayhem",
+    "gameState": {
+      "status": "connected",
+      "activePlayer": {
+        "championName": "Jinx",
+        "level": 10,
+        "currentGold": 1100,
+        "runes": {
+          "keystone": "Unknown",
+          "primaryTree": "Unknown",
+          "secondaryTree": "Unknown"
+        },
+        "stats": {
+          "attackDamage": 80,
+          "abilityPower": 0,
+          "armor": 50,
+          "magicResist": 36,
+          "maxHealth": 1250,
+          "currentHealth": 1250,
+          "moveSpeed": 325,
+          "attackSpeed": 1.15,
+          "abilityHaste": 0,
+          "critChance": 0.2
+        }
+      },
+      "players": [
+        {
+          "championName": "Jinx",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 223124, "name": "Kraken Slayer" },
+            { "id": 223006, "name": "Berserker's Greaves" },
+            { "id": 223046, "name": "Phantom Dancer" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Player1",
+          "position": "",
+          "isActivePlayer": true
+        },
+        {
+          "championName": "Maokai",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 9,
+          "items": [
+            { "id": 223068, "name": "Sunfire Aegis" },
+            { "id": 223111, "name": "Mercury's Treads" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Ahri",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 4,
+          "deaths": 4,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Sona",
+          "team": "ORDER",
+          "level": 9,
+          "kills": 0,
+          "deaths": 5,
+          "assists": 12,
+          "items": [{ "id": 226620, "name": "Moonstone Renewer" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Darius",
+          "team": "ORDER",
+          "level": 10,
+          "kills": 3,
+          "deaths": 3,
+          "assists": 4,
+          "items": [
+            { "id": 223078, "name": "Trinity Force" },
+            { "id": 223047, "name": "Plated Steelcaps" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Ally4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Vex",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 5,
+          "deaths": 3,
+          "assists": 6,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy1",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Thresh",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 1,
+          "deaths": 4,
+          "assists": 9,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy2",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Draven",
+          "team": "CHAOS",
+          "level": 11,
+          "kills": 6,
+          "deaths": 3,
+          "assists": 2,
+          "items": [
+            { "id": 667666, "name": "The Collector" },
+            { "id": 223006, "name": "Berserker's Greaves" },
+            { "id": 223031, "name": "Infinity Edge" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy3",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Syndra",
+          "team": "CHAOS",
+          "level": 10,
+          "kills": 4,
+          "deaths": 3,
+          "assists": 5,
+          "items": [
+            { "id": 226655, "name": "Luden's Echo" },
+            { "id": 223020, "name": "Sorcerer's Shoes" }
+          ],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy4",
+          "position": "",
+          "isActivePlayer": false
+        },
+        {
+          "championName": "Nautilus",
+          "team": "CHAOS",
+          "level": 9,
+          "kills": 1,
+          "deaths": 5,
+          "assists": 8,
+          "items": [{ "id": 223190, "name": "Locket of the Iron Solari" }],
+          "summonerSpells": ["Flash", "Mark"],
+          "riotIdGameName": "Enemy5",
+          "position": "",
+          "isActivePlayer": false
+        }
+      ],
+      "gameMode": "KIWI",
+      "gameTime": 600
+    },
+    "gameModeId": "aram-mayhem",
+    "chosenAugments": ["Slow and Steady"],
+    "query": {
+      "question": "New augments: Slow and Steady, Vampirism, Get Excited! Which one?",
+      "history": [
+        {
+          "question": "I'm being offered From Beginning To End, Slow and Steady, and Flashy. Which should I pick?",
+          "answer": "Pick From Beginning to End. It synergizes with Jinx's attack speed scaling. Re-roll Slow and Steady and Flashy."
+        },
+        {
+          "question": "I chose Slow and Steady instead.",
+          "answer": "OK, Slow and Steady works too. It gives you bonus damage for staying at range."
+        }
+      ],
+      "augmentOptions": ["Slow and Steady", "Vampirism", "Get Excited!"]
+    },
+    "response": null,
+    "error": null,
+    "scorerContext": {
+      "items": ["Kraken Slayer", "Berserker's Greaves", "Phantom Dancer"],
+      "gold": 1100,
+      "champion": "Jinx",
+      "gameTime": "10:00"
+    }
+  }
+]

--- a/scripts/inspect-evals.ts
+++ b/scripts/inspect-evals.ts
@@ -23,6 +23,8 @@ const GATE_SCORERS = [
   "Item Awareness",
   "Structured Output",
   "Augment Re-Roll Accuracy",
+  "State Awareness",
+  "Gold-Aware Recommendations",
 ];
 const RANKING_SCORERS = [
   "Brevity",
@@ -30,6 +32,7 @@ const RANKING_SCORERS = [
   "Conversational Continuity",
   "Gold Awareness",
   "Unnecessary Warnings",
+  "Pivot Explanation",
 ];
 const GATE_THRESHOLD = 0.8;
 
@@ -155,6 +158,9 @@ const SCORER_LABELS: Record<string, string> = {
   "Conversational Continuity": "Contin",
   "Gold Awareness": "Gold",
   "Unnecessary Warnings": "NoWarn",
+  "State Awareness": "State",
+  "Gold-Aware Recommendations": "GoldFmt",
+  "Pivot Explanation": "Pivot",
 };
 
 function label(scorer: string): string {
@@ -205,8 +211,8 @@ function cmdSummary() {
   }
   const rankKeys = [...allRanking];
 
-  // Column widths
-  const nameW = 30;
+  // Column widths — nameW adapts to the longest suite name
+  const nameW = Math.max(30, ...summaries.map((s) => s.name.length));
   const fixW = 5;
   const gateW = 22;
   const rankColW = 8;

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -43,6 +43,9 @@ import { scoreBrevity, scoreDecisiveness } from "./scorers/response-format";
 import { scoreConversationalContinuity } from "./scorers/conversational-continuity";
 import { scoreGoldAwareness } from "./scorers/gold-awareness";
 import { scoreUnnecessaryWarnings } from "./scorers/unnecessary-warnings";
+import { scoreStateAwareness } from "./scorers/state-awareness";
+import { scorePivotExplanation } from "./scorers/pivot-explanation";
+import { scoreGoldAwareRecommendations } from "./scorers/gold-aware-recommendations";
 
 // --- Types ---
 
@@ -76,6 +79,17 @@ interface EvalInput {
   userPrompt: string;
   history: Array<{ question: string; answer: string }>;
   expectedReferences?: string[];
+  scorerHints?: ScorerHints;
+  enemyChampions: string[];
+}
+
+interface ScorerHints {
+  stateAwareness?: Array<
+    "grievous-wounds" | "mr-needed" | "enemy-comp" | "existing-items"
+  >;
+  pivotExpected?: boolean;
+  priorRecommendation?: string;
+  goldAware?: boolean;
 }
 
 interface EvalOutput {
@@ -123,6 +137,7 @@ function gameFixtureToInput(f: GameFixture): EvalInput {
     userPrompt,
     history: f.query.history ?? [],
     expectedReferences: f.expectedReferences,
+    enemyChampions: f.context.enemyTeam.map((e) => e.champion),
   };
 }
 
@@ -150,11 +165,12 @@ for (const input of validGameInputs) {
 // --- Model setup ---
 
 const openaiKey = process.env.VITE_OPENAI_API_KEY ?? process.env.OPENAI_API_KEY;
-const openrouterKey = process.env.OPENROUTER_API_KEY;
+const openrouterKey =
+  process.env.VITE_OPENROUTER_API_KEY ?? process.env.OPENROUTER_API_KEY;
 
 if (!openaiKey && !openrouterKey) {
   throw new Error(
-    "At least one API key required in .env: VITE_OPENAI_API_KEY, OPENAI_API_KEY, or OPENROUTER_API_KEY"
+    "At least one API key required in .env: VITE_OPENAI_API_KEY, OPENAI_API_KEY, VITE_OPENROUTER_API_KEY, or OPENROUTER_API_KEY"
   );
 }
 
@@ -175,7 +191,8 @@ interface ModelCandidate {
 // Models to evaluate across providers and tiers.
 // Comment/uncomment to control which models run.
 const models: ModelCandidate[] = [
-  { name: "GPT 5.4 mini", id: "gpt-5.4-mini", provider: "openai" },
+  { name: "GPT 5.4 mini", id: "openai/gpt-5.4-mini", provider: "openrouter" },
+  // { name: "GPT 5.4 mini", id: "gpt-5.4-mini", provider: "openai" },
   // { name: "GPT 5.4", id: "openai/gpt-5.4", provider: "openrouter" },
   // { name: "Gemini 2.5 Pro", id: "google/gemini-2.5-pro", provider: "openrouter" },
   // { name: "Claude Sonnet 4.6", id: "anthropic/claude-sonnet-4.6", provider: "openrouter" },
@@ -188,7 +205,7 @@ function getModel(candidate: ModelCandidate) {
   }
   if (!openrouter)
     throw new Error(`OpenRouter key required for ${candidate.name}`);
-  return openrouter(candidate.id);
+  return openrouter.chat(candidate.id);
 }
 
 // --- Scorers ---
@@ -272,13 +289,61 @@ const unnecessaryWarnings = createScorer<EvalInput, EvalOutput>({
   },
 });
 
-const GATE_SCORERS = [itemAwareness, structuredOutput, augmentRerollAccuracy];
+const stateAwareness = createScorer<EvalInput, EvalOutput>({
+  name: "State Awareness",
+  description:
+    "Checks that the model references relevant game state (enemy comp, items, resistances)",
+  scorer: ({ input, output }) => {
+    return scoreStateAwareness(
+      output.answer,
+      input.scorerHints?.stateAwareness,
+      input.items,
+      input.enemyChampions
+    );
+  },
+});
+
+const pivotExplanation = createScorer<EvalInput, EvalOutput>({
+  name: "Pivot Explanation",
+  description:
+    "Checks that recommendation changes from prior turns are explained",
+  scorer: ({ input, output }) => {
+    return scorePivotExplanation(
+      output.answer,
+      input.scorerHints?.pivotExpected,
+      input.scorerHints?.priorRecommendation,
+      input.history
+    );
+  },
+});
+
+const goldAwareRecommendations = createScorer<EvalInput, EvalOutput>({
+  name: "Gold-Aware Recommendations",
+  description:
+    "Checks that item recommendations follow the destination + component format",
+  scorer: ({ input, output }) => {
+    return scoreGoldAwareRecommendations(
+      output.answer,
+      input.gold,
+      input.question
+    );
+  },
+});
+
+const GATE_SCORERS = [
+  itemAwareness,
+  structuredOutput,
+  augmentRerollAccuracy,
+  stateAwareness,
+  goldAwareRecommendations,
+];
 const RANKING_SCORERS = [
   brevity,
   decisiveness,
   conversationalContinuity,
   goldAwareness,
   unnecessaryWarnings,
+  pivotExplanation,
 ];
 const ALL_SCORERS = [...GATE_SCORERS, ...RANKING_SCORERS];
 
@@ -353,6 +418,7 @@ interface MultiTurnFixture {
   } | null;
   error: string | null;
   expectedReferences?: string[];
+  scorerHints?: ScorerHints;
   scorerContext: {
     items: string[];
     gold: number;
@@ -469,6 +535,8 @@ if (existsSync(multiTurnFixturesDir)) {
       userPrompt: "", // not used in multi-turn — messages carry the content
       history: f.query.history ?? [],
       expectedReferences: f.expectedReferences,
+      scorerHints: f.scorerHints,
+      enemyChampions: enemyPlayers.map((p) => p.championName),
       messages: [...session.messages],
     };
   }

--- a/src/lib/ai/prompts.test.ts
+++ b/src/lib/ai/prompts.test.ts
@@ -108,6 +108,23 @@ describe("buildSystemPrompt", () => {
     expect(prompt).not.toContain("re-roll");
   });
 
+  it("includes gold-aware item recommendation format", () => {
+    const prompt = buildSystemPrompt({
+      gameMode: "CLASSIC",
+      lcuGameMode: "CLASSIC",
+    });
+    expect(prompt).toContain(
+      "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now"
+    );
+    expect(prompt).toContain(
+      "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g"
+    );
+    expect(prompt).toContain(
+      "most expensive component the player can currently afford"
+    );
+    expect(prompt).not.toContain("buy Needlessly Large Rod next (1250g)");
+  });
+
   it("excludes augment rules for non-ARAM modes", () => {
     const prompt = buildSystemPrompt({
       gameMode: "CLASSIC",
@@ -593,6 +610,24 @@ describe("buildGameSystemPrompt", () => {
     expect(prompt).toContain("ITEM AWARENESS");
     expect(prompt).toContain("GOLD AWARENESS");
     expect(prompt).toContain("RESPONSE RULES");
+  });
+
+  it("includes gold-aware item recommendation format", () => {
+    const prompt = buildGameSystemPrompt(
+      createStubMode(),
+      createStubGameData(),
+      createGameState()
+    );
+    expect(prompt).toContain(
+      "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now"
+    );
+    expect(prompt).toContain(
+      "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g"
+    );
+    expect(prompt).toContain(
+      "most expensive component the player can currently afford"
+    );
+    expect(prompt).not.toContain("buy Needlessly Large Rod next (1250g)");
   });
 
   it("includes state snapshot format instructions", () => {

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -6,6 +6,9 @@ import type { GameState } from "../game-state/types";
 import { formatGameTime, formatModifier } from "../format";
 import { GAME_MODE_MAYHEM, GAME_MODE_ARAM } from "../mode/types";
 
+const ITEM_RECOMMENDATIONS_RULE =
+  "ITEM RECOMMENDATIONS: Always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold.";
+
 export function buildSystemPrompt(context: {
   gameMode: string;
   lcuGameMode: string;
@@ -16,7 +19,7 @@ export function buildSystemPrompt(context: {
     "",
     "ITEM AWARENESS: Do not recommend purchasing items already listed in the player's inventory.",
     "GOLD AWARENESS: The gold amount shown is the player's exact current gold. Use it to determine what they can afford. Do not hedge with 'if you can buy' when the gold amount is visible.",
-    "ITEM RECOMMENDATIONS: Always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold.",
+    ITEM_RECOMMENDATIONS_RULE,
     "",
     "RESPONSE RULES:",
     "- Be extremely concise. Sacrifice grammar for concision.",
@@ -264,9 +267,7 @@ export function buildGameSystemPrompt(
   sections.push(
     "GOLD AWARENESS: The gold amount shown is the player's exact current gold. Use it to determine what they can afford. Do not hedge with 'if you can buy' when the gold amount is visible."
   );
-  sections.push(
-    "ITEM RECOMMENDATIONS: Always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold."
-  );
+  sections.push(ITEM_RECOMMENDATIONS_RULE);
   sections.push("");
   sections.push("RESPONSE RULES:");
   sections.push("- Be extremely concise. Sacrifice grammar for concision.");

--- a/src/lib/ai/prompts.ts
+++ b/src/lib/ai/prompts.ts
@@ -16,7 +16,7 @@ export function buildSystemPrompt(context: {
     "",
     "ITEM AWARENESS: Do not recommend purchasing items already listed in the player's inventory.",
     "GOLD AWARENESS: The gold amount shown is the player's exact current gold. Use it to determine what they can afford. Do not hedge with 'if you can buy' when the gold amount is visible.",
-    "ITEM RECOMMENDATIONS: Always name the full target item you're building toward AND the immediate component to buy. Example: 'Build toward Rabadon's Deathcap — buy Needlessly Large Rod next (1250g).' Players think in terms of completed items, not components.",
+    "ITEM RECOMMENDATIONS: Always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold.",
     "",
     "RESPONSE RULES:",
     "- Be extremely concise. Sacrifice grammar for concision.",
@@ -265,7 +265,7 @@ export function buildGameSystemPrompt(
     "GOLD AWARENESS: The gold amount shown is the player's exact current gold. Use it to determine what they can afford. Do not hedge with 'if you can buy' when the gold amount is visible."
   );
   sections.push(
-    "ITEM RECOMMENDATIONS: Always name the full target item you're building toward AND the immediate component to buy. Example: 'Build toward Rabadon's Deathcap — buy Needlessly Large Rod next (1250g).' Players think in terms of completed items, not components."
+    "ITEM RECOMMENDATIONS: Always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold."
   );
   sections.push("");
   sections.push("RESPONSE RULES:");

--- a/src/lib/ai/scorers/gold-aware-recommendations.test.ts
+++ b/src/lib/ai/scorers/gold-aware-recommendations.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect } from "vitest";
+import { scoreGoldAwareRecommendations } from "./gold-aware-recommendations";
+
+describe("scoreGoldAwareRecommendations", () => {
+  // --- N/A cases ---
+
+  it("returns 1 for non-item questions", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Focus on peeling for your carry in teamfights.",
+        1500,
+        "How should I play teamfights?"
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when gold is 0", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "You need to farm up before buying anything.",
+        0,
+        "What item should I buy?"
+      )
+    ).toBe(1);
+  });
+
+  // --- Passing cases ---
+
+  it("returns 1 when response has destination and component (can afford)", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.",
+        1500,
+        "What should I buy next?"
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when response has destination and component (can't afford)", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.",
+        200,
+        "What item should I buy?"
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when response uses 'build toward' with bold formatting", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward **Rabadon's Deathcap**. You can get a **Needlessly Large Rod** now.",
+        1500,
+        "What should I build next?"
+      )
+    ).toBe(1);
+  });
+
+  // --- Failing cases ---
+
+  it("returns 0 when only a component is named without destination", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Buy Needlessly Large Rod now.",
+        1500,
+        "What item should I buy?"
+      )
+    ).toBe(0);
+  });
+
+  it("returns 0 when only a destination is named without component", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward Rabadon's Deathcap.",
+        1500,
+        "What should I buy next?"
+      )
+    ).toBe(0);
+  });
+
+  // --- Edge cases ---
+
+  it("returns 1 for non-item question that mentions an item name", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Rabadon's gives you a big AP spike for teamfights. Focus on positioning.",
+        1500,
+        "How do I deal with their Katarina?"
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when response uses 'pick up' as component verb", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward Infinity Edge. Pick up a B.F. Sword now.",
+        1500,
+        "What item should I buy?"
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when response uses 'grab' as component verb", () => {
+    expect(
+      scoreGoldAwareRecommendations(
+        "Build toward Sunfire Aegis. Grab a Bami's Cinder now.",
+        1500,
+        "What should I buy next?"
+      )
+    ).toBe(1);
+  });
+});

--- a/src/lib/ai/scorers/gold-aware-recommendations.ts
+++ b/src/lib/ai/scorers/gold-aware-recommendations.ts
@@ -1,0 +1,56 @@
+/**
+ * Gold-Aware Recommendations scorer for the coaching eval pipeline.
+ *
+ * Gate scorer: checks that item recommendations follow the
+ * destination + component format. The response should name
+ * a completed (destination) item AND a buildable component.
+ */
+
+// Same item-question gate used by the gold-awareness scorer
+const ITEM_QUESTION_PATTERN = /item|buy|build|next|shop|gold/i;
+
+// Patterns indicating the response names a destination (completed) item
+const DESTINATION_PATTERNS = [/build toward\s/i, /build towards\s/i];
+
+// Patterns indicating the response names a component to buy
+const COMPONENT_PATTERNS = [
+  /you can get (?:a |an )?\w/i,
+  /pick up (?:a |an )?\w/i,
+  /grab (?:a |an )?\w/i,
+  /\bbuy (?:a |an )?\w/i,
+];
+
+/**
+ * Check whether an item recommendation follows the destination + component format.
+ *
+ * Returns 1.0 if:
+ * - Not an item-related question (scorer doesn't apply)
+ * - Gold is 0 (nothing to buy)
+ * - Response names both a destination item and a component
+ *
+ * Returns 0.0 if:
+ * - Response only names a component without a destination
+ * - Response only names a destination without a component
+ */
+export function scoreGoldAwareRecommendations(
+  response: string,
+  gold: number,
+  question: string
+): number {
+  // Only score item-related questions
+  if (!ITEM_QUESTION_PATTERN.test(question)) return 1;
+  if (gold === 0) return 1;
+
+  const hasDestination = DESTINATION_PATTERNS.some((p) => p.test(response));
+  const hasComponent = COMPONENT_PATTERNS.some((p) => p.test(response));
+
+  // Both must be present for an item recommendation to pass
+  if (hasDestination && hasComponent) return 1;
+
+  // If neither is present, the response might not be an item recommendation
+  // (e.g., a tactical answer to a question containing "next")
+  if (!hasDestination && !hasComponent) return 1;
+
+  // One without the other is a format violation
+  return 0;
+}

--- a/src/lib/ai/scorers/pivot-explanation.test.ts
+++ b/src/lib/ai/scorers/pivot-explanation.test.ts
@@ -114,6 +114,17 @@ describe("scorePivotExplanation", () => {
     ).toBe(0.5);
   });
 
+  it("returns 0.5 when pivot expected but response reaffirms prior item with causal language", () => {
+    expect(
+      scorePivotExplanation(
+        "Keep Thornmail because it gives you armor and anti-heal.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(0.5);
+  });
+
   it("returns 1 with explanation using 'instead' for pivot", () => {
     expect(
       scorePivotExplanation(

--- a/src/lib/ai/scorers/pivot-explanation.test.ts
+++ b/src/lib/ai/scorers/pivot-explanation.test.ts
@@ -1,0 +1,127 @@
+import { describe, it, expect } from "vitest";
+import { scorePivotExplanation } from "./pivot-explanation";
+
+describe("scorePivotExplanation", () => {
+  const emptyHistory: Array<{ question: string; answer: string }> = [];
+
+  it("returns 1 when pivotExpected is undefined (N/A fixture)", () => {
+    expect(
+      scorePivotExplanation(
+        "Build Thornmail.",
+        undefined,
+        undefined,
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when pivotExpected is false and response is consistent", () => {
+    expect(
+      scorePivotExplanation(
+        "Still recommend Spirit Visage for the MR and healing.",
+        false,
+        "Spirit Visage",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when pivot detected and explanation uses 'because'", () => {
+    expect(
+      scorePivotExplanation(
+        "Switch to Force of Nature because their team added more AP threats.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when pivot detected and explanation uses 'since'", () => {
+    expect(
+      scorePivotExplanation(
+        "Build Randuin's Omen instead. Since they sold their healing items, Thornmail is less valuable.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when pivot detected and explanation uses 'now that'", () => {
+    expect(
+      scorePivotExplanation(
+        "Now that you picked Goliath, pivot to Heartsteel for the synergy.",
+        true,
+        "Infinity Edge",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("returns 0 when pivot detected but no explanation", () => {
+    expect(
+      scorePivotExplanation(
+        "Build Force of Nature.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(0);
+  });
+
+  it("returns 0 when pivot detected and response has no causal language", () => {
+    expect(
+      scorePivotExplanation(
+        "Get Randuin's Omen next. You can pick up a Warden's Mail now.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(0);
+  });
+
+  it("returns 0.5 when pivot expected but response still recommends same item", () => {
+    expect(
+      scorePivotExplanation(
+        "Build toward Thornmail. You can get a Bramble Vest now.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(0.5);
+  });
+
+  it("returns 1 when response explicitly says 'still recommend' the prior item with pivotExpected false", () => {
+    expect(
+      scorePivotExplanation(
+        "I still recommend Spirit Visage — the healing synergy is too good to pass up.",
+        false,
+        "Spirit Visage",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+
+  it("handles case-insensitive comparison of prior recommendation", () => {
+    expect(
+      scorePivotExplanation(
+        "Build toward THORNMAIL for the armor and anti-heal.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(0.5);
+  });
+
+  it("returns 1 with explanation using 'instead' for pivot", () => {
+    expect(
+      scorePivotExplanation(
+        "Go for Wit's End instead — your augment synergizes better with on-hit.",
+        true,
+        "Thornmail",
+        emptyHistory
+      )
+    ).toBe(1);
+  });
+});

--- a/src/lib/ai/scorers/pivot-explanation.ts
+++ b/src/lib/ai/scorers/pivot-explanation.ts
@@ -1,0 +1,73 @@
+/**
+ * Pivot Explanation scorer for the coaching eval pipeline.
+ *
+ * Ranking scorer: when the LLM changes its recommendation from a prior
+ * turn, checks whether it explains why. Validates that multi-turn
+ * conversations reduce the "whiplash" problem.
+ */
+
+// Causal language patterns that indicate the LLM is explaining a change
+const CAUSAL_PATTERNS = [
+  "because",
+  "since ",
+  "now that",
+  "changed",
+  "instead",
+  "switched",
+  "pivot",
+  "better option",
+  "no longer",
+  "doesn't make sense",
+  "less valuable",
+  "more valuable",
+  "synergizes",
+  "synergy",
+  "given that",
+  "due to",
+];
+
+/**
+ * Score whether a recommendation change (pivot) is properly explained.
+ *
+ * - No pivot expected or detected → 1.0 (not applicable)
+ * - Pivot detected + explanation present → 1.0
+ * - Pivot detected + no explanation → 0.0
+ * - Pivot expected but not detected (still recommends same) → 0.5
+ */
+export function scorePivotExplanation(
+  response: string,
+  pivotExpected: boolean | undefined,
+  priorRecommendation: string | undefined,
+  _history: Array<{ question: string; answer: string }>
+): number {
+  // Not a pivot fixture
+  if (pivotExpected === undefined) return 1;
+
+  // No prior recommendation to compare against
+  if (!priorRecommendation) return 1;
+
+  const lower = response.toLowerCase();
+  const priorLower = priorRecommendation.toLowerCase();
+
+  // Check if the response still recommends the same item.
+  // Mentioning the prior item in a dismissive context ("less valuable",
+  // "no longer", "instead of") doesn't count as still recommending it.
+  const mentionsPrior = lower.includes(priorLower);
+  const dismissesIt = CAUSAL_PATTERNS.some((p) => lower.includes(p));
+  const stillRecommendsSame = mentionsPrior && !dismissesIt;
+
+  if (pivotExpected && stillRecommendsSame) {
+    // Expected a pivot but the LLM didn't change its recommendation
+    return 0.5;
+  }
+
+  if (!pivotExpected) {
+    // No pivot expected — consistent recommendation is good
+    return 1;
+  }
+
+  // Pivot detected (pivotExpected=true and response doesn't mention prior item)
+  // Check for causal explanation
+  const hasExplanation = CAUSAL_PATTERNS.some((p) => lower.includes(p));
+  return hasExplanation ? 1 : 0;
+}

--- a/src/lib/ai/scorers/pivot-explanation.ts
+++ b/src/lib/ai/scorers/pivot-explanation.ts
@@ -6,8 +6,8 @@
  * conversations reduce the "whiplash" problem.
  */
 
-// Causal language patterns that indicate the LLM is explaining a change
-const CAUSAL_PATTERNS = [
+// Patterns that indicate the LLM is explaining a change in recommendation
+const EXPLANATION_PATTERNS = [
   "because",
   "since ",
   "now that",
@@ -24,6 +24,20 @@ const CAUSAL_PATTERNS = [
   "synergy",
   "given that",
   "due to",
+];
+
+// Subset of explanation patterns that indicate the prior item is being
+// dismissed rather than reaffirmed. "Keep Thornmail because it's great"
+// should NOT count as a dismissal, but "Thornmail is no longer useful"
+// should.
+const DISMISSAL_PATTERNS = [
+  "instead",
+  "switched",
+  "pivot",
+  "no longer",
+  "doesn't make sense",
+  "less valuable",
+  "rather than",
 ];
 
 /**
@@ -50,10 +64,11 @@ export function scorePivotExplanation(
   const priorLower = priorRecommendation.toLowerCase();
 
   // Check if the response still recommends the same item.
-  // Mentioning the prior item in a dismissive context ("less valuable",
-  // "no longer", "instead of") doesn't count as still recommending it.
+  // Mentioning the prior item alongside dismissal language ("no longer",
+  // "instead", "less valuable") counts as pivoting away, not reaffirming.
+  // But "keep Thornmail because..." is reaffirming despite causal language.
   const mentionsPrior = lower.includes(priorLower);
-  const dismissesIt = CAUSAL_PATTERNS.some((p) => lower.includes(p));
+  const dismissesIt = DISMISSAL_PATTERNS.some((p) => lower.includes(p));
   const stillRecommendsSame = mentionsPrior && !dismissesIt;
 
   if (pivotExpected && stillRecommendsSame) {
@@ -66,8 +81,9 @@ export function scorePivotExplanation(
     return 1;
   }
 
-  // Pivot detected (pivotExpected=true and response doesn't mention prior item)
+  // Pivot detected (pivotExpected=true and response doesn't mention prior item,
+  // or mentions it in a dismissive context)
   // Check for causal explanation
-  const hasExplanation = CAUSAL_PATTERNS.some((p) => lower.includes(p));
+  const hasExplanation = EXPLANATION_PATTERNS.some((p) => lower.includes(p));
   return hasExplanation ? 1 : 0;
 }

--- a/src/lib/ai/scorers/state-awareness.test.ts
+++ b/src/lib/ai/scorers/state-awareness.test.ts
@@ -1,0 +1,227 @@
+import { describe, it, expect } from "vitest";
+import { scoreStateAwareness } from "./state-awareness";
+
+describe("scoreStateAwareness", () => {
+  it("returns 1 when no hints provided (N/A fixture)", () => {
+    expect(scoreStateAwareness("Buy Rabadon's Deathcap.", undefined, [])).toBe(
+      1
+    );
+  });
+
+  it("returns 1 when hints array is empty", () => {
+    expect(scoreStateAwareness("Buy Rabadon's Deathcap.", [], [])).toBe(1);
+  });
+
+  // --- grievous-wounds rule ---
+
+  it("returns 0 when grievous-wounds hint present but response has no GW keywords", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(0);
+  });
+
+  it("returns 1 when grievous-wounds hint present and response mentions anti-heal", () => {
+    expect(
+      scoreStateAwareness(
+        "You need anti-heal against Soraka. Build toward Morellonomicon.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when grievous-wounds hint present and response mentions grievous wounds", () => {
+    expect(
+      scoreStateAwareness(
+        "Pick up grievous wounds to cut their healing.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when grievous-wounds hint present and response mentions Thornmail", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Thornmail for the anti-heal passive.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when grievous-wounds hint present and response mentions Oblivion Orb", () => {
+    expect(
+      scoreStateAwareness(
+        "You can get an Oblivion Orb now to reduce their healing.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when grievous-wounds hint present and response mentions Chempunk", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Chempunk Chainsword.",
+        ["grievous-wounds"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  // --- mr-needed rule ---
+
+  it("returns 0 when mr-needed hint present but response has no MR keywords", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Infinity Edge for more damage.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(0);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions magic resist", () => {
+    expect(
+      scoreStateAwareness(
+        "You need magic resist against their AP-heavy comp.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions MR", () => {
+    expect(
+      scoreStateAwareness(
+        "Get some MR — they have 3 AP threats.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions Spirit Visage", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Spirit Visage for sustain and MR.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions Force of Nature", () => {
+    expect(
+      scoreStateAwareness(
+        "Force of Nature is your best option here.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions Banshee's Veil", () => {
+    expect(
+      scoreStateAwareness(
+        "Consider Banshee's Veil for the spell shield.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when mr-needed hint present and response mentions Abyssal Mask", () => {
+    expect(
+      scoreStateAwareness(
+        "Abyssal Mask will help your team deal more magic damage.",
+        ["mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+
+  // --- enemy-comp rule ---
+
+  it("returns 0 when enemy-comp hint present but response is generic", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Infinity Edge. You can get a B.F. Sword now.",
+        ["enemy-comp"],
+        [],
+        ["Syndra", "Vex", "Brand"]
+      )
+    ).toBe(0);
+  });
+
+  it("returns 1 when enemy-comp hint present and response mentions an enemy champion", () => {
+    expect(
+      scoreStateAwareness(
+        "Against Syndra, you want magic resist.",
+        ["enemy-comp"],
+        [],
+        ["Syndra", "Vex", "Brand"]
+      )
+    ).toBe(1);
+  });
+
+  it("returns 1 when enemy-comp hint present and response mentions damage profile", () => {
+    expect(
+      scoreStateAwareness(
+        "Their team is mostly AP damage, so prioritize MR.",
+        ["enemy-comp"],
+        [],
+        ["Syndra", "Vex", "Brand"]
+      )
+    ).toBe(1);
+  });
+
+  // --- existing-items rule ---
+
+  it("returns 0 when existing-items hint present but response ignores owned items", () => {
+    expect(
+      scoreStateAwareness(
+        "Build toward Rabadon's Deathcap.",
+        ["existing-items"],
+        ["Mercury's Treads", "Titanic Hydra"]
+      )
+    ).toBe(0);
+  });
+
+  it("returns 1 when existing-items hint present and response references an owned item", () => {
+    expect(
+      scoreStateAwareness(
+        "Since you already have Titanic Hydra, build toward Sunfire Aegis.",
+        ["existing-items"],
+        ["Mercury's Treads", "Titanic Hydra"]
+      )
+    ).toBe(1);
+  });
+
+  // --- multiple rules ---
+
+  it("returns 0 when one rule passes but another fails", () => {
+    expect(
+      scoreStateAwareness(
+        "You need anti-heal to cut their healing. Build Morellonomicon.",
+        ["grievous-wounds", "mr-needed"],
+        []
+      )
+    ).toBe(0);
+  });
+
+  it("returns 1 when all rules pass", () => {
+    expect(
+      scoreStateAwareness(
+        "You need anti-heal against their healing and MR against their AP. Build Morellonomicon for grievous wounds.",
+        ["grievous-wounds", "mr-needed"],
+        []
+      )
+    ).toBe(1);
+  });
+});

--- a/src/lib/ai/scorers/state-awareness.ts
+++ b/src/lib/ai/scorers/state-awareness.ts
@@ -1,0 +1,114 @@
+/**
+ * State Awareness scorer for the coaching eval pipeline.
+ *
+ * Gate scorer: checks that the model references relevant game state
+ * information when the fixture's scorerHints indicate it should.
+ * Returns 0 if a required reference is missing, 1 if all are present.
+ */
+
+export type StateAwarenessRule =
+  | "grievous-wounds"
+  | "mr-needed"
+  | "enemy-comp"
+  | "existing-items";
+
+const GRIEVOUS_WOUNDS_KEYWORDS = [
+  "grievous wounds",
+  "anti-heal",
+  "antiheal",
+  "morellonomicon",
+  "thornmail",
+  "oblivion orb",
+  "chempunk",
+  "chainsword",
+];
+
+const MR_KEYWORDS = [
+  "magic resist",
+  " mr ",
+  " mr.",
+  " mr,",
+  "spirit visage",
+  "force of nature",
+  "banshee's veil",
+  "banshee's",
+  "abyssal mask",
+  "wit's end",
+  "maw of malmortius",
+  "malmortius",
+  "hollow radiance",
+  "kaenic rookern",
+];
+
+// Damage profile keywords that show the model acknowledged the enemy comp
+const COMP_AWARENESS_KEYWORDS = [
+  " ap ",
+  " ad ",
+  "magic damage",
+  "physical damage",
+  "ap-heavy",
+  "ad-heavy",
+  "ap heavy",
+  "ad heavy",
+  "all ap",
+  "all ad",
+  "mostly ap",
+  "mostly ad",
+];
+
+function hasKeyword(lower: string, keywords: string[]): boolean {
+  return keywords.some((kw) => lower.includes(kw));
+}
+
+/**
+ * Check whether a coaching response demonstrates awareness of the game state.
+ *
+ * Each rule in `hints` maps to a set of keywords that should appear in the
+ * response. All rules must pass for a score of 1. Any failure yields 0.
+ *
+ * Returns 1.0 if no hints are provided (not a state-awareness fixture).
+ */
+export function scoreStateAwareness(
+  response: string,
+  hints: StateAwarenessRule[] | undefined,
+  items: string[],
+  enemyChampions?: string[]
+): number {
+  if (!hints || hints.length === 0) return 1;
+
+  const lower = response.toLowerCase();
+
+  for (const rule of hints) {
+    switch (rule) {
+      case "grievous-wounds":
+        if (!hasKeyword(lower, GRIEVOUS_WOUNDS_KEYWORDS)) return 0;
+        break;
+
+      case "mr-needed":
+        if (!hasKeyword(lower, MR_KEYWORDS)) return 0;
+        break;
+
+      case "enemy-comp": {
+        // Check if response mentions any enemy champion or a damage profile keyword
+        const mentionsEnemy = enemyChampions?.some((name) =>
+          lower.includes(name.toLowerCase())
+        );
+        const mentionsProfile = hasKeyword(lower, COMP_AWARENESS_KEYWORDS);
+        if (!mentionsEnemy && !mentionsProfile) return 0;
+        break;
+      }
+
+      case "existing-items": {
+        // Check if response references any of the player's owned items
+        if (items.length === 0) break; // nothing to check
+        const mentionsItem = items.some(
+          (item) => item.length > 3 && lower.includes(item.toLowerCase())
+        );
+        if (!mentionsItem) return 0;
+        break;
+      }
+    }
+  }
+
+  return 1;
+}


### PR DESCRIPTION
Closes #83

## Summary

- **State Awareness** (gate scorer) — checks responses reference game state: grievous wounds vs healing, MR vs AP-heavy comps, enemy comp acknowledgment, existing item references
- **Pivot Explanation** (ranking scorer) — checks recommendation changes from prior turns are explained with causal language
- **Gold-Aware Recommendations** (gate scorer) — checks item recommendations follow destination + component format ("Build toward X. You can get Y now/at Zg.")
- Updated ITEM RECOMMENDATIONS prompt instruction in both `buildSystemPrompt` and `buildGameSystemPrompt`
- Added `scorerHints` to fixture/eval types for per-fixture scorer metadata
- 15 new synthetic multi-turn fixtures + 3 new continuity fixtures
- Updated `inspect-evals` script with new scorer columns and dynamic column widths
- OpenRouter support via `VITE_OPENROUTER_API_KEY` env var
- Eval baseline established: 97% overall, with known gaps in brevity and state awareness tracked in #89

### Deferred

- **Proactive Concern Flagging** — proactive coaching triggers not designed yet
- **Build Coherence** — LLM-as-judge would false-negative on creative ARAM Mayhem builds (#88)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Improved item recommendation format (explicit destination + affordable component phrasing).
  * Added multi-turn evaluation scorers (state-awareness, pivot-explanation, gold-aware recommendations) to the eval pipeline.

* **Documentation**
  * New docs: gold-aware recommendation format, eval scorers design, and updated technical reference.

* **Tests & Fixtures**
  * New unit tests for scorers and prompt guidance; added synthetic multi-turn continuity fixtures.

* **Tooling**
  * Eval tooling updated for alternate provider support and improved summary formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->