### PR TITLE
fix: flush overlay compositor on every hide + add clear escape hatch

### DIFF
--- a/electron/main.ts
+++ b/electron/main.ts
@@ -707,6 +707,39 @@ function registerOverlayIpc(): void {
       // Ignore — window may not be ready
     }
   });
+
+  // Overlay compositor flush — renderer requests a forced repaint after a
+  // state-hidden transition (#111). React unmounting isn't enough for
+  // ow-electron's compositor; it retains the last painted frame until an
+  // external trigger forces a flush.
+  ipcMain.on("request-overlay-flush", (_e, label: unknown) => {
+    const target =
+      label === "badge"
+        ? badgeOverlay
+        : label === "strip"
+          ? stripOverlay
+          : null;
+    if (!target?.window) return;
+    forceCompositorFlush(
+      target.window,
+      typeof label === "string" ? label : "unknown"
+    );
+  });
+
+  // Clear overlays — user-triggered escape hatch (#111). Broadcasts to
+  // every renderer so overlay state machines reset to their initial state,
+  // then flushes the compositor on both overlay windows so the DOM
+  // unmounts paint through.
+  ipcMain.on("clear-overlays", () => {
+    overlayLog.info("Clear overlays requested — broadcasting reset");
+    sendToAllWindows("clear-overlays", {});
+    if (badgeOverlay?.window) {
+      forceCompositorFlush(badgeOverlay.window, "badge");
+    }
+    if (stripOverlay?.window) {
+      forceCompositorFlush(stripOverlay.window, "strip");
+    }
+  });
 }
 
 function initOverlay(): void {
@@ -826,8 +859,31 @@ function registerOverlayHotkeys(overlayApi: any): void {
     }
   );
 
+  // Ctrl+Shift+Space — escape hatch for stuck overlays (#111). Mirrors
+  // the "Clear overlays" button in the main app window. Same flow: reset
+  // every overlay's React state and force a main-process compositor flush.
+  overlayApi.hotkeys.register(
+    {
+      name: "clear-overlays",
+      keyCode: 32, // VK_SPACE
+      modifiers: { ctrl: true, shift: true },
+      passthrough: true,
+    },
+    (_hotkey: any, state: "pressed" | "released") => {
+      if (state !== "pressed") return;
+      overlayLog.info("Ctrl+Shift+Space pressed — clearing overlays");
+      sendToAllWindows("clear-overlays", {});
+      if (badgeOverlay?.window) {
+        forceCompositorFlush(badgeOverlay.window, "badge");
+      }
+      if (stripOverlay?.window) {
+        forceCompositorFlush(stripOverlay.window, "strip");
+      }
+    }
+  );
+
   voiceLog.info(
-    "Overlay hotkeys registered: NumpadSubtract (hold-to-talk), Shift+Tab (edit mode), F8 (calibration)"
+    "Overlay hotkeys registered: NumpadSubtract (hold-to-talk), Shift+Tab (edit mode), F8 (calibration), Ctrl+Shift+Space (clear overlays)"
   );
 }
 

--- a/electron/preload.ts
+++ b/electron/preload.ts
@@ -106,4 +106,25 @@ contextBridge.exposeInMainWorld("electronAPI", {
     ipcRenderer.on("coaching-response", handler);
     return () => ipcRenderer.removeListener("coaching-response", handler);
   },
+
+  // Overlay compositor flush — renderer asks main to force the overlay
+  // window to repaint after a state-hidden transition (#111). React
+  // unmounts the DOM fine, but ow-electron's compositor retains the
+  // last-painted frame without a main-process nudge.
+  requestOverlayFlush: (label: "badge" | "strip") => {
+    ipcRenderer.send("request-overlay-flush", label);
+  },
+
+  // Clear overlays — app window or hotkey asks main to reset overlay
+  // state machines and flush. Main broadcasts `clear-overlays` to every
+  // renderer.
+  clearOverlays: () => {
+    ipcRenderer.send("clear-overlays");
+  },
+
+  onClearOverlays: (callback: () => void) => {
+    const handler = () => callback();
+    ipcRenderer.on("clear-overlays", handler);
+    return () => ipcRenderer.removeListener("clear-overlays", handler);
+  },
 });

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -21,7 +21,6 @@ import { InGameView } from "./components/InGameView";
 import { LastGameCard } from "./components/coaching";
 import { CoachingPipeline } from "./components/CoachingPipeline";
 import { ConnectionStatus } from "./components/ConnectionStatus";
-import { PersonalityToggle } from "./components/PersonalityToggle";
 import { SimulatorPanel } from "./simulator/SimulatorPanel";
 import {
   createModeRegistry,
@@ -198,8 +197,7 @@ function App() {
   if (loading && !data) {
     return (
       <main className="app-root">
-        <StatusBar isRecording={voice.isRecording} dataVersion="" />
-        <PersonalityToggle />
+        <StatusBar isRecording={voice.isRecording} />
         <div className="app-loading">Loading game data...</div>
       </main>
     );
@@ -208,8 +206,7 @@ function App() {
   if (error && !data) {
     return (
       <main className="app-root">
-        <StatusBar isRecording={voice.isRecording} dataVersion="" />
-        <PersonalityToggle />
+        <StatusBar isRecording={voice.isRecording} />
         <div className="app-error">Error: {error}</div>
       </main>
     );
@@ -219,8 +216,7 @@ function App() {
 
   return (
     <main className="app-root">
-      <StatusBar isRecording={voice.isRecording} dataVersion={data.version} />
-      <PersonalityToggle />
+      <StatusBar isRecording={voice.isRecording} />
       <CoachingProvider
         mode={detectedMode}
         liveGameState={liveGame}

--- a/src/components/ClearOverlaysButton.module.css
+++ b/src/components/ClearOverlaysButton.module.css
@@ -1,0 +1,28 @@
+.button {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.3rem;
+  background: transparent;
+  color: #8890a4;
+  border: 1px solid #2a2f3e;
+  padding: 0.15rem 0.5rem;
+  border-radius: 0.2rem;
+  cursor: pointer;
+  font-family: "JetBrains Mono", "Fira Code", monospace;
+  font-size: 0.65rem;
+  transition:
+    background 0.12s,
+    color 0.12s,
+    border-color 0.12s;
+}
+
+.button:hover {
+  background: #181c26;
+  color: #e8a0a0;
+  border-color: #6e3f3f;
+}
+
+.hint {
+  color: #4a5168;
+  font-size: 0.6rem;
+}

--- a/src/components/ClearOverlaysButton.tsx
+++ b/src/components/ClearOverlaysButton.tsx
@@ -1,0 +1,29 @@
+import { useCallback } from "react";
+import { getLogger } from "../lib/logger";
+import styles from "./ClearOverlaysButton.module.css";
+
+const appLog = getLogger("app");
+
+/**
+ * Escape hatch for stuck overlays (#111). Sends the `clear-overlays`
+ * IPC to the main process, which broadcasts a reset to every overlay
+ * window and forces a compositor flush. Global Ctrl+Shift+Space does
+ * the same thing via the ow-electron hotkey bridge.
+ */
+export function ClearOverlaysButton() {
+  const handleClick = useCallback(() => {
+    appLog.info("Clear overlays button clicked");
+    window.electronAPI?.clearOverlays();
+  }, []);
+
+  return (
+    <button
+      type="button"
+      className={styles.button}
+      onClick={handleClick}
+      title="Reset overlay state and force repaint (Ctrl+Shift+Space)"
+    >
+      Clear overlays
+    </button>
+  );
+}

--- a/src/components/PersonalityToggle.module.css
+++ b/src/components/PersonalityToggle.module.css
@@ -1,13 +1,9 @@
 .toggle {
-  display: flex;
+  display: inline-flex;
   align-items: center;
-  gap: 0.5rem;
-  padding: 0.35rem 0.6rem;
-  background: #12151c;
-  border-bottom: 1px solid #2a2f3e;
+  gap: 0.35rem;
   font-family: "JetBrains Mono", "Fira Code", monospace;
   font-size: 0.65rem;
-  flex-shrink: 0;
 }
 
 .label {
@@ -17,15 +13,15 @@
 }
 
 .buttons {
-  display: flex;
-  gap: 0.25rem;
+  display: inline-flex;
+  gap: 0.2rem;
 }
 
 .button {
   background: transparent;
   color: #8890a4;
   border: 1px solid #2a2f3e;
-  padding: 0.2rem 0.5rem;
+  padding: 0.15rem 0.45rem;
   border-radius: 0.2rem;
   cursor: pointer;
   font: inherit;

--- a/src/components/StatusBar.tsx
+++ b/src/components/StatusBar.tsx
@@ -1,13 +1,14 @@
 import { useLiveGameState } from "../hooks/useLiveGameState";
 import { useGameLifecycle } from "../hooks/useGameLifecycle";
+import { PersonalityToggle } from "./PersonalityToggle";
+import { ClearOverlaysButton } from "./ClearOverlaysButton";
 import styles from "./StatusBar.module.css";
 
 interface StatusBarProps {
   isRecording: boolean;
-  dataVersion: string;
 }
 
-export function StatusBar({ isRecording, dataVersion }: StatusBarProps) {
+export function StatusBar({ isRecording }: StatusBarProps) {
   const liveGame = useLiveGameState();
   const { event: lifecycle } = useGameLifecycle();
 
@@ -43,13 +44,9 @@ export function StatusBar({ isRecording, dataVersion }: StatusBarProps) {
         )}
       </div>
       <div className={styles.right}>
-        <span className={styles.muted}>
-          {isConnected ? "Connected" : "Disconnected"}
-        </span>
+        <PersonalityToggle />
         <span className={styles.sep}>|</span>
-        <span className={styles.muted} title="League of Legends patch version">
-          v{dataVersion}
-        </span>
+        <ClearOverlaysButton />
         <span className={styles.sep}>|</span>
         <VoiceIndicator isRecording={isRecording} />
       </div>

--- a/src/hooks/__tests__/useVoiceInput.test.ts
+++ b/src/hooks/__tests__/useVoiceInput.test.ts
@@ -48,6 +48,9 @@ beforeEach(() => {
     onCoachingRequest: vi.fn(() => () => {}),
     sendCoachingResponse: vi.fn(),
     onCoachingResponse: vi.fn(() => () => {}),
+    requestOverlayFlush: vi.fn(),
+    clearOverlays: vi.fn(),
+    onClearOverlays: vi.fn(() => () => {}),
   };
 });
 
@@ -83,6 +86,9 @@ describe("useVoiceInput", () => {
       onCoachingRequest: vi.fn(() => () => {}),
       sendCoachingResponse: vi.fn(),
       onCoachingResponse: vi.fn(() => () => {}),
+      requestOverlayFlush: vi.fn(),
+      clearOverlays: vi.fn(),
+      onClearOverlays: vi.fn(() => () => {}),
     };
   });
 

--- a/src/lib/reactive/electron-bridge.ts
+++ b/src/lib/reactive/electron-bridge.ts
@@ -23,6 +23,9 @@ interface ElectronAPI {
   onCoachingRequest(callback: () => void): () => void;
   sendCoachingResponse(data: unknown): void;
   onCoachingResponse(callback: (data: unknown) => void): () => void;
+  requestOverlayFlush(label: "badge" | "strip"): void;
+  clearOverlays(): void;
+  onClearOverlays(callback: () => void): () => void;
 }
 
 declare global {

--- a/src/overlay/CoachingStripWindow.tsx
+++ b/src/overlay/CoachingStripWindow.tsx
@@ -135,6 +135,32 @@ export function CoachingStripWindow() {
     return () => unlisten();
   }, []);
 
+  // Manual clear from app window or hotkey (#111 safety valve). Resets
+  // every visible-state flag to its baseline so the strip hides; main
+  // process fires `forceCompositorFlush` on broadcast of this IPC.
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onClearOverlays) return;
+
+    const unlisten = api.onClearOverlays(() => {
+      stripLog.info("Clear overlays — resetting strip state");
+      setText("");
+      setThinking(false);
+      setVisible(false);
+      setFresh(false);
+      if (freshTimerRef.current) {
+        clearTimeout(freshTimerRef.current);
+        freshTimerRef.current = null;
+      }
+      if (thinkingTimerRef.current) {
+        clearTimeout(thinkingTimerRef.current);
+        thinkingTimerRef.current = null;
+      }
+    });
+
+    return () => unlisten();
+  }, []);
+
   // Log significant state changes (thinking/visible transitions, not hover)
   useEffect(() => {
     stripLog.debug(

--- a/src/overlay/OverlayApp.tsx
+++ b/src/overlay/OverlayApp.tsx
@@ -68,6 +68,7 @@ export function OverlayApp() {
           clearTimeout(analyzingTimerRef.current);
           analyzingTimerRef.current = null;
         }
+        window.electronAPI?.requestOverlayFlush("badge");
       }
     });
 
@@ -80,6 +81,13 @@ export function OverlayApp() {
   // a compositor layer routes through the same paint path as a real DOM
   // change. Call after any state transition that changes what should be
   // visible. (#98)
+  //
+  // Pairs with `requestOverlayFlush` for state-hidden transitions — the
+  // React-side nudge alone isn't enough to dislodge the last-painted
+  // frame from ow-electron's compositor; the main-process flush
+  // (`forceCompositorFlush` in electron/main.ts) is what actually
+  // guarantees the window repaints when offer/coaching go back to null
+  // (#111).
   const forcePaintNudge = useCallback(() => {
     requestAnimationFrame(() => {
       const root = document.getElementById("overlay-root");
@@ -90,6 +98,33 @@ export function OverlayApp() {
       });
     });
   }, []);
+
+  const requestMainFlush = useCallback(() => {
+    window.electronAPI?.requestOverlayFlush("badge");
+  }, []);
+
+  // Manual clear from app window or hotkey (#111 safety valve). Resets
+  // state to the hidden baseline and nudges the compositor. Main process
+  // already triggers `forceCompositorFlush` on broadcast of this IPC, so
+  // the renderer only needs the React-side state reset + paint nudge.
+  useEffect(() => {
+    const api = window.electronAPI;
+    if (!api?.onClearOverlays) return;
+
+    const unlisten = api.onClearOverlays(() => {
+      overlayLog.info("Clear overlays — resetting badge state");
+      offerNamesRef.current = null;
+      setAugmentOffer(null);
+      setCoachingData(null);
+      if (analyzingTimerRef.current) {
+        clearTimeout(analyzingTimerRef.current);
+        analyzingTimerRef.current = null;
+      }
+      forcePaintNudge();
+    });
+
+    return () => unlisten();
+  }, [forcePaintNudge]);
 
   // Listen for coaching responses relayed from desktop window
   useEffect(() => {
@@ -189,9 +224,10 @@ export function OverlayApp() {
         setAugmentOffer(null);
         setCoachingData(null);
         forcePaintNudge();
+        requestMainFlush();
       }, ANALYZING_TIMEOUT_MS);
     },
-    [forcePaintNudge]
+    [forcePaintNudge, requestMainFlush]
   );
 
   const handleAugmentPicked = useCallback(() => {
@@ -204,7 +240,8 @@ export function OverlayApp() {
       analyzingTimerRef.current = null;
     }
     forcePaintNudge();
-  }, [forcePaintNudge]);
+    requestMainFlush();
+  }, [forcePaintNudge, requestMainFlush]);
 
   // Log state changes for debugging stale badge issues.
   // This is what determines whether "Analyzing" or actual badges render —


### PR DESCRIPTION
## Summary

Closes #111.

Fixes the stuck augment-badge overlay after a pick (and its variants after analyzing-timeout and game-exit), and adds a user-facing escape hatch for any future overlay that gets stuck.

## Root cause

`forceCompositorFlush` in `electron/main.ts` is the only thing that actually forces an ow-electron overlay window to repaint. Before this PR it was wired to exactly one renderer event: `coaching-response` with `source === "augment"`. That meant the strip got flushed on every coaching response and the badges got flushed only when new coaching arrived *for* the badges. Pick events, analyzing timeouts, and game-exit transitioned the React state to hidden and unmounted the DOM — but the compositor retained the last-painted frame because nothing in those paths reached the main process.

Previous attempts on this issue stayed on the renderer side and added more DOM paint nudges. The actual gap was in the IPC wiring between renderer and main.

## Changes

### Primary fix — compositor flush on every hide

- **New IPC `request-overlay-flush`** — renderer asks main to run `forceCompositorFlush` on a named overlay window (`badge` or `strip`).
- **`OverlayApp.tsx`** calls it in all three hide paths: augment pick, analyzing timeout, game-exit.
- React-side `forcePaintNudge` is retained alongside it — the two are defense in depth. Renderer nudge handles the DOM-layer paint; main flush handles the compositor.

### Safety valve — manual clear

- **New IPC `clear-overlays`** — app window or hotkey sends to main. Main broadcasts `clear-overlays` to every renderer AND force-flushes both overlay windows.
- **`OverlayApp.tsx`** and **`CoachingStripWindow.tsx`** listen and reset every piece of visible state to the hidden baseline.
- **`ClearOverlaysButton`** component added to `StatusBar` right side (replaces the standalone row).
- **Global hotkey Ctrl+Shift+Space** registered via `overlayApi.hotkeys` with the same pattern as the existing NumpadSubtract / Shift+Tab / F8 hotkeys (keyCode 32 + `{ ctrl: true, shift: true }`).

### Status-bar cleanup

- Personality toggle and the new Clear Overlays button moved into `StatusBar`'s right side (formerly three separate stacked rows — one row now).
- Dropped the redundant "Connected" / "Disconnected" text — the green/grey dot already conveys connection state.
- Dropped the `v{dataVersion}` display — the patch version is already shown inside `LastGameCard` alongside the champion/item/augment counts.

## Acceptance criteria status

- [x] Badge overlay reliably unmounts when state transitions to `hidden`
- [x] App window has a visible "Clear overlays" control
- [x] A global hotkey (Ctrl+Shift+Space) clears all overlay windows immediately
- [x] The clear action resets the overlay state machine to its initial (hidden) state without requiring a new GEP event
- [x] Works for both augment-badges overlay and coaching-strip overlay

## Notes

Playtest-confirmed: badges no longer persist after a pick. The "Clear overlays" button and Ctrl+Shift+Space both exercise the same broadcast + flush path as belt-and-suspenders.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "Clear Overlays" button with Ctrl+Shift+Space hotkey to reset overlay display
  * Improved overlay rendering refresh mechanism to prevent stuck frames

* **Bug Fixes**
  * Enhanced overlay state management and compositor repaint handling

* **Style**
  * Removed personality toggle from main interface
  * Updated status bar layout with new button placement

<!-- end of auto-generated comment: release notes by coderabbit.ai -->