### PR TITLE
fix: route item-rec voice queries + harden format compliance

### DIFF
--- a/src/components/CoachingPipeline.tsx
+++ b/src/components/CoachingPipeline.tsx
@@ -25,6 +25,7 @@ import {
   augmentFitFeature,
   type AugmentFitResult,
 } from "../lib/ai/features/augment-fit";
+import { isItemRecQuestion, itemRecFeature } from "../lib/ai/features/item-rec";
 import { voiceQueryFeature } from "../lib/ai/features/voice-query";
 import { useCoachingContext } from "../hooks/useCoachingContext";
 import { useLiveGameState } from "../hooks/useLiveGameState";
@@ -465,11 +466,25 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
       window.electronAPI?.sendCoachingRequest();
 
       try {
-        const { value: response, retried } = await sessionRef.current.ask(
-          voiceQueryFeature,
-          { snapshot, question },
-          { signal: options?.signal }
+        // Route item-purchase questions to itemRecFeature so its prompt's
+        // destination+component format rule applies (#113). Strategic /
+        // positional / mechanical questions stay on voiceQueryFeature.
+        const useItemRec = isItemRecQuestion(trimmedQuestion);
+        proactiveLog.info(
+          `Voice question routing: "${trimmedQuestion}" → ${useItemRec ? "itemRec" : "voiceQuery"}`
         );
+        const askResult = useItemRec
+          ? await sessionRef.current.ask(
+              itemRecFeature,
+              { snapshot, question },
+              { signal: options?.signal }
+            )
+          : await sessionRef.current.ask(
+              voiceQueryFeature,
+              { snapshot, question },
+              { signal: options?.signal }
+            );
+        const { value: response, retried } = askResult;
 
         const gameTime = liveGameStateRef.current.gameTime;
         pushCoachingExchange(

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -372,12 +372,19 @@ interface MultiTurnFixture {
   query: {
     question: string;
     history?: Array<{ question: string; answer: string }>;
-    augmentOptions?: Array<{
-      name: string;
-      description: string;
-      tier: string;
-      sets?: string[];
-    }>;
+    // Accepts two shapes. Full objects carry metadata the augment-fit
+    // feature doesn't actually consume (the user message rehydrates from
+    // `gameData.augments.get(name)`), so lightweight string-form fixtures
+    // are valid for tests that only need names (e.g. re-roll tracking).
+    augmentOptions?: Array<
+      | string
+      | {
+          name: string;
+          description: string;
+          tier: string;
+          sets?: string[];
+        }
+    >;
   };
   response: {
     answer: string;
@@ -498,7 +505,9 @@ function classifyFixture(
       kind: "augment-fit",
       input: {
         snapshot,
-        augmentNames: f.query.augmentOptions.map((o) => o.name),
+        augmentNames: f.query.augmentOptions.map((o) =>
+          typeof o === "string" ? o : o.name
+        ),
         chosenAugments: f.chosenAugments,
         gameData,
       },

--- a/src/lib/ai/coaching.eval.ts
+++ b/src/lib/ai/coaching.eval.ts
@@ -51,6 +51,12 @@ import {
   type GamePlanResult,
 } from "./features/game-plan";
 import {
+  isItemRecQuestion,
+  itemRecFeature,
+  type ItemRecInput,
+  type ItemRecResult,
+} from "./features/item-rec";
+import {
   voiceQueryFeature,
   type VoiceQueryInput,
   type VoiceQueryResult,
@@ -468,10 +474,16 @@ function buildFixtureState(f: MultiTurnFixture): {
 /**
  * Pick the feature that owns this fixture and build its typed input.
  *
- * Today's fixtures cover augment-offer calls and open-ended voice queries.
- * Game-plan and item-rec classifications are wired up but not exercised by
- * the current fixture set — they're here so new fixtures pick up the right
- * feature automatically.
+ * Classification order is load-bearing and must mirror production routing
+ * in `CoachingPipeline.tsx`:
+ *   1. `augment-fit` — augment offer context outranks anything else.
+ *   2. `game-plan` — the "update game plan" voice command.
+ *   3. `item-rec` — questions about buying/building items (#113).
+ *   4. `voice-query` — everything else: strategic, positional, mechanical.
+ *
+ * Today's fixtures cover augment-offer calls, item-rec questions, and
+ * open-ended voice queries. Game-plan is wired up but not exercised by the
+ * current fixture set.
  */
 function classifyFixture(
   f: MultiTurnFixture,
@@ -479,6 +491,7 @@ function classifyFixture(
 ):
   | { kind: "augment-fit"; input: AugmentFitInput }
   | { kind: "game-plan"; input: GamePlanInput }
+  | { kind: "item-rec"; input: ItemRecInput }
   | { kind: "voice-query"; input: VoiceQueryInput } {
   if (f.query.augmentOptions && f.query.augmentOptions.length >= 2) {
     return {
@@ -497,6 +510,12 @@ function classifyFixture(
       input: { snapshot },
     };
   }
+  if (isItemRecQuestion(f.query.question)) {
+    return {
+      kind: "item-rec",
+      input: { snapshot, question: f.query.question },
+    };
+  }
   return {
     kind: "voice-query",
     input: { snapshot, question: f.query.question },
@@ -505,8 +524,8 @@ function classifyFixture(
 
 /** Boundary normalize per-feature results to the shared EvalOutput shape. */
 function normalize(
-  kind: "augment-fit" | "game-plan" | "voice-query",
-  result: AugmentFitResult | GamePlanResult | VoiceQueryResult
+  kind: "augment-fit" | "game-plan" | "item-rec" | "voice-query",
+  result: AugmentFitResult | GamePlanResult | ItemRecResult | VoiceQueryResult
 ): EvalOutput {
   if (kind === "augment-fit") {
     const r = result as AugmentFitResult;
@@ -527,6 +546,14 @@ function normalize(
         reasoning: item.reason,
       })),
       buildPath: r.buildPath,
+    };
+  }
+  if (kind === "item-rec") {
+    const r = result as ItemRecResult;
+    return {
+      answer: r.answer,
+      recommendations: r.recommendations,
+      buildPath: [],
     };
   }
   const r = result as VoiceQueryResult;
@@ -578,6 +605,10 @@ function buildEvalInput(f: MultiTurnFixture): EvalInput {
         classification.input
       );
       return normalize("game-plan", value);
+    }
+    if (classification.kind === "item-rec") {
+      const { value } = await session.ask(itemRecFeature, classification.input);
+      return normalize("item-rec", value);
     }
     const { value } = await session.ask(
       voiceQueryFeature,

--- a/src/lib/ai/features/item-rec/index.ts
+++ b/src/lib/ai/features/item-rec/index.ts
@@ -27,3 +27,36 @@ export const itemRecFeature: CoachingFeature<ItemRecInput, ItemRecResult> = {
 
   summarizeForHistory: (result) => result.answer,
 };
+
+/**
+ * Classifier for the item-rec routing gate (#113).
+ *
+ * Two-clause match:
+ *
+ * 1. **Item-intent signal** — one of the words that's reliably about
+ *    buying/building items (`item(s)`, `build(s)`/`building`, `buy(s)`/`buying`,
+ *    `purchase`/`purchasing`, `rush`/`rushing`). The tense/number variants
+ *    matter: past-tense `built` intentionally doesn't match, since "I just
+ *    built my boots" is a statement, not a request for a recommendation.
+ * 2. **Question shape** — either a `?` suffix OR a leading wh-word / modal /
+ *    auxiliary. Whisper occasionally drops terminal punctuation, so we can't
+ *    rely on `?` alone. Requiring question shape rules out statements of
+ *    fact that mention build/item words ("I'm building my lead.").
+ *
+ * Both clauses must hold — the keyword alone has too many false positives,
+ * and the shape alone misses item questions. The combination nails the
+ * failing fixture set from #113 without bleeding into strategic, positional,
+ * or mechanical questions.
+ */
+const ITEM_INTENT_PATTERN =
+  /\b(items?|builds?|building|buy(?:ing|s)?|purchas(?:e|es|ing)|rush(?:ing|es)?)\b/i;
+const QUESTION_SHAPE_PATTERN =
+  /\?\s*$|^\s*(what|which|should|do|does|did|am|are|is|can|could|would|will)\b/i;
+
+export function isItemRecQuestion(text: string): boolean {
+  const trimmed = text.trim();
+  if (!trimmed) return false;
+  return (
+    ITEM_INTENT_PATTERN.test(trimmed) && QUESTION_SHAPE_PATTERN.test(trimmed)
+  );
+}

--- a/src/lib/ai/features/item-rec/is-item-rec-question.test.ts
+++ b/src/lib/ai/features/item-rec/is-item-rec-question.test.ts
@@ -1,0 +1,62 @@
+import { describe, it, expect } from "vitest";
+import { isItemRecQuestion } from "./index";
+
+describe("isItemRecQuestion", () => {
+  describe("matches item-purchase questions", () => {
+    const hits = [
+      // Failing fixtures from #113 eval regression
+      "What's my next item?",
+      "Should I still be building tank items?",
+      "What item should I buy?",
+      "Still building Spirit Visage?",
+      "What item do I need?",
+      "Same build?",
+      "What should I build next?",
+      // Other natural item-rec phrasings
+      "What should I buy?",
+      "What do I buy next?",
+      "Do I build tank or damage?",
+      "What's a good item for this matchup?",
+      "Should I rush Zhonya's?",
+      "What builds work on Yasuo?",
+      // Whisper sometimes drops terminal punctuation
+      "what item do I need",
+      "what should I build next",
+      // Case-insensitive
+      "WHAT ITEM SHOULD I BUY?",
+    ];
+    for (const phrase of hits) {
+      it(`matches "${phrase}"`, () => {
+        expect(isItemRecQuestion(phrase)).toBe(true);
+      });
+    }
+  });
+
+  describe("does not match strategic, positional, or mechanical questions", () => {
+    const misses = [
+      "Who should I focus?",
+      "Should I go dragon?",
+      "Am I winning lane?",
+      "What's the plan?",
+      "Should I push or farm?",
+      "When do I all-in?",
+      "How do I play this matchup?",
+      "Can you coach me on trading?",
+      "What's my power spike?",
+      // Statements of fact mentioning item words — not questions
+      "I just built my boots.",
+      "I'm building my lead.",
+      "Rush Zhonya's",
+      // "Update game plan" command — routed earlier by isUpdatePlanCommand
+      "Update game plan",
+      // Empty / whitespace
+      "",
+      "   ",
+    ];
+    for (const phrase of misses) {
+      it(`does not match "${phrase}"`, () => {
+        expect(isItemRecQuestion(phrase)).toBe(false);
+      });
+    }
+  });
+});

--- a/src/lib/ai/features/item-rec/prompt.ts
+++ b/src/lib/ai/features/item-rec/prompt.ts
@@ -1,13 +1,16 @@
 /**
  * Task prompt for item-rec feature.
  *
- * Enforces the destination + component item-purchase format, adds proactive
- * awareness for grievous-wounds / MR / resistance gaps, and treats the item
- * pool as a curated viable set (not a build order). This block is appended
- * to the base context on every item-rec LLM call.
+ * Enforces the destination + component item-purchase format on EVERY
+ * response, adds proactive awareness for grievous-wounds / MR / resistance
+ * gaps, and treats the item pool as a curated viable set (not a build
+ * order). This block is appended to the base context on every item-rec
+ * LLM call. The routing layer (`isItemRecQuestion`) only sends item-purchase
+ * questions here, so the universal format rule is safe — non-item queries
+ * don't reach this feature.
  */
 export const ITEM_REC_TASK_PROMPT = [
-  "ITEM RECOMMENDATIONS: When recommending an item purchase, always name the destination (completed) item AND a buildable component. If the player can afford a component: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford. If no component is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold. For non-purchase responses (strategy, positioning, augments), just name items naturally without this format.",
+  "ITEM RECOMMENDATIONS: Every response must name a destination (completed) item AND a buildable component — no exceptions. This applies equally to fresh recommendations, yes/no confirmations ('keep building tank'), clarifications, follow-ups, corrections, and replies to player pushback or frustration. If the player asks for more specificity or challenges a prior answer, respond with an updated destination+component, not a conversational explanation. Format: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod now.' If not affordable: 'Build toward Rabadon's Deathcap. You can get a Needlessly Large Rod at 1250g.' Name the most expensive component the player can currently afford; if none is affordable, name the cheapest and its gold threshold. Never recommend unrelated filler items just to spend gold.",
   "",
   "PROACTIVE AWARENESS: Before answering any item question, check the enemy team composition. If the enemy has heavy healing (Soraka, Aatrox, Yuumi, Warwick, Dr. Mundo), mention grievous wounds. If 3+ enemies deal magic damage, mention magic resist. If you notice other build gaps (missing resistances, unusually high unspent gold), flag them briefly.",
   "",

--- a/src/lib/ai/index.ts
+++ b/src/lib/ai/index.ts
@@ -26,6 +26,7 @@ export {
   type AugmentFitResult,
 } from "./features/augment-fit";
 export {
+  isItemRecQuestion,
   itemRecFeature,
   type ItemRecInput,
   type ItemRecResult,


### PR DESCRIPTION
## Summary

Closes #113.

Routes voice queries asking what to buy/build to `itemRecFeature` so its destination+component prompt rule applies, hardens that prompt so the rule survives clarification and pushback, and fixes an unrelated eval crash surfaced during verification.

## Commits

1. **`fix: route item-purchase voice queries to itemRecFeature`**
   - New `isItemRecQuestion(text)` predicate in `src/lib/ai/features/item-rec/index.ts`. Two-clause match: item-intent keyword (`item(s)`, `build(s)/building`, `buy(ing/s)`, `purchase/ing`, `rush(ing/es)`) AND question shape (trailing `?` OR leading wh-word/modal). Both required — single-clause matching false-positives on statements like "I'm building my lead."
   - 31 classifier tests covering every failing fixture from the issue plus strategic/positional/mechanical negatives.
   - Eval classifier (`coaching.eval.ts`) and production routing (`CoachingPipeline.tsx`) both consult the predicate in lockstep so eval and prod stay aligned.

2. **`fix: accept string-form augmentOptions in eval fixtures`**
   - Three synthetic re-roll fixtures in `synthetic-multiturn-scorers.json` use `augmentOptions: string[]` while the type declared `Array<{ name, description, tier, ... }>`. Crashed every eval run at `augment-fit/index.ts:29` (`Cannot read properties of undefined (reading 'toLowerCase')`).
   - Widened `MultiTurnFixture.augmentOptions` to accept either shape and normalized extraction: `typeof o === "string" ? o : o.name`. Full-object fixtures still work.

3. **`fix: require destination+component format on every item-rec response`**
   - Original prompt said "when recommending an item purchase" — which the model interpreted as "fresh recommendations only," not yes/no confirmations, clarifications, or pushback responses. Since routing now only sends item-purchase questions to this feature, the format rule can apply universally.
   - Rewritten to: "Every response must name a destination (completed) item AND a buildable component — no exceptions. This applies equally to fresh recommendations, yes/no confirmations ('keep building tank'), clarifications, follow-ups, corrections, and replies to player pushback or frustration."

## Eval evidence

`Gold-Aware Recommendations` across runs (same fixtures, same model `openai/gpt-5.4-mini`, only code changes between runs):

| Run | Common | Mayhem | SR | Notes |
|---|---|---|---|---|
| 89 | 69% | 91% | 67% | Pre-#112 baseline (monolithic prompt) |
| 90 | 55% | 87% | 100% | Post-#112 — regression reported in #113 |
| 100 | 62% | 94% (n=31) | 100% | Commit 1 — routing wired, 3 fixtures still crashed |
| 101 | 55% | 94% (n=34) | 100% | Commit 2 — crashes fixed, all 79 fixtures run |
| 102 | **71%** | 97% | 100% | Commit 3 — prompt hardened |
| 103 | **69%** | 94% | 100% | Same prompt — variance check |

Runs 100/101 (no code change between them) showed ±7 non-determinism noise. Runs 102/103 (no code change between them) showed a 2-point spread — tighter variance, both above or at the run-89 baseline. The prompt change moved the Common Gold-Aware mean from ~58% to ~70% — a +12 shift that dwarfs the ±3 within-prompt variance.

Every other scorer stayed ≥93% across all three new commits. No regressions.

## Acceptance criteria status

- [x] Voice queries asking what to buy/build route to `itemRecFeature`
- [x] Strategic/positional/mechanical voice queries continue to route to `voiceQueryFeature`
- [x] Item-question fixtures return the destination+component format
- [x] `Gold-Aware Recommendations` on Common recovers (run 102: 71%, run 103: 69%, both ≥ the 69% run-89 baseline)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coaching system now intelligently detects item-purchase-related questions and routes them to a specialized recommendation feature for improved accuracy and relevance.

* **Tests**
  * Added comprehensive unit tests for the new question classification system, covering various question phrasings, case variations, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->