### PR TITLE
fix: discard stale coaching response after fast augment pick

### DIFF
--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -107,6 +107,16 @@ export function OverlayApp() {
         `Augment coaching received (${delay}ms delay, recs: ${recNames?.join(", ")})`
       );
 
+      // Discard responses that arrive after the player already picked.
+      // The abort signal races with the response — if the pick cleared
+      // the offer before this fires, applying it would show stale badges.
+      if (!offerNamesRef.current) {
+        overlayLog.info(
+          "Discarding stale coaching response — offer already cleared by pick"
+        );
+        return;
+      }
+
       if (analyzingTimerRef.current) {
         clearTimeout(analyzingTimerRef.current);
         analyzingTimerRef.current = null;

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -110,9 +110,29 @@ export function OverlayApp() {
       // Discard responses that arrive after the player already picked.
       // The abort signal races with the response — if the pick cleared
       // the offer before this fires, applying it would show stale badges.
-      if (!offerNamesRef.current) {
+      const currentOfferNames = offerNamesRef.current;
+      if (!currentOfferNames) {
         overlayLog.info(
           "Discarding stale coaching response — offer already cleared by pick"
+        );
+        return;
+      }
+
+      // Also discard if the response was for a previous offer: fast pick →
+      // new offer arrives → stale response from the prior offer finally lands.
+      // offerNamesRef is now non-null but points to the new offer, so we need
+      // to check the response actually matches the current augment names.
+      const currentOfferNameSet = new Set(
+        currentOfferNames.map((n) => n.toLowerCase())
+      );
+      const matchesCurrentOffer =
+        response.recommendations?.length === currentOfferNames.length &&
+        response.recommendations.every((r) =>
+          currentOfferNameSet.has(r.name.toLowerCase())
+        );
+      if (!matchesCurrentOffer) {
+        overlayLog.info(
+          "Discarding stale coaching response — recommendations do not match current offer"
         );
         return;
       }


### PR DESCRIPTION
## Summary

Closes #103

Guards `onCoachingResponse` in `OverlayApp.tsx` against applying a coaching response after the player has already picked an augment. When the abort signal races with the LLM response, the response is discarded instead of setting stale badge data on a cleared offer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed an issue where outdated coaching responses could be processed after the player had completed their selection, preventing incorrect UI updates or stale data from being displayed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->