### PR TITLE
feat: show assigned champion name in status indicator during champ select

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -79,7 +79,7 @@ function App() {
   }, []);
 
   const { data, loading, error } = useGameData();
-  const { event: lifecycle, lastPhase } = useGameLifecycle();
+  const { event: lifecycle, lastPhase, championName } = useGameLifecycle();
   const liveGame = useLiveGameState();
   useUserInput();
   useZoom();
@@ -228,7 +228,11 @@ function App() {
             <InGameView state={effectiveState} gameData={data} />
           ) : (
             <div className="app-idle">
-              <ConnectionStatus lifecycle={lifecycle} lastPhase={lastPhase} />
+              <ConnectionStatus
+                lifecycle={lifecycle}
+                lastPhase={lastPhase}
+                championName={championName}
+              />
               <LastGameCard
                 dataVersion={data.version}
                 championCount={data.champions.size}

--- a/src/components/ConnectionStatus.tsx
+++ b/src/components/ConnectionStatus.tsx
@@ -8,6 +8,7 @@ const statusLog = getLogger("ui");
 interface ConnectionStatusProps {
   lifecycle: GameLifecycleEvent;
   lastPhase: GameflowPhase | null;
+  championName: string | null;
 }
 
 type Variant =
@@ -34,7 +35,8 @@ interface StatusInfo {
  */
 function getStatus(
   lifecycle: GameLifecycleEvent,
-  lastPhase: GameflowPhase | null
+  lastPhase: GameflowPhase | null,
+  championName: string | null
 ): StatusInfo {
   if (lifecycle.type === "connection") {
     if (lifecycle.connected) {
@@ -105,7 +107,7 @@ function getStatus(
         return {
           variant: "active",
           label: "Champion Select",
-          detail: "Pick your champion",
+          detail: championName ?? "Pick your champion",
         };
       case "GameStart":
       case "InProgress":
@@ -139,7 +141,11 @@ function getStatus(
 
   // Non-phase event that doesn't match the current phase — fall back to phase
   if (lastPhase) {
-    return getStatus({ type: "phase", phase: lastPhase }, lastPhase);
+    return getStatus(
+      { type: "phase", phase: lastPhase },
+      lastPhase,
+      championName
+    );
   }
 
   return {
@@ -158,10 +164,11 @@ function describeEvent(event: GameLifecycleEvent): string {
 export function ConnectionStatus({
   lifecycle,
   lastPhase,
+  championName,
 }: ConnectionStatusProps) {
   const prevStatusRef = useRef<string | null>(null);
 
-  const status = getStatus(lifecycle, lastPhase);
+  const status = getStatus(lifecycle, lastPhase, championName);
 
   const statusKey = `${status.variant}:${status.label}`;
   if (statusKey !== prevStatusRef.current) {

--- a/src/hooks/__tests__/useGameLifecycle.test.ts
+++ b/src/hooks/__tests__/useGameLifecycle.test.ts
@@ -1,12 +1,37 @@
 import { renderHook, act } from "@testing-library/react";
 import { describe, it, expect, afterEach, vi } from "vitest";
 import { useGameLifecycle } from "../useGameLifecycle";
-import { gameLifecycle$ } from "../../lib/reactive";
+import { gameLifecycle$, liveGameState$ } from "../../lib/reactive";
 import type { GameLifecycleEvent } from "../../lib/reactive";
+import type { LiveGameState } from "../../lib/reactive/types";
+
+vi.mock("../../lib/data-ingest/champion-id-map", () => {
+  const nameMap: Record<number, string> = {
+    136: "Aurelion Sol",
+    222: "Jinx",
+  };
+  return {
+    resolveChampionName: vi.fn((id: number) => nameMap[id]),
+  };
+});
+
+function defaultState(overrides: Partial<LiveGameState> = {}): LiveGameState {
+  return {
+    activePlayer: null,
+    players: [],
+    gameMode: "",
+    lcuGameMode: "",
+    gameTime: 0,
+    champSelect: null,
+    eogStats: null,
+    ...overrides,
+  };
+}
 
 describe("useGameLifecycle", () => {
   afterEach(() => {
     gameLifecycle$.next({ type: "connection", connected: false });
+    liveGameState$.next(defaultState());
   });
 
   it("returns the current event from the observable", () => {
@@ -81,5 +106,69 @@ describe("useGameLifecycle", () => {
 
     unmount();
     expect(gameLifecycle$.observers.length).toBe(initialSubscribers);
+  });
+
+  it("returns championName from locked champion during ChampSelect", () => {
+    const { result } = renderHook(() => useGameLifecycle());
+
+    act(() => {
+      gameLifecycle$.next({ type: "phase", phase: "ChampSelect" });
+      liveGameState$.next(
+        defaultState({
+          champSelect: {
+            localPlayerCellId: 0,
+            myTeam: [{ cellId: 0, championId: 222, championPickIntent: 0 }],
+          },
+        })
+      );
+    });
+
+    expect(result.current.championName).toBe("Jinx");
+  });
+
+  it("returns championName from hover intent when not locked", () => {
+    const { result } = renderHook(() => useGameLifecycle());
+
+    act(() => {
+      gameLifecycle$.next({ type: "phase", phase: "ChampSelect" });
+      liveGameState$.next(
+        defaultState({
+          champSelect: {
+            localPlayerCellId: 0,
+            myTeam: [{ cellId: 0, championId: 0, championPickIntent: 136 }],
+          },
+        })
+      );
+    });
+
+    expect(result.current.championName).toBe("Aurelion Sol");
+  });
+
+  it("returns null championName when not in ChampSelect", () => {
+    const { result } = renderHook(() => useGameLifecycle());
+
+    act(() => {
+      gameLifecycle$.next({ type: "phase", phase: "InProgress" });
+      liveGameState$.next(
+        defaultState({
+          champSelect: {
+            localPlayerCellId: 0,
+            myTeam: [{ cellId: 0, championId: 222, championPickIntent: 0 }],
+          },
+        })
+      );
+    });
+
+    expect(result.current.championName).toBeNull();
+  });
+
+  it("returns null championName when champSelect is null", () => {
+    const { result } = renderHook(() => useGameLifecycle());
+
+    act(() => {
+      gameLifecycle$.next({ type: "phase", phase: "ChampSelect" });
+    });
+
+    expect(result.current.championName).toBeNull();
   });
 });

--- a/src/hooks/useGameLifecycle.ts
+++ b/src/hooks/useGameLifecycle.ts
@@ -1,8 +1,9 @@
 import { useState, useEffect, useRef } from "react";
 import type { GameLifecycleEvent } from "../lib/reactive";
 import type { GameflowPhase } from "../lib/reactive/types";
-import { gameLifecycle$ } from "../lib/reactive";
-import { debounceTime, filter, merge } from "rxjs";
+import { gameLifecycle$, liveGameState$ } from "../lib/reactive";
+import { resolveChampionName } from "../lib/data-ingest/champion-id-map";
+import { debounceTime, filter, merge, map, distinctUntilChanged } from "rxjs";
 
 /**
  * Subscribe to game lifecycle events.
@@ -13,15 +14,33 @@ import { debounceTime, filter, merge } from "rxjs";
  */
 const DEBOUNCE_MS = 400;
 
+/** Extract the local player's champion name from raw champ select session data. */
+function getLocalChampionName(champSelect: unknown): string | null {
+  if (champSelect == null || typeof champSelect !== "object") return null;
+  const cs = champSelect as Record<string, unknown>;
+  const localCellId = cs.localPlayerCellId as number | undefined;
+  const myTeam = cs.myTeam as Array<Record<string, unknown>> | undefined;
+  if (!Array.isArray(myTeam)) return null;
+  const local = myTeam.find((m) => m.cellId === localCellId);
+  if (!local) return null;
+  const lockedId = local.championId as number;
+  if (lockedId > 0) return resolveChampionName(lockedId) ?? null;
+  const hoverId = local.championPickIntent as number;
+  if (hoverId > 0) return resolveChampionName(hoverId) ?? null;
+  return null;
+}
+
 export function useGameLifecycle(): {
   event: GameLifecycleEvent;
   lastPhase: GameflowPhase | null;
+  championName: string | null;
 } {
   const [event, setEvent] = useState<GameLifecycleEvent>(
     gameLifecycle$.getValue()
   );
   const lastPhaseRef = useRef<GameflowPhase | null>(null);
   const [lastPhase, setLastPhase] = useState<GameflowPhase | null>(null);
+  const [championName, setChampionName] = useState<string | null>(null);
 
   useEffect(() => {
     // Phase and connection events: deliver immediately
@@ -35,7 +54,7 @@ export function useGameLifecycle(): {
       debounceTime(DEBOUNCE_MS)
     );
 
-    const sub = merge(immediate$, debounced$).subscribe((e) => {
+    const lifecycleSub = merge(immediate$, debounced$).subscribe((e) => {
       if (e.type === "phase") {
         lastPhaseRef.current = e.phase;
         setLastPhase(e.phase);
@@ -43,8 +62,23 @@ export function useGameLifecycle(): {
       setEvent(e);
     });
 
-    return () => sub.unsubscribe();
+    // Derive champion name from champ select data, only during ChampSelect phase
+    const championSub = liveGameState$
+      .pipe(
+        map((state) =>
+          lastPhaseRef.current === "ChampSelect"
+            ? getLocalChampionName(state.champSelect)
+            : null
+        ),
+        distinctUntilChanged()
+      )
+      .subscribe(setChampionName);
+
+    return () => {
+      lifecycleSub.unsubscribe();
+      championSub.unsubscribe();
+    };
   }, []);
 
-  return { event, lastPhase };
+  return { event, lastPhase, championName };
 }

--- a/src/hooks/useGameLifecycle.ts
+++ b/src/hooks/useGameLifecycle.ts
@@ -3,7 +3,14 @@ import type { GameLifecycleEvent } from "../lib/reactive";
 import type { GameflowPhase } from "../lib/reactive/types";
 import { gameLifecycle$, liveGameState$ } from "../lib/reactive";
 import { resolveChampionName } from "../lib/data-ingest/champion-id-map";
-import { debounceTime, filter, merge, map, distinctUntilChanged } from "rxjs";
+import {
+  combineLatest,
+  debounceTime,
+  distinctUntilChanged,
+  filter,
+  map,
+  merge,
+} from "rxjs";
 
 /**
  * Subscribe to game lifecycle events.
@@ -62,11 +69,15 @@ export function useGameLifecycle(): {
       setEvent(e);
     });
 
-    // Derive champion name from champ select data, only during ChampSelect phase
-    const championSub = liveGameState$
+    // Derive champion name when either phase or champ select data changes
+    const phase$ = gameLifecycle$.pipe(
+      filter((e) => e.type === "phase"),
+      map((e) => (e as { type: "phase"; phase: GameflowPhase }).phase)
+    );
+    const championSub = combineLatest([phase$, liveGameState$])
       .pipe(
-        map((state) =>
-          lastPhaseRef.current === "ChampSelect"
+        map(([phase, state]) =>
+          phase === "ChampSelect"
             ? getLocalChampionName(state.champSelect)
             : null
         ),


### PR DESCRIPTION
## Summary
- `useGameLifecycle` hook now derives the local player's champion name from `liveGameState$` champ select data during ChampSelect phase
- `ConnectionStatus` displays the champion name (e.g., "Jinx") instead of "Pick your champion" when a champion is assigned or hovered
- Works for both locked champions and hover intent (ARAM random assignment, standard pick)

Closes #94

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Connection status now displays your champion during ChampSelect: shows locked pick or the hovered pick when not locked, and shows nothing outside ChampSelect.
* **Tests**
  * Added tests verifying champion-name behavior across ChampSelect and non-ChampSelect scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->