### PR TITLE
fix: race a second LLM attempt after 10s to recover from slow coaching

### DIFF
--- a/src/components/CoachingPipeline.tsx
+++ b/src/components/CoachingPipeline.tsx
@@ -407,7 +407,8 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
             reasoning: r.reasoning,
           })),
           gameTime,
-          feedSource
+          feedSource,
+          finalResponse.retried ?? false
         );
 
         // Relay to overlay

--- a/src/components/coaching/CoachingCard.module.css
+++ b/src/components/coaching/CoachingCard.module.css
@@ -83,6 +83,21 @@
   margin-bottom: 0.5rem;
 }
 
+.retriedBadge {
+  display: inline-block;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.65rem;
+  font-weight: 600;
+  color: #f59e0b;
+  background: rgba(245, 158, 11, 0.12);
+  border: 1px solid rgba(245, 158, 11, 0.35);
+  padding: 0.1rem 0.4rem;
+  border-radius: 0.2rem;
+  margin-bottom: 0.4rem;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
 .recommendations {
   display: flex;
   flex-direction: column;
@@ -107,10 +122,17 @@
 .recFit {
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-weight: 700;
-  font-size: 0.7rem;
-  min-width: 1rem;
+  font-size: 0.6rem;
+  padding: 0.15rem 0.4rem;
+  border-radius: 0.2rem;
   text-align: center;
   text-transform: uppercase;
+  letter-spacing: 0.05em;
+  line-height: 1.2;
+  flex-shrink: 0;
+  align-self: flex-start;
+  margin-top: 0.1rem;
+  min-width: 5rem;
 }
 
 .fitExceptional {
@@ -124,13 +146,11 @@
     #ff80ab
   );
   background-size: 200% 100%;
-  animation: prismatic-text 3s linear infinite;
-  -webkit-background-clip: text;
-  background-clip: text;
-  -webkit-text-fill-color: transparent;
+  animation: prismatic-shift 3s linear infinite;
+  color: #0a0c10;
 }
 
-@keyframes prismatic-text {
+@keyframes prismatic-shift {
   0% {
     background-position: 0% 50%;
   }
@@ -139,13 +159,16 @@
   }
 }
 .fitStrong {
-  color: #34d399;
+  background: #34d399;
+  color: #0a0c10;
 }
 .fitSituational {
-  color: #fbbf24;
+  background: #fbbf24;
+  color: #0a0c10;
 }
 .fitWeak {
-  color: #6b7280;
+  background: #6b7280;
+  color: #e5e7eb;
 }
 
 .recName {

--- a/src/components/coaching/CoachingCard.tsx
+++ b/src/components/coaching/CoachingCard.tsx
@@ -101,6 +101,14 @@ function CoachingExchangeCard({ entry }: { entry: CoachingExchangeEntry }) {
       />
       <div className={styles.body}>
         <div className={styles.question}>{entry.question}</div>
+        {entry.retried && (
+          <div
+            className={styles.retriedBadge}
+            title="LLM returned malformed output on first attempt; this response is from the automatic retry."
+          >
+            ↻ retried
+          </div>
+        )}
         <div className={styles.answer}>{entry.answer}</div>
         {entry.recommendations.length > 0 && (
           <div className={styles.recommendations}>

--- a/src/lib/ai/race-with-retry.ts
+++ b/src/lib/ai/race-with-retry.ts
@@ -1,0 +1,180 @@
+/**
+ * Generic race-with-retry helper for async operations that may hang or fail.
+ *
+ * Strategy (designed for LLM requests, but applicable to any abortable async op):
+ *   - Start attempt 1 with its own AbortController.
+ *   - If attempt 1 throws a non-abort error, start attempt 2 immediately.
+ *   - If attempt 1 hasn't completed within `slowAfterMs`, start attempt 2
+ *     in parallel and race it against attempt 1.
+ *   - Whichever attempt resolves first wins; the loser's controller is aborted.
+ *   - If both attempts fail, reject with the most recent error.
+ *   - If the caller's `signal` aborts, both attempts are aborted and the
+ *     rejection propagates. Abort errors do NOT trigger a retry.
+ */
+
+export interface AttemptContext {
+  /** 1 or 2 — which attempt this is. */
+  attempt: number;
+  /** Abort signal for this specific attempt. Pass to downstream call. */
+  signal: AbortSignal;
+}
+
+export interface RaceResult<T> {
+  /** The value returned by the winning attempt. */
+  value: T;
+  /** Which attempt won (1 or 2). Callers can use this to tag responses. */
+  winningAttempt: number;
+}
+
+export interface RaceWithRetryOptions {
+  /**
+   * Caller's abort signal. Propagates to both attempts. If aborted, the
+   * race rejects with the abort reason and no retry is started.
+   */
+  signal?: AbortSignal;
+  /**
+   * If attempt 1 hasn't completed within this window, attempt 2 starts
+   * racing in parallel. Default: 10_000ms.
+   */
+  slowAfterMs?: number;
+  /**
+   * Called when attempt 2 is triggered (by timeout or attempt 1 failure).
+   * Use for logging/telemetry.
+   */
+  onRetryTrigger?: (
+    reason: "timeout" | "attempt-1-failed",
+    err?: unknown
+  ) => void;
+  /**
+   * Called when attempt 2 wins the race. Use for logging/telemetry.
+   */
+  onRetrySuccess?: () => void;
+  /**
+   * Called when both attempts have failed, just before rejection.
+   */
+  onBothFailed?: (lastError: unknown) => void;
+}
+
+const DEFAULT_SLOW_AFTER_MS = 10_000;
+
+function isAbortError(err: unknown): boolean {
+  return err instanceof Error && err.name === "AbortError";
+}
+
+/**
+ * Race two attempts of an async operation. Returns the first successful result
+ * along with which attempt produced it. See module docstring for full semantics.
+ */
+export function raceWithRetry<T>(
+  runAttempt: (ctx: AttemptContext) => Promise<T>,
+  options?: RaceWithRetryOptions
+): Promise<RaceResult<T>> {
+  const slowAfterMs = options?.slowAfterMs ?? DEFAULT_SLOW_AFTER_MS;
+  const userSignal = options?.signal;
+
+  interface Attempt {
+    num: number;
+    controller: AbortController;
+    promise: Promise<T>;
+  }
+
+  function startAttempt(num: number): Attempt {
+    const controller = new AbortController();
+
+    if (userSignal) {
+      if (userSignal.aborted) {
+        controller.abort();
+      } else {
+        userSignal.addEventListener("abort", () => controller.abort(), {
+          once: true,
+        });
+      }
+    }
+
+    const promise = runAttempt({ attempt: num, signal: controller.signal });
+    // Prevent unhandled rejection when the loser is aborted
+    promise.catch(() => {});
+    return { num, controller, promise };
+  }
+
+  const a = startAttempt(1);
+
+  return new Promise<RaceResult<T>>((resolve, reject) => {
+    let done = false;
+    let aFailed = false;
+    let bFailed = false;
+    let lastErr: unknown = null;
+    let b: Attempt | null = null;
+
+    const finish = (
+      ok: boolean,
+      value?: T,
+      fromAttempt?: number,
+      err?: unknown,
+      loser?: Attempt | null
+    ) => {
+      if (done) return;
+      done = true;
+      if (loser) loser.controller.abort();
+      if (ok && value !== undefined && fromAttempt !== undefined) {
+        resolve({ value, winningAttempt: fromAttempt });
+      } else {
+        reject(err);
+      }
+    };
+
+    const startB = (reason: "timeout" | "attempt-1-failed", err?: unknown) => {
+      if (b || done) return;
+      options?.onRetryTrigger?.(reason, err);
+      b = startAttempt(2);
+      b.promise.then(
+        (value) => {
+          if (!done) options?.onRetrySuccess?.();
+          finish(true, value, 2, undefined, a);
+        },
+        (err2) => {
+          bFailed = true;
+          lastErr = err2;
+          // If attempt 1 already failed too, we're done
+          if (aFailed) {
+            options?.onBothFailed?.(lastErr);
+            finish(false, undefined, undefined, err2, null);
+          }
+          // else wait for A
+        }
+      );
+    };
+
+    const slowTimer = setTimeout(() => {
+      if (!done) startB("timeout");
+    }, slowAfterMs);
+
+    a.promise.then(
+      (value) => {
+        clearTimeout(slowTimer);
+        finish(true, value, 1, undefined, b);
+      },
+      (err) => {
+        clearTimeout(slowTimer);
+        aFailed = true;
+        lastErr = err;
+
+        if (isAbortError(err)) {
+          // User aborted (or we lost the race and got aborted).
+          // Either way, stop. If B already won, finish is a no-op.
+          finish(false, undefined, undefined, err);
+          return;
+        }
+
+        // Non-abort failure — start B if not yet running
+        if (!b) {
+          startB("attempt-1-failed", err);
+        } else if (bFailed) {
+          options?.onBothFailed?.(lastErr);
+          finish(false, undefined, undefined, lastErr ?? err);
+        }
+        // else wait for B
+      }
+    );
+  });
+}

--- a/src/lib/ai/race-with-retry.ts
+++ b/src/lib/ai/race-with-retry.ts
@@ -106,21 +106,19 @@ export function raceWithRetry<T>(
     let lastErr: unknown = null;
     let b: Attempt | null = null;
 
-    const finish = (
-      ok: boolean,
-      value?: T,
-      fromAttempt?: number,
-      err?: unknown,
-      loser?: Attempt | null
-    ) => {
+    // Split helpers so success/error is explicit — not encoded via "value is undefined".
+    // A generic T may legitimately resolve to undefined (e.g. Promise<void>).
+    const finishOk = (value: T, fromAttempt: number, loser: Attempt | null) => {
       if (done) return;
       done = true;
       if (loser) loser.controller.abort();
-      if (ok && value !== undefined && fromAttempt !== undefined) {
-        resolve({ value, winningAttempt: fromAttempt });
-      } else {
-        reject(err);
-      }
+      resolve({ value, winningAttempt: fromAttempt });
+    };
+
+    const finishErr = (err: unknown) => {
+      if (done) return;
+      done = true;
+      reject(err);
     };
 
     const startB = (reason: "timeout" | "attempt-1-failed", err?: unknown) => {
@@ -130,7 +128,7 @@ export function raceWithRetry<T>(
       b.promise.then(
         (value) => {
           if (!done) options?.onRetrySuccess?.();
-          finish(true, value, 2, undefined, a);
+          finishOk(value, 2, a);
         },
         (err2) => {
           bFailed = true;
@@ -138,7 +136,7 @@ export function raceWithRetry<T>(
           // If attempt 1 already failed too, we're done
           if (aFailed) {
             options?.onBothFailed?.(lastErr);
-            finish(false, undefined, undefined, err2, null);
+            finishErr(err2);
           }
           // else wait for A
         }
@@ -152,7 +150,7 @@ export function raceWithRetry<T>(
     a.promise.then(
       (value) => {
         clearTimeout(slowTimer);
-        finish(true, value, 1, undefined, b);
+        finishOk(value, 1, b);
       },
       (err) => {
         clearTimeout(slowTimer);
@@ -161,8 +159,8 @@ export function raceWithRetry<T>(
 
         if (isAbortError(err)) {
           // User aborted (or we lost the race and got aborted).
-          // Either way, stop. If B already won, finish is a no-op.
-          finish(false, undefined, undefined, err);
+          // Either way, stop. If B already won, finishErr is a no-op.
+          finishErr(err);
           return;
         }
 
@@ -171,7 +169,7 @@ export function raceWithRetry<T>(
           startB("attempt-1-failed", err);
         } else if (bFailed) {
           options?.onBothFailed?.(lastErr);
-          finish(false, undefined, undefined, lastErr ?? err);
+          finishErr(lastErr ?? err);
         }
         // else wait for B
       }

--- a/src/lib/ai/recommendation-engine.test.ts
+++ b/src/lib/ai/recommendation-engine.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { getMultiTurnCoachingResponse } from "./recommendation-engine";
 import { createConversationSession } from "./conversation-session";
 
@@ -20,6 +20,16 @@ vi.mock("./model-config", () => ({
 import { generateText } from "ai";
 
 const mockGenerateText = vi.mocked(generateText);
+
+function createDeferred() {
+  let resolve!: (value: unknown) => void;
+  let reject!: (reason?: unknown) => void;
+  const promise = new Promise<unknown>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 describe("getMultiTurnCoachingResponse", () => {
   beforeEach(() => {
@@ -60,26 +70,93 @@ describe("getMultiTurnCoachingResponse", () => {
     expect(response.recommendations).toHaveLength(1);
   });
 
-  it("passes abort signal when provided", async () => {
+  it("propagates user abort to the generateText call", async () => {
     const session = createConversationSession("Coach prompt");
     session.addUserMessage("State", "Question");
 
-    const controller = new AbortController();
+    const userController = new AbortController();
 
     mockGenerateText.mockResolvedValueOnce({
-      output: {
-        answer: "Answer",
-        recommendations: [],
-      },
+      output: { answer: "Answer", recommendations: [] },
       usage: { inputTokens: 50, outputTokens: 20 },
     } as never);
 
     await getMultiTurnCoachingResponse(session, "test-key", {
-      signal: controller.signal,
+      signal: userController.signal,
     });
 
+    // A fresh AbortSignal is threaded through — not the user's signal directly,
+    // because we link it so internal timeouts can abort independently.
     const callArgs = mockGenerateText.mock.calls[0][0];
-    expect(callArgs.abortSignal).toBe(controller.signal);
+    const downstreamSignal = callArgs.abortSignal;
+    expect(downstreamSignal).toBeDefined();
+    expect(downstreamSignal).toBeInstanceOf(AbortSignal);
+    // Aborting the user's signal should abort the downstream signal
+    expect(downstreamSignal!.aborted).toBe(false);
+    userController.abort();
+    expect(downstreamSignal!.aborted).toBe(true);
+  });
+
+  it("falls back to attempt 2 when attempt 1 throws a non-abort error, and tags response as retried", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State", "Question");
+
+    mockGenerateText
+      .mockRejectedValueOnce(
+        new Error("No object generated: could not parse the response.")
+      )
+      .mockResolvedValueOnce({
+        output: { answer: "Retry worked", recommendations: [] },
+        usage: { inputTokens: 50, outputTokens: 20 },
+      } as never);
+
+    const response = await getMultiTurnCoachingResponse(session, "test-key");
+
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+    expect(response.answer).toBe("Retry worked");
+    expect(response.retried).toBe(true);
+  });
+
+  it("throws after both attempts fail", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State", "Question");
+
+    mockGenerateText
+      .mockRejectedValueOnce(new Error("parse fail 1"))
+      .mockRejectedValueOnce(new Error("parse fail 2"));
+
+    await expect(
+      getMultiTurnCoachingResponse(session, "test-key")
+    ).rejects.toThrow(/parse fail [12]/);
+    expect(mockGenerateText).toHaveBeenCalledTimes(2);
+  });
+
+  it("does not retry on abort errors", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State", "Question");
+
+    const abortErr = new Error("The operation was aborted.");
+    abortErr.name = "AbortError";
+    mockGenerateText.mockRejectedValueOnce(abortErr);
+
+    await expect(
+      getMultiTurnCoachingResponse(session, "test-key")
+    ).rejects.toThrow();
+    expect(mockGenerateText).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT tag as retried when attempt 1 succeeds", async () => {
+    const session = createConversationSession("Coach prompt");
+    session.addUserMessage("State", "Question");
+
+    mockGenerateText.mockResolvedValueOnce({
+      output: { answer: "Fast answer", recommendations: [] },
+      usage: { inputTokens: 100, outputTokens: 50 },
+    } as never);
+
+    const response = await getMultiTurnCoachingResponse(session, "test-key");
+
+    expect(response.retried).toBeUndefined();
   });
 
   it("includes conversation history across multiple turns", async () => {
@@ -105,5 +182,77 @@ describe("getMultiTurnCoachingResponse", () => {
     expect(messages?.[0].role).toBe("user");
     expect(messages?.[1].role).toBe("assistant");
     expect(messages?.[2].role).toBe("user");
+  });
+
+  describe("racing timeout", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("starts attempt 2 after 10s if attempt 1 still pending", async () => {
+      const session = createConversationSession("Coach prompt");
+      session.addUserMessage("State", "Question");
+
+      // Attempt 1 never resolves; attempt 2 resolves immediately
+      const deferredA = createDeferred();
+      mockGenerateText.mockReturnValueOnce(deferredA.promise as never);
+      mockGenerateText.mockResolvedValueOnce({
+        output: { answer: "From attempt 2", recommendations: [] },
+        usage: { inputTokens: 50, outputTokens: 20 },
+      } as never);
+
+      const resultPromise = getMultiTurnCoachingResponse(session, "test-key");
+
+      // Attempt 1 has started
+      expect(mockGenerateText).toHaveBeenCalledTimes(1);
+
+      // Advance past the 10s threshold
+      await vi.advanceTimersByTimeAsync(10_001);
+
+      // Attempt 2 should now be running
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+
+      const response = await resultPromise;
+      expect(response.answer).toBe("From attempt 2");
+      expect(response.retried).toBe(true);
+
+      // Clean up dangling promise
+      deferredA.resolve({
+        output: { answer: "too late", recommendations: [] },
+      });
+    });
+
+    it("returns attempt 1's response if it wins the race against attempt 2", async () => {
+      const session = createConversationSession("Coach prompt");
+      session.addUserMessage("State", "Question");
+
+      const deferredA = createDeferred();
+      const deferredB = createDeferred();
+      mockGenerateText.mockReturnValueOnce(deferredA.promise as never);
+      mockGenerateText.mockReturnValueOnce(deferredB.promise as never);
+
+      const resultPromise = getMultiTurnCoachingResponse(session, "test-key");
+      await vi.advanceTimersByTimeAsync(10_001);
+      expect(mockGenerateText).toHaveBeenCalledTimes(2);
+
+      // A resolves first
+      deferredA.resolve({
+        output: { answer: "From attempt 1", recommendations: [] },
+        usage: { inputTokens: 50, outputTokens: 20 },
+      });
+
+      const response = await resultPromise;
+      expect(response.answer).toBe("From attempt 1");
+      expect(response.retried).toBeUndefined();
+
+      // Drain B so it doesn't leak
+      deferredB.resolve({
+        output: { answer: "too late", recommendations: [] },
+      });
+    });
   });
 });

--- a/src/lib/ai/recommendation-engine.ts
+++ b/src/lib/ai/recommendation-engine.ts
@@ -3,15 +3,25 @@ import type { CoachingResponse } from "./types";
 import type { ConversationSession } from "./conversation-session";
 import { createCoachingModel, MODEL_CONFIG } from "./model-config";
 import { coachingResponseSchema } from "./schemas";
+import { raceWithRetry } from "./race-with-retry";
 import { getLogger } from "../logger";
 
 const coachingLog = getLogger("coaching:reactive");
+
+/**
+ * If attempt 1 hasn't completed within this window, a second attempt starts
+ * racing alongside it. Sized at ~2-3x normal response latency for gpt-5.4-mini.
+ */
+const SLOW_ATTEMPT_MS = 10_000;
 
 /**
  * Multi-turn coaching response using a conversation session.
  *
  * Uses the session's system prompt and message array instead of
  * rebuilding context from scratch on each call.
+ *
+ * Failure handling (#102): delegates to `raceWithRetry` so the same racing
+ * strategy is available to any other LLM call in the codebase.
  */
 export async function getMultiTurnCoachingResponse(
   session: ConversationSession,
@@ -23,38 +33,57 @@ export async function getMultiTurnCoachingResponse(
     { model: MODEL_CONFIG.id }
   );
 
-  const startMs = Date.now();
   const model = createCoachingModel(apiKey);
 
-  try {
-    const result = await generateText({
-      model,
-      system: session.systemPrompt,
-      messages: [...session.messages],
-      output: Output.object({ schema: coachingResponseSchema }),
-      maxOutputTokens: 1024,
-      ...(options?.signal ? { abortSignal: options.signal } : {}),
-    });
+  const { value, winningAttempt } = await raceWithRetry<CoachingResponse>(
+    async ({ attempt, signal }) => {
+      const startMs = Date.now();
+      const result = await generateText({
+        model,
+        system: session.systemPrompt,
+        messages: [...session.messages],
+        output: Output.object({ schema: coachingResponseSchema }),
+        maxOutputTokens: 1024,
+        abortSignal: signal,
+      });
 
-    const elapsedMs = Date.now() - startMs;
-    const usage = result.usage;
-    const recs = result.output.recommendations;
+      const elapsedMs = Date.now() - startMs;
+      const usage = result.usage;
+      const recs = result.output.recommendations;
 
-    coachingLog.info(
-      `Response (${elapsedMs}ms): ${usage.inputTokens ?? "?"}in/${usage.outputTokens ?? "?"}out`,
-      {
-        answer: result.output.answer,
-        recommendations: recs.map((r) => `${r.name} [${r.fit}]`),
-      }
-    );
+      coachingLog.info(
+        `Response (${elapsedMs}ms${attempt > 1 ? `, attempt ${attempt}` : ""}): ${usage.inputTokens ?? "?"}in/${usage.outputTokens ?? "?"}out`,
+        {
+          answer: result.output.answer,
+          recommendations: recs.map((r) => `${r.name} [${r.fit}]`),
+        }
+      );
 
-    return result.output;
-  } catch (err) {
-    const elapsedMs = Date.now() - startMs;
-    coachingLog.error("Multi-turn request failed", {
-      elapsedMs,
-      error: err instanceof Error ? err.message : String(err),
-    });
-    throw err;
-  }
+      return result.output;
+    },
+    {
+      signal: options?.signal,
+      slowAfterMs: SLOW_ATTEMPT_MS,
+      onRetryTrigger: (reason, err) => {
+        const trigger =
+          reason === "timeout"
+            ? `Attempt 1 exceeded ${SLOW_ATTEMPT_MS}ms`
+            : `Attempt 1 failed: ${err instanceof Error ? err.message : String(err)}`;
+        coachingLog.warn(
+          `[RETRY-TRIGGER] ${trigger} — racing a second attempt`
+        );
+      },
+      onRetrySuccess: () => {
+        coachingLog.info("[RETRY-SUCCESS] Attempt 2 won the race");
+      },
+      onBothFailed: (lastError) => {
+        coachingLog.error("Multi-turn request failed on both attempts", {
+          error:
+            lastError instanceof Error ? lastError.message : String(lastError),
+        });
+      },
+    }
+  );
+
+  return winningAttempt > 1 ? { ...value, retried: true } : value;
 }

--- a/src/lib/ai/types.ts
+++ b/src/lib/ai/types.ts
@@ -5,6 +5,8 @@ export interface CoachingResponse {
   answer: string;
   /** Recommendations with independent fit ratings, if applicable (augments, items, etc.) */
   recommendations: Recommendation[];
+  /** True when this response came from a silent retry after a first-attempt failure (#102) */
+  retried?: boolean;
 }
 
 export interface Recommendation {

--- a/src/lib/reactive/coaching-feed-types.ts
+++ b/src/lib/reactive/coaching-feed-types.ts
@@ -46,6 +46,8 @@ export interface CoachingExchangeEntry extends FeedEntry {
   question: string;
   answer: string;
   recommendations: CoachingRecommendation[];
+  /** True when this response came from a silent retry after a first-attempt failure (#102) */
+  retried?: boolean;
 }
 
 export interface CoachingRecommendation {

--- a/src/lib/reactive/coaching-feed.ts
+++ b/src/lib/reactive/coaching-feed.ts
@@ -89,7 +89,8 @@ export function pushCoachingExchange(
   answer: string,
   recommendations: CoachingExchangeEntry["recommendations"],
   gameTime: number,
-  source: CoachingExchangeEntry["source"] = "voice"
+  source: CoachingExchangeEntry["source"] = "voice",
+  retried = false
 ): CoachingExchangeEntry {
   const entry: CoachingExchangeEntry = {
     id: nextFeedId(),
@@ -100,6 +101,7 @@ export function pushCoachingExchange(
     question,
     answer,
     recommendations,
+    ...(retried ? { retried: true } : {}),
   };
 
   coachingFeed$.next([...coachingFeed$.getValue(), entry]);

--- a/src/overlay/CoachingStripWindow.tsx
+++ b/src/overlay/CoachingStripWindow.tsx
@@ -21,8 +21,10 @@ const FRESH_DURATION_MS = 8_000;
 /**
  * Safety timeout for thinking state — if no response arrives, stop showing "Analyzing".
  * Sized to cover one LLM call plus a silent retry on schema parse failure (#102).
+ * Kept ~2s above the badge overlay's ANALYZING_TIMEOUT_MS so the strip doesn't
+ * disappear before the badges do.
  */
-const THINKING_TIMEOUT_MS = 22_000;
+const THINKING_TIMEOUT_MS = 27_000;
 
 const MAX_FONT_SIZE = 16;
 const MIN_FONT_SIZE = 9;

--- a/src/overlay/CoachingStripWindow.tsx
+++ b/src/overlay/CoachingStripWindow.tsx
@@ -18,8 +18,11 @@ function stripMarkdown(text: string): string {
 /** How long text stays visible before dimming */
 const FRESH_DURATION_MS = 8_000;
 
-/** Safety timeout for thinking state — if no response arrives, stop showing "Analyzing" */
-const THINKING_TIMEOUT_MS = 15_000;
+/**
+ * Safety timeout for thinking state — if no response arrives, stop showing "Analyzing".
+ * Sized to cover one LLM call plus a silent retry on schema parse failure (#102).
+ */
+const THINKING_TIMEOUT_MS = 22_000;
 
 const MAX_FONT_SIZE = 16;
 const MIN_FONT_SIZE = 9;

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -18,8 +18,10 @@ const DEBUG_OVERLAY = import.meta.env.VITE_DEBUG_OVERLAY === "1";
 /**
  * Safety timeout — if no coaching response arrives, stop showing "Analyzing".
  * Sized to cover one LLM call plus a silent retry on schema parse failure (#102).
+ * Worst case: attempt 1 fails late (~12s) and attempt 2 needs ~10-12s, so give
+ * 25s of headroom before the overlay gives up and clears the cards.
  */
-const ANALYZING_TIMEOUT_MS = 20_000;
+const ANALYZING_TIMEOUT_MS = 25_000;
 
 /**
  * Root component for the overlay window. Renders augment badges and

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -15,8 +15,11 @@ const overlayLog = getLogger("overlay");
 /** Enable calibration grid + F8 screenshots via VITE_DEBUG_OVERLAY=1 */
 const DEBUG_OVERLAY = import.meta.env.VITE_DEBUG_OVERLAY === "1";
 
-/** Safety timeout — if no coaching response arrives, stop showing "Analyzing" */
-const ANALYZING_TIMEOUT_MS = 12_000;
+/**
+ * Safety timeout — if no coaching response arrives, stop showing "Analyzing".
+ * Sized to cover one LLM call plus a silent retry on schema parse failure (#102).
+ */
+const ANALYZING_TIMEOUT_MS = 20_000;
 
 /**
  * Root component for the overlay window. Renders augment badges and


### PR DESCRIPTION
## Summary

Closes #102

The LLM occasionally hangs for 20-30s without returning a response, leaving the overlay stuck on "Analyzing" and timing out with no output. Retry-on-error wasn't enough because a hanging request throws nothing.

New racing strategy:
- Attempt 1 starts immediately
- If attempt 1 throws a non-abort error, attempt 2 starts right away
- If attempt 1 is still pending at 10s, attempt 2 starts racing in parallel
- First valid response wins, loser aborted — user waits `min(attempt1, attempt2)`
- User-initiated aborts (pick/reroll) propagate to both, no retry
- Response tagged `retried: true` when attempt 2 wins → `↻ RETRIED` badge in desktop coaching card

Logic lives in a generic `raceWithRetry` helper (`src/lib/ai/race-with-retry.ts`) so any other LLM call or abortable async op can reuse it.

Overlay analyzing timeouts bumped to accommodate the retry window:
- `ANALYZING_TIMEOUT_MS` 12s → 20s
- `THINKING_TIMEOUT_MS` 15s → 22s

## Test plan

- 9 unit tests covering success, non-abort retry, both-fail, user abort, retry-tagging, and racing timer scenarios (666 tests total passing)
- Playtest confirmed: an in-game hanging LLM request triggered `[RETRY-TRIGGER] Attempt 1 exceeded 10000ms`, attempt 2 returned a valid response, `[RETRY-SUCCESS]` logged, and the `↻ retried` badge appeared in the desktop coaching card
