### PR TITLE
Distinguish remakes from defeats across surfaces and aggregates

### DIFF
--- a/docs/reference/technical-reference.md
+++ b/docs/reference/technical-reference.md
@@ -172,6 +172,17 @@ Available at the `PreEndOfGame` phase transition (immediately when the nexus die
 - Player summoner names are sometimes empty
 - KDA/stats per player (not in the eog-stats-block — only available from the Live Client Data API during the game)
 
+### Remake detection (`gameEndedInEarlySurrender`)
+
+A remade game (a player fails to connect, the team votes to void the match near the 3-minute mark) is a third outcome, neither a win nor a loss. Two LCU sources expose it:
+
+- **eog-stats-block:** `gameEndedInEarlySurrender` is a top-level boolean. A remade game also has `isWinningTeam: false` for every team, so deriving win/loss from `isWinningTeam` alone mis-labels a remake as a loss.
+- **match-history:** remade games DO appear in `/lol-match-history` (verified by direct LCU query). The flag lives per-participant at `participants[].stats.gameEndedInEarlySurrender`. `gameDuration` is short (~150s observed) but is the only other tell.
+
+Do NOT confuse this with `gameEndedInSurrender`, the normal 15:00+ forfeit. That still records a real win or loss and must stay win/loss. The app-side phase timing (InProgress to WaitingForStats) reads ~3:00 for a remake because it includes the post-nexus wait; that is not the real game length, so do not use duration as a remake heuristic. Use the flag.
+
+The app models the outcome as the `GameResult` union (`win` | `loss` | `remake`) in `src/lib/game-result.ts`; `deriveGameResult()` maps the two flags. Remakes are excluded from win/loss and KDA aggregates (`windowStats`) and never trigger the post-game takeaway LLM call.
+
 ### Game mode internal names
 
 | Display name    | Live Client Data API `gameMode` | LCU `gameMode` | Live Client `mapNumber` | Constant           |
@@ -642,18 +653,18 @@ Phase 5a's persistent coach decision log records every `coaching-response` IPC p
 
 ### SWR scoped cache provider — global `mutate` misses it
 
-`<SWRConfig value={{ provider }}>` creates a *scoped* cache. The package-level `mutate` exported from `swr` only operates on SWR's *default* (unscoped) cache, so calling it does nothing visible when a custom provider is in play — the fetch never fires, the hook never revalidates, and there is no error.
+`<SWRConfig value={{ provider }}>` creates a _scoped_ cache. The package-level `mutate` exported from `swr` only operates on SWR's _default_ (unscoped) cache, so calling it does nothing visible when a custom provider is in play — the fetch never fires, the hook never revalidates, and there is no error.
 
 - **Symptom:** an invalidation trigger runs (logs confirm it), but the `useSWR` consumer never re-fetches.
-- **Fix:** the provider-scoped mutator is only reachable via `useSWRConfig().mutate` *inside* the `<SWRConfig>` subtree. Non-React engine code (RxJS store subscriptions) can't call a hook, so `src/lib/cache/swr-bridge.ts` holds a module-level ref: a tiny `<SWRBridge />` component calls `setScopedMutate(useSWRConfig().mutate)` in an effect, and engine code calls `invalidateKey(...)`. Invalidations issued before the bridge mounts are queued and drained on registration.
+- **Fix:** the provider-scoped mutator is only reachable via `useSWRConfig().mutate` _inside_ the `<SWRConfig>` subtree. Non-React engine code (RxJS store subscriptions) can't call a hook, so `src/lib/cache/swr-bridge.ts` holds a module-level ref: a tiny `<SWRBridge />` component calls `setScopedMutate(useSWRConfig().mutate)` in an effect, and engine code calls `invalidateKey(...)`. Invalidations issued before the bridge mounts are queued and drained on registration.
 - **React Fast Refresh caveat:** HMR can hot-swap a component's definition without the new JSX ever entering the live tree, so a freshly-added `<SWRBridge />` may not actually render until a full reload. Dev-only; a hard refresh fixes it. Production mounts the tree once and is unaffected.
 
 ### SWR side effects: fetcher body runs before the cache commits
 
-A side effect placed at the end of a `useSWR` fetcher runs *before* SWR writes the resolved value into its cache. Anything that reads the cache immediately after (a readiness gate, another hook) sees stale data.
+A side effect placed at the end of a `useSWR` fetcher runs _before_ SWR writes the resolved value into its cache. Anything that reads the cache immediately after (a readiness gate, another hook) sees stale data.
 
 - **Observed (#129):** `markMatchesRefreshed()` called inside `fetchMatches` flipped a "data is ready" gate while `useMatchHistory().matches` still held the previous fetch — the post-game surface revealed with the prior game's match row.
-- **Fix:** move the side effect to SWR's `onSuccess` config callback. `onSuccess` fires *after* the cache is committed, so every consumer reading the cache in the render that follows sees the new value.
+- **Fix:** move the side effect to SWR's `onSuccess` config callback. `onSuccess` fires _after_ the cache is committed, so every consumer reading the cache in the render that follows sees the new value.
 
 ### LCU lockfile appears seconds before the HTTPS server binds
 
@@ -666,6 +677,6 @@ The LCU lockfile (and thus credentials) becomes readable several seconds before 
 
 When a game ends, the gameflow phase moves to `WaitingForStats`/`PreEndOfGame`/`EndOfGame` — and `resolveSurface` auto-routes to the post-game surface on that signal. `liveGameState.activePlayer` clears separately, ~500ms+ later.
 
-- **Consequence:** a hide gate keyed off `activePlayer` clearing engages *after* the surface has already mounted and rendered cached (previous-game) data — a visible flash.
-- **Fix:** `post-game-readiness.ts` flips `postGameReady$` to `false` on the phase transition into a post-game phase (subscribed via `wirePostGameReadiness`), so the surface mounts already gated. It flips back to `true` only once *both* the in-memory snapshot and the match-history fetch are fresh for the just-ended game; a 15s failsafe forces reveal if a signal never lands.
+- **Consequence:** a hide gate keyed off `activePlayer` clearing engages _after_ the surface has already mounted and rendered cached (previous-game) data — a visible flash.
+- **Fix:** `post-game-readiness.ts` flips `postGameReady$` to `false` on the phase transition into a post-game phase (subscribed via `wirePostGameReadiness`), so the surface mounts already gated. It flips back to `true` only once _both_ the in-memory snapshot and the match-history fetch are fresh for the just-ended game; a 15s failsafe forces reveal if a signal never lands.
 - **Display must be pinned to the snapshot's gameId:** `PostGameSurface` scopes its records filter and match-history row lookup to `snapshot.gameId`. When `focusGameId` is known, never substitute another game's match row (e.g. `recentGames(1)[0]`) — return `undefined` and let `mergeMeta` fall back to the takeaway/snapshot champion, which is the same game.

--- a/src/components/CoachingPipeline.tsx
+++ b/src/components/CoachingPipeline.tsx
@@ -321,6 +321,13 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
     // A remade game (player failed to connect, game voided near the
     // 3-minute mark) has nothing worth coaching on. Skip the takeaway
     // LLM call entirely; the game still records elsewhere as a remake.
+    //
+    // When `eog` times out (the LCU never surfaced the stats block
+    // within the wait window) we also skip: without an authoritative
+    // result we cannot tell a remake from a real loss, and writing a
+    // takeaway with a guessed `isWin: false` poisons the on-disk
+    // decision log with a record that contradicts match history once
+    // it lands.
     const isRemake = eog?.result === "remake";
     if (
       takeawayEnabled &&
@@ -329,6 +336,7 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
       lastState.activePlayer &&
       hasActivity &&
       sessionGameIdGuard &&
+      eog !== null &&
       !isRemake
     ) {
       const championName =

--- a/src/components/CoachingPipeline.tsx
+++ b/src/components/CoachingPipeline.tsx
@@ -258,7 +258,7 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
     const activeInfo = lastState.players.find((p) => p.isActivePlayer);
     if (eog === null) {
       proactiveLog.warn(
-        "Game-end reached without eogStats within timeout; isWin will fall back to last-known sources"
+        "Game-end reached without eogStats within timeout; result will fall back to last-known sources"
       );
     }
 
@@ -277,7 +277,7 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
         activeInfo?.championName ??
         lastState.activePlayer?.championName ??
         "Unknown",
-      isWin: eog?.isWin ?? false,
+      result: eog?.result ?? "loss",
       kills: activeInfo?.kills ?? 0,
       deaths: activeInfo?.deaths ?? 0,
       assists: activeInfo?.assists ?? 0,
@@ -318,13 +318,18 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
     // takeaway would collapse onto the same empty-string key in the
     // decision log and conflate unrelated games — skip instead.
     const sessionGameIdGuard = gameSessionIdRef.current;
+    // A remade game (player failed to connect, game voided near the
+    // 3-minute mark) has nothing worth coaching on. Skip the takeaway
+    // LLM call entirely; the game still records elsewhere as a remake.
+    const isRemake = eog?.result === "remake";
     if (
       takeawayEnabled &&
       apiKey &&
       lastInGameMode &&
       lastState.activePlayer &&
       hasActivity &&
-      sessionGameIdGuard
+      sessionGameIdGuard &&
+      !isRemake
     ) {
       const championName =
         activeInfo?.championName ??
@@ -346,7 +351,7 @@ export function CoachingPipeline({ gameData }: CoachingPipelineProps) {
       const takeawayInput: PostGameTakeawayInput = {
         champion: championName,
         gameMode: lastState.gameMode || eog?.gameMode || "",
-        isWin: eog?.isWin ?? false,
+        isWin: eog?.result === "win",
         duration: eog?.gameLength ?? lastState.gameTime,
         kills: activeInfo?.kills ?? 0,
         deaths: activeInfo?.deaths ?? 0,

--- a/src/components/InGameView.tsx
+++ b/src/components/InGameView.tsx
@@ -5,6 +5,7 @@ import { EnemyStrip } from "./EnemyStrip";
 import { useCoachingFeed } from "../hooks/useCoachingFeed";
 import { useGamePlan } from "../hooks/useGamePlan";
 import { useLastGameMeta } from "../hooks/useLastGameMeta";
+import { resultLabel } from "../lib/game-result";
 import styles from "./InGameView.module.css";
 
 interface InGameViewProps {
@@ -62,8 +63,8 @@ export function InGameView({ state, gameData }: InGameViewProps) {
           {lastGame.championName ? (
             <span className={styles.endedMeta}>
               {lastGame.championName}
-              {lastGame.isWin !== null
-                ? ` · ${lastGame.isWin ? "win" : "loss"}`
+              {lastGame.result !== null
+                ? ` · ${resultLabel(lastGame.result).toLowerCase()}`
                 : ""}
             </span>
           ) : null}

--- a/src/hooks/__tests__/useMatchHistory.test.ts
+++ b/src/hooks/__tests__/useMatchHistory.test.ts
@@ -23,7 +23,7 @@ const sampleMatch: MatchSummary = {
   championId: 99,
   gameMode: "ARAM",
   queueId: 450,
-  isWin: true,
+  result: "win",
   kills: 12,
   deaths: 4,
   assists: 18,
@@ -47,7 +47,7 @@ function wrapper({ children }: { children: ReactNode }) {
         shouldRetryOnError: false,
       },
     },
-    children,
+    children
   );
 }
 
@@ -89,7 +89,7 @@ describe("useMatchHistory", () => {
             shouldRetryOnError: false,
           },
         },
-        children,
+        children
       );
     }
 
@@ -108,7 +108,7 @@ describe("useMatchHistory", () => {
       () =>
         new Promise<MatchSummary[]>((r) => {
           resolve = r;
-        }),
+        })
     );
 
     // Use the provider-scoped mutate (the global `mutate` from "swr"
@@ -118,7 +118,7 @@ describe("useMatchHistory", () => {
         history: useMatchHistory(),
         mutate: useSWRConfig().mutate,
       }),
-      { wrapper },
+      { wrapper }
     );
 
     expect(result.current.history.isValidating).toBe(false);

--- a/src/hooks/__tests__/useMatchHistory.test.ts
+++ b/src/hooks/__tests__/useMatchHistory.test.ts
@@ -17,21 +17,23 @@ vi.mock("../../lib/match-history/runtime", () => ({
   getMatchHistoryStore: () => mockStore,
 }));
 
-const sampleMatch: MatchSummary = {
-  gameId: "1234567890",
-  championName: "Lux",
-  championId: 99,
-  gameMode: "ARAM",
-  queueId: 450,
-  result: "win",
-  kills: 12,
-  deaths: 4,
-  assists: 18,
-  largestKillingSpree: 3,
-  durationSeconds: 1634,
-  gameCreation: 1_700_000_000_000,
-  finalItems: [],
-};
+function createSampleMatch(): MatchSummary {
+  return {
+    gameId: "1234567890",
+    championName: "Lux",
+    championId: 99,
+    gameMode: "ARAM",
+    queueId: 450,
+    result: "win",
+    kills: 12,
+    deaths: 4,
+    assists: 18,
+    largestKillingSpree: 3,
+    durationSeconds: 1634,
+    gameCreation: 1_700_000_000_000,
+    finalItems: [],
+  };
+}
 
 function wrapper({ children }: { children: ReactNode }) {
   return createElement(
@@ -54,7 +56,7 @@ function wrapper({ children }: { children: ReactNode }) {
 describe("useMatchHistory", () => {
   beforeEach(() => {
     mockStore = {
-      fetchMatches: vi.fn().mockResolvedValue([sampleMatch]),
+      fetchMatches: vi.fn().mockResolvedValue([createSampleMatch()]),
       dispose: vi.fn(),
     };
   });
@@ -74,7 +76,7 @@ describe("useMatchHistory", () => {
   it("renders cached matches on first render with no fetch and no validating state", async () => {
     function wrapperWithCache({ children }: { children: ReactNode }) {
       const cache = new Map<string, unknown>([
-        ["match-history", { data: [sampleMatch] }],
+        ["match-history", { data: [createSampleMatch()] }],
       ]);
       return createElement(
         SWRConfig,
@@ -97,7 +99,7 @@ describe("useMatchHistory", () => {
       wrapper: wrapperWithCache,
     });
 
-    expect(result.current.matches).toEqual([sampleMatch]);
+    expect(result.current.matches).toEqual([createSampleMatch()]);
     expect(result.current.isValidating).toBe(false);
     expect(mockStore.fetchMatches).not.toHaveBeenCalled();
   });
@@ -132,13 +134,13 @@ describe("useMatchHistory", () => {
     });
 
     act(() => {
-      resolve([sampleMatch]);
+      resolve([createSampleMatch()]);
     });
 
     await waitFor(() => {
       expect(result.current.history.isValidating).toBe(false);
     });
-    expect(result.current.history.matches).toEqual([sampleMatch]);
+    expect(result.current.history.matches).toEqual([createSampleMatch()]);
   });
 
   it("exposes windowStats and recentGames convenience wrappers", () => {

--- a/src/hooks/useLastGameMeta.test.ts
+++ b/src/hooks/useLastGameMeta.test.ts
@@ -1,0 +1,99 @@
+import { describe, it, expect } from "vitest";
+import { mergeMeta } from "./useLastGameMeta";
+import type { MatchSummary } from "../lib/match-history/types";
+import type { TakeawayDecision } from "../lib/decision-log/types";
+import type { LastGameSnapshot } from "../lib/reactive/coaching-feed-types";
+
+function matchSummary(overrides: Partial<MatchSummary> = {}): MatchSummary {
+  return {
+    gameId: "G1",
+    championName: "Lux",
+    championId: 99,
+    gameMode: "ARAM",
+    queueId: 450,
+    result: "win",
+    kills: 10,
+    deaths: 5,
+    assists: 15,
+    largestKillingSpree: 2,
+    finalItems: [],
+    durationSeconds: 1500,
+    gameCreation: 1_700_000_000_000,
+    ...overrides,
+  };
+}
+
+function takeaway(overrides: Partial<TakeawayDecision> = {}): TakeawayDecision {
+  return {
+    id: "T1",
+    gameId: "G1",
+    gameMode: "ARAM",
+    sentAt: 1_700_000_000_000,
+    retried: false,
+    schemaVersion: 1,
+    source: "takeaway",
+    narrative: "A game happened.",
+    champion: "Lux",
+    isWin: true,
+    duration: 1500,
+    kills: 10,
+    deaths: 5,
+    assists: 15,
+    finalGold: 12000,
+    finalItems: [],
+    recommendedBuild: [],
+    matchedItemCount: 0,
+    ...overrides,
+  };
+}
+
+function snapshot(overrides: Partial<LastGameSnapshot> = {}): LastGameSnapshot {
+  return {
+    gameId: "G1",
+    championName: "Lux",
+    result: "win",
+    kills: 10,
+    deaths: 5,
+    assists: 15,
+    gameTime: 1500,
+    gameMode: "ARAM",
+    items: [],
+    augments: [],
+    recentExchanges: [],
+    ...overrides,
+  };
+}
+
+describe("mergeMeta result resolution", () => {
+  it("resolves a remade match-history record to a remake result", () => {
+    const meta = mergeMeta(matchSummary({ result: "remake" }), null, null);
+    expect(meta.result).toBe("remake");
+  });
+
+  it("lets match-history win over both the takeaway and the snapshot", () => {
+    const meta = mergeMeta(
+      matchSummary({ result: "loss" }),
+      takeaway({ isWin: true }),
+      snapshot({ result: "win" })
+    );
+    expect(meta.result).toBe("loss");
+  });
+
+  it("bridges the takeaway's boolean isWin when no match record exists", () => {
+    expect(mergeMeta(undefined, takeaway({ isWin: true }), null).result).toBe(
+      "win"
+    );
+    expect(mergeMeta(undefined, takeaway({ isWin: false }), null).result).toBe(
+      "loss"
+    );
+  });
+
+  it("falls back to the snapshot result when it is the only source", () => {
+    const meta = mergeMeta(undefined, null, snapshot({ result: "remake" }));
+    expect(meta.result).toBe("remake");
+  });
+
+  it("resolves result to null when every source is absent", () => {
+    expect(mergeMeta(undefined, null, null).result).toBeNull();
+  });
+});

--- a/src/hooks/useLastGameMeta.ts
+++ b/src/hooks/useLastGameMeta.ts
@@ -5,6 +5,7 @@ import { useDecisionLogQuery } from "./useDecisionLogQuery";
 import type { TakeawayDecision } from "../lib/decision-log/types";
 import type { MatchSummary } from "../lib/match-history/types";
 import type { LastGameSnapshot } from "../lib/reactive/coaching-feed-types";
+import type { GameResult } from "../lib/game-result";
 
 /**
  * Resolved metadata for the just-finished (or currently-being-viewed)
@@ -24,11 +25,11 @@ import type { LastGameSnapshot } from "../lib/reactive/coaching-feed-types";
  *
  * Each field falls back independently so partial sources still
  * contribute something useful — e.g. match-history landing first
- * supplies isWin / mode while we wait for the takeaway.
+ * supplies result / mode while we wait for the takeaway.
  */
 export interface LastGameMeta {
   championName: string | null;
-  isWin: boolean | null;
+  result: GameResult | null;
   /** Coarse mode label, NOT formatted for display (caller normalises). */
   gameMode: string | null;
   kills: number | null;
@@ -80,7 +81,14 @@ export function mergeMeta(
       takeaway?.champion ??
       snapshot?.championName ??
       null,
-    isWin: match?.isWin ?? takeaway?.isWin ?? snapshot?.isWin ?? null,
+    // TakeawayDecision still carries a boolean `isWin`: a takeaway is
+    // only ever written for a coached win/loss game, never a remake, so
+    // it can only contribute "win" or "loss" here.
+    result:
+      match?.result ??
+      (takeaway ? (takeaway.isWin ? "win" : "loss") : undefined) ??
+      snapshot?.result ??
+      null,
     gameMode:
       match?.gameMode ?? takeaway?.gameMode ?? snapshot?.gameMode ?? null,
     kills: match?.kills ?? takeaway?.kills ?? snapshot?.kills ?? null,

--- a/src/lib/game-result.ts
+++ b/src/lib/game-result.ts
@@ -1,0 +1,45 @@
+/**
+ * The outcome of a League match as the app models it.
+ *
+ * `remake` is a third state, distinct from a loss. When a player fails
+ * to connect, their team can vote to void the game at roughly the
+ * 3-minute mark. The LCU reports this via `gameEndedInEarlySurrender`
+ * (a per-participant field in match history, a top-level field in the
+ * end-of-game stats block). A remade game carries no win/loss record
+ * and awards no rewards, so it must never be folded into win/loss
+ * display or into win/loss/KDA aggregates.
+ *
+ * Note: a remake is NOT the same as a normal surrender. A team that
+ * forfeits at 15:00+ produces `gameEndedInSurrender` and still records
+ * a real win or loss, which stays `win` / `loss` here.
+ */
+export type GameResult = "win" | "loss" | "remake";
+
+/**
+ * Derive the {@link GameResult} from the two LCU signals.
+ *
+ * `gameEndedInEarlySurrender` takes precedence: a remade game has no
+ * winning team, so its `win` flag is meaningless (false for everyone).
+ */
+export function deriveGameResult(
+  win: boolean,
+  gameEndedInEarlySurrender: boolean
+): GameResult {
+  if (gameEndedInEarlySurrender) return "remake";
+  return win ? "win" : "loss";
+}
+
+/**
+ * Capitalised display label for a {@link GameResult}. Callers adjust
+ * casing for their surface (the post-game eyebrow uppercases it).
+ */
+export function resultLabel(result: GameResult): string {
+  switch (result) {
+    case "win":
+      return "Win";
+    case "loss":
+      return "Loss";
+    case "remake":
+      return "Remake";
+  }
+}

--- a/src/lib/match-history/aggregate.test.ts
+++ b/src/lib/match-history/aggregate.test.ts
@@ -12,7 +12,7 @@ function match(overrides: Partial<MatchSummary> = {}): MatchSummary {
     championId: 99,
     gameMode: "ARAM",
     queueId: 450,
-    isWin: true,
+    result: "win",
     kills: 10,
     deaths: 5,
     assists: 15,
@@ -40,14 +40,57 @@ describe("windowStats", () => {
 
   it("counts wins and losses inside the window", () => {
     const matches = [
-      match({ gameId: "G1", isWin: true, gameCreation: NOW - 1 * DAY }),
-      match({ gameId: "G2", isWin: false, gameCreation: NOW - 2 * DAY }),
-      match({ gameId: "G3", isWin: true, gameCreation: NOW - 3 * DAY }),
+      match({ gameId: "G1", result: "win", gameCreation: NOW - 1 * DAY }),
+      match({ gameId: "G2", result: "loss", gameCreation: NOW - 2 * DAY }),
+      match({ gameId: "G3", result: "win", gameCreation: NOW - 3 * DAY }),
     ];
     const s = windowStats(matches, { days: 7, now: NOW });
     expect(s.totalGames).toBe(3);
     expect(s.wins).toBe(2);
     expect(s.losses).toBe(1);
+  });
+
+  it("excludes remade games from totals, win/loss counts, and KDA", () => {
+    const matches = [
+      match({
+        gameId: "W",
+        result: "win",
+        kills: 10,
+        deaths: 5,
+        assists: 5,
+        gameCreation: NOW - 1 * DAY,
+      }),
+      match({
+        gameId: "R",
+        result: "remake",
+        kills: 7,
+        deaths: 2,
+        assists: 3,
+        gameCreation: NOW - 2 * DAY,
+      }),
+    ];
+    const s = windowStats(matches, { days: 7, now: NOW });
+    expect(s.totalGames).toBe(1);
+    expect(s.wins).toBe(1);
+    expect(s.losses).toBe(0);
+    expect(s.totalKills).toBe(10);
+    expect(s.avgKDA).toBeCloseTo(3); // (10+5)/5, the remake not averaged in
+  });
+
+  it("returns zero stats when the window contains only remakes", () => {
+    const s = windowStats(
+      [match({ result: "remake", gameCreation: NOW - 1 * DAY })],
+      { days: 7, now: NOW }
+    );
+    expect(s).toEqual({
+      totalGames: 0,
+      wins: 0,
+      losses: 0,
+      avgKDA: 0,
+      totalKills: 0,
+      totalDeaths: 0,
+      totalAssists: 0,
+    });
   });
 
   it("ignores matches outside the day window", () => {

--- a/src/lib/match-history/aggregate.ts
+++ b/src/lib/match-history/aggregate.ts
@@ -20,7 +20,11 @@ export function windowStats(
 ): WindowStats {
   const days = options.days ?? 7;
   const cutoff = options.now - days * DAY_MS;
-  const inWindow = matches.filter((m) => m.gameCreation >= cutoff);
+  // A remade game is voided: it carries no win/loss record. Drop it
+  // before tallying so it never skews the W/L count or the KDA average.
+  const inWindow = matches.filter(
+    (m) => m.gameCreation >= cutoff && m.result !== "remake"
+  );
 
   if (inWindow.length === 0) {
     return {
@@ -41,7 +45,7 @@ export function windowStats(
   let kdaSum = 0;
 
   for (const m of inWindow) {
-    if (m.isWin) wins += 1;
+    if (m.result === "win") wins += 1;
     totalKills += m.kills;
     totalDeaths += m.deaths;
     totalAssists += m.assists;

--- a/src/lib/match-history/parse.test.ts
+++ b/src/lib/match-history/parse.test.ts
@@ -38,7 +38,7 @@ describe("lcuMatchToSummary", () => {
     expect(m?.championId).toBe(99);
     expect(m?.gameMode).toBe("ARAM");
     expect(m?.queueId).toBe(450);
-    expect(m?.isWin).toBe(true);
+    expect(m?.result).toBe("win");
     expect(m?.kills).toBe(12);
     expect(m?.deaths).toBe(4);
     expect(m?.assists).toBe(18);
@@ -119,7 +119,39 @@ describe("lcuMatchToSummary", () => {
     expect(m?.kills).toBe(0);
     expect(m?.deaths).toBe(0);
     expect(m?.assists).toBe(0);
-    expect(m?.isWin).toBe(false);
+    expect(m?.result).toBe("loss");
+  });
+
+  it("marks result as remake when the game ended in early surrender", () => {
+    const m = lcuMatchToSummary(
+      {
+        ...fullPayload,
+        participants: [
+          {
+            championId: 99,
+            stats: { win: false, gameEndedInEarlySurrender: true },
+          },
+        ],
+      },
+      resolver
+    );
+    expect(m?.result).toBe("remake");
+  });
+
+  it("treats a normal (non-early) surrender as a real loss, not a remake", () => {
+    const m = lcuMatchToSummary(
+      {
+        ...fullPayload,
+        participants: [
+          {
+            championId: 99,
+            stats: { win: false, gameEndedInSurrender: true },
+          },
+        ],
+      },
+      resolver
+    );
+    expect(m?.result).toBe("loss");
   });
 
   it("handles numeric gameId by stringifying it", () => {

--- a/src/lib/match-history/parse.ts
+++ b/src/lib/match-history/parse.ts
@@ -1,4 +1,5 @@
 import type { MatchSummary } from "./types";
+import { deriveGameResult } from "../game-result";
 
 /**
  * Subset of the LCU /lol-match-history match payload we read. The real
@@ -11,6 +12,13 @@ interface LcuMatchParticipant {
   championId?: number;
   stats?: {
     win?: boolean;
+    /**
+     * True when the game was remade (a player failed to connect, the
+     * team voided it near the 3-minute mark). Distinct from
+     * `gameEndedInSurrender`, a normal 15:00+ forfeit that still
+     * records a real win or loss.
+     */
+    gameEndedInEarlySurrender?: boolean;
     kills?: number;
     deaths?: number;
     assists?: number;
@@ -112,7 +120,10 @@ export function lcuMatchToSummary(
     gameMode,
     queueId,
     finalItems,
-    isWin: stats.win === true,
+    result: deriveGameResult(
+      stats.win === true,
+      stats.gameEndedInEarlySurrender === true
+    ),
     kills: typeof stats.kills === "number" ? stats.kills : 0,
     deaths: typeof stats.deaths === "number" ? stats.deaths : 0,
     assists: typeof stats.assists === "number" ? stats.assists : 0,

--- a/src/lib/match-history/types.ts
+++ b/src/lib/match-history/types.ts
@@ -1,3 +1,5 @@
+import type { GameResult } from "../game-result";
+
 /**
  * Stable internal shape for one match in the player's history. The LCU's
  * raw payload is normalized through `parse.ts` into this shape so callers
@@ -14,8 +16,8 @@ export interface MatchSummary {
   gameMode: string;
   /** Specific Riot queueId (e.g. 450 = ARAM) — useful when modes alone are coarse. */
   queueId: number;
-  /** True iff the player won this match. */
-  isWin: boolean;
+  /** Win, loss, or remake (a voided game; never counts as win/loss). */
+  result: GameResult;
   kills: number;
   deaths: number;
   assists: number;

--- a/src/lib/reactive/coaching-feed-types.ts
+++ b/src/lib/reactive/coaching-feed-types.ts
@@ -8,6 +8,7 @@
  */
 
 import type { BuildPathItem, FitRating } from "../ai/types";
+import type { GameResult } from "../game-result";
 
 /** Base fields shared by all feed entries */
 export interface FeedEntry {
@@ -71,7 +72,7 @@ export interface LastGameSnapshot {
    */
   gameId: string | null;
   championName: string;
-  isWin: boolean;
+  result: GameResult;
   kills: number;
   deaths: number;
   assists: number;

--- a/src/lib/reactive/coaching-feed.test.ts
+++ b/src/lib/reactive/coaching-feed.test.ts
@@ -148,7 +148,7 @@ describe("captureLastGameSnapshot", () => {
     captureLastGameSnapshot({
       gameId: "test-game-1",
       championName: "Katarina",
-      isWin: true,
+      result: "win",
       kills: 12,
       deaths: 4,
       assists: 15,
@@ -171,7 +171,7 @@ describe("captureLastGameSnapshot", () => {
     const snapshot = lastGameSnapshot$.getValue();
     expect(snapshot).not.toBeNull();
     expect(snapshot!.championName).toBe("Katarina");
-    expect(snapshot!.isWin).toBe(true);
+    expect(snapshot!.result).toBe("win");
     expect(snapshot!.items).toHaveLength(6);
     expect(snapshot!.recentExchanges).toHaveLength(1);
   });
@@ -184,7 +184,7 @@ describe("resetForNewGame", () => {
     captureLastGameSnapshot({
       gameId: "test-game-1",
       championName: "Katarina",
-      isWin: true,
+      result: "win",
       kills: 8,
       deaths: 3,
       assists: 12,

--- a/src/lib/reactive/debug-filters.test.ts
+++ b/src/lib/reactive/debug-filters.test.ts
@@ -182,7 +182,7 @@ describe("hasGameStateChangedMeaningfully", () => {
         gameId: "1",
         gameLength: 600,
         gameMode: "ARAM",
-        isWin: true,
+        result: "win",
         championId: 1,
         items: [],
       },

--- a/src/lib/reactive/debug-summarizers.test.ts
+++ b/src/lib/reactive/debug-summarizers.test.ts
@@ -327,6 +327,20 @@ describe("summarizeLiveGameState", () => {
     ).toBe("EOG: LOSS | CHERRY | 15:00");
   });
 
+  it("shows EOG remake", () => {
+    const eogStats: EogStats = {
+      gameId: "789",
+      gameLength: 151,
+      gameMode: "ARAM",
+      result: "remake",
+      championId: 266,
+      items: [],
+    };
+    expect(
+      summarizeLiveGameState(createDefaultLiveGameState({ eogStats }))
+    ).toBe("EOG: REMAKE | ARAM | 2:31");
+  });
+
   it("shows champion, level, time, mode, and player count", () => {
     const state = createDefaultLiveGameState({
       activePlayer: createActivePlayer({

--- a/src/lib/reactive/debug-summarizers.test.ts
+++ b/src/lib/reactive/debug-summarizers.test.ts
@@ -5,6 +5,7 @@ import {
   summarizeUserInput,
 } from "./debug-summarizers";
 import type {
+  EogStats,
   GameLifecycleEvent,
   LiveGameState,
   UserInputEvent,
@@ -299,11 +300,11 @@ describe("summarizeLiveGameState", () => {
   });
 
   it("shows EOG with game mode and duration", () => {
-    const eogStats = {
+    const eogStats: EogStats = {
       gameId: "123",
       gameLength: 1200,
       gameMode: "ARAM",
-      isWin: true,
+      result: "win",
       championId: 103,
       items: [3089],
     };
@@ -313,11 +314,11 @@ describe("summarizeLiveGameState", () => {
   });
 
   it("shows EOG loss", () => {
-    const eogStats = {
+    const eogStats: EogStats = {
       gameId: "456",
       gameLength: 900,
       gameMode: "CHERRY",
-      isWin: false,
+      result: "loss",
       championId: 222,
       items: [],
     };

--- a/src/lib/reactive/debug-summarizers.ts
+++ b/src/lib/reactive/debug-summarizers.ts
@@ -179,7 +179,7 @@ function summarizeChampSelect(champSelect: unknown): string {
 /** Summarize end-of-game stats with useful detail. */
 function summarizeEog(state: LiveGameState): string {
   const eog = state.eogStats!;
-  const parts = [eog.isWin ? "WIN" : "LOSS"];
+  const parts = [eog.result.toUpperCase()];
 
   if (eog.gameMode) parts.push(eog.gameMode);
   if (eog.gameLength > 0) parts.push(formatGameTime(eog.gameLength));

--- a/src/lib/reactive/engine.test.ts
+++ b/src/lib/reactive/engine.test.ts
@@ -918,11 +918,11 @@ describe("ReactiveEngine", () => {
       const state = liveGameState$.getValue();
       expect(state.eogStats).not.toBeNull();
       expect(state.eogStats?.gameId).toBe("67890");
-      expect(state.eogStats?.isWin).toBe(true);
+      expect(state.eogStats?.result).toBe("win");
       expect(state.eogStats?.championId).toBe(86);
     });
 
-    it("returns isWin based on the player's team, not teams[0]", async () => {
+    it("returns result based on the player's team, not teams[0]", async () => {
       bridge.setLcuAvailable(12345, "secret");
       bridge.setRiotApiResponse(createRiotApiResponse({ gameTime: 300 }));
       bridge.setFetchLcuResponse({
@@ -955,7 +955,42 @@ describe("ReactiveEngine", () => {
       await vi.advanceTimersByTimeAsync(0);
 
       const state = liveGameState$.getValue();
-      expect(state.eogStats?.isWin).toBe(true);
+      expect(state.eogStats?.result).toBe("win");
+    });
+
+    it("marks result as remake when gameEndedInEarlySurrender is true", async () => {
+      bridge.setLcuAvailable(12345, "secret");
+      bridge.setRiotApiResponse(createRiotApiResponse({ gameTime: 151 }));
+      // A remade game: no team wins, and the LCU flags the early
+      // surrender at the top level of the eog-stats-block.
+      bridge.setFetchLcuResponse({
+        gameId: "70001",
+        gameLength: 151,
+        gameMode: "CLASSIC",
+        gameEndedInEarlySurrender: true,
+        teams: [
+          { isWinningTeam: false, isPlayerTeam: true },
+          { isWinningTeam: false, isPlayerTeam: false },
+        ],
+        localPlayer: { championId: 86, stats: { ITEM0: 1001 } },
+      });
+      engine.start();
+      await vi.advanceTimersByTimeAsync(0);
+
+      bridge.simulateLcuEvent({
+        uri: "/lol-gameflow/v1/gameflow-phase",
+        event_type: "Update",
+        data: "InProgress",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+      bridge.simulateLcuEvent({
+        uri: "/lol-gameflow/v1/gameflow-phase",
+        event_type: "Update",
+        data: "PreEndOfGame",
+      });
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(liveGameState$.getValue().eogStats?.result).toBe("remake");
     });
 
     it("handles EOG fetch failure gracefully", async () => {

--- a/src/lib/reactive/engine.ts
+++ b/src/lib/reactive/engine.ts
@@ -28,6 +28,7 @@ import {
   gameEnded$,
 } from "./streams";
 import { normalizeGameState, extractMapNumber } from "../game-state/normalize";
+import { deriveGameResult } from "../game-result";
 import { resetForNewGame } from "./coaching-feed";
 import type { PlatformBridge, LcuEventPayload } from "./platform-bridge";
 import type {
@@ -90,6 +91,10 @@ function parseEogStats(raw: Record<string, unknown>): EogStats {
   // ordering in the LCU payload does not match the player's team.
   const playerTeam = teams?.find((t) => t.isPlayerTeam);
   const isWin = playerTeam?.isWinningTeam ?? false;
+  // A remade game (early surrender near the 3-minute mark) has no
+  // winning team, so `isWinningTeam` is false for everyone. The LCU
+  // flags it separately at the top level of the eog-stats-block.
+  const gameEndedInEarlySurrender = raw.gameEndedInEarlySurrender === true;
 
   // Extract item IDs from stats (ITEM0..ITEM6), filtering out 0s
   const items: number[] = [];
@@ -106,7 +111,7 @@ function parseEogStats(raw: Record<string, unknown>): EogStats {
     gameId: String(raw.gameId ?? ""),
     gameLength: Number(raw.gameLength ?? 0),
     gameMode: String(raw.gameMode ?? ""),
-    isWin,
+    result: deriveGameResult(isWin, gameEndedInEarlySurrender),
     championId: localPlayer?.championId ?? 0,
     items,
   };
@@ -331,11 +336,16 @@ export class ReactiveEngine {
           )
         )
         .subscribe((evt) => {
+          // The eog-stats-block serializes its fields alphabetically, so
+          // the result-bearing top-level keys (gameEndedInEarlySurrender,
+          // gameId, gameMode) sit well past 200 chars. Keep enough to log
+          // every top-level scalar without dumping the huge team/player
+          // arrays that come later.
           engineLog.info(`Post-game event: ${evt.uri}`, {
             data:
               typeof evt.data === "string"
                 ? evt.data
-                : JSON.stringify(evt.data)?.slice(0, 200),
+                : JSON.stringify(evt.data)?.slice(0, 2000),
           });
         })
     );

--- a/src/lib/reactive/types.ts
+++ b/src/lib/reactive/types.ts
@@ -1,5 +1,6 @@
 import type { ActivePlayer, PlayerInfo } from "../game-state/types";
 import type { Augment } from "../data-ingest/types";
+import type { GameResult } from "../game-result";
 
 // Gameflow phases from LCU API
 export type GameflowPhase =
@@ -92,7 +93,7 @@ export interface EogStats {
   gameId: string;
   gameLength: number;
   gameMode: string;
-  isWin: boolean;
+  result: GameResult;
   championId: number;
   items: number[];
 }

--- a/src/lib/reactive/wait-for-eog-stats.test.ts
+++ b/src/lib/reactive/wait-for-eog-stats.test.ts
@@ -25,7 +25,7 @@ function makeEog(overrides: Partial<EogStats> = {}): EogStats {
     gameId: "abc",
     gameLength: 1500,
     gameMode: "ARAM",
-    isWin: true,
+    result: "win",
     championId: 99,
     items: [],
     ...overrides,
@@ -42,7 +42,7 @@ afterEach(() => {
 
 describe("waitForEogStats", () => {
   it("resolves immediately when the stream already carries eogStats", async () => {
-    const eog = makeEog({ isWin: true });
+    const eog = makeEog({ result: "win" });
     const live$ = new BehaviorSubject<LiveGameState>(
       makeLiveGameState({ eogStats: eog })
     );
@@ -61,7 +61,7 @@ describe("waitForEogStats", () => {
     await vi.advanceTimersByTimeAsync(0);
     expect(seen).toEqual([]);
 
-    const eog = makeEog({ isWin: false });
+    const eog = makeEog({ result: "loss" });
     live$.next(makeLiveGameState({ eogStats: eog }));
     await vi.advanceTimersByTimeAsync(0);
     expect(seen).toEqual([eog]);
@@ -110,7 +110,7 @@ describe("waitForEogStats", () => {
     expect(seen).toEqual([eog]);
     expect(completed).toBe(true);
 
-    live$.next(makeLiveGameState({ eogStats: makeEog({ isWin: false }) }));
+    live$.next(makeLiveGameState({ eogStats: makeEog({ result: "loss" }) }));
     await vi.advanceTimersByTimeAsync(0);
     expect(seen).toEqual([eog]);
   });

--- a/src/lib/reactive/wait-for-eog-stats.ts
+++ b/src/lib/reactive/wait-for-eog-stats.ts
@@ -5,7 +5,7 @@
  * Why this exists: the LCU emits `/lol-end-of-game/v1/eog-stats-block`
  * a few hundred milliseconds AFTER `activePlayer` becomes null at game
  * end. The post-game-takeaway pipeline (and the last-game snapshot
- * capture) need the authoritative `isWin` from the eog payload — using
+ * capture) need the authoritative `result` from the eog payload — using
  * the synchronous `liveGameState.eogStats` at the activePlayer-null
  * transition reads as `null` and stamps every match as a defeat.
  *

--- a/src/simulator/SimulatorPanel.tsx
+++ b/src/simulator/SimulatorPanel.tsx
@@ -10,6 +10,7 @@
 import { useState, useRef } from "react";
 import type { LoadedGameData } from "../lib/data-ingest";
 import type { LiveGameState } from "../lib/reactive/types";
+import type { GameResult } from "../lib/game-result";
 import { liveGameState$ } from "../lib/reactive/streams";
 import { augmentOffer$, augmentPicked$ } from "../lib/reactive/gep-bridge";
 import { playerIntent$ } from "../lib/reactive/streams";
@@ -89,11 +90,11 @@ export function SimulatorPanel({ gameData }: SimulatorPanelProps) {
     liveGameState$.next(updated);
   }
 
-  function endGame(win: boolean) {
+  function endGame(result: GameResult) {
     if (!currentStateRef.current) return;
 
     const eog = createMockEogStats({
-      isWin: win,
+      result,
       championName: champion,
       gameLength: gameTime,
       gameMode,
@@ -266,15 +267,18 @@ export function SimulatorPanel({ gameData }: SimulatorPanelProps) {
               </button>
               <button
                 className={styles.btnPrimary}
-                onClick={() => endGame(true)}
+                onClick={() => endGame("win")}
               >
                 Win
               </button>
               <button
                 className={styles.btnDanger}
-                onClick={() => endGame(false)}
+                onClick={() => endGame("loss")}
               >
                 Defeat
+              </button>
+              <button className={styles.btn} onClick={() => endGame("remake")}>
+                Remake
               </button>
             </>
           )}

--- a/src/simulator/mock-state.test.ts
+++ b/src/simulator/mock-state.test.ts
@@ -176,24 +176,32 @@ describe("createMockGameState", () => {
 describe("createMockEogStats", () => {
   it("creates EOG stats with win/loss", () => {
     const eog = createMockEogStats({
-      isWin: true,
+      result: "win",
       championName: "Ahri",
     });
     expect(eog).not.toBeNull();
-    expect(eog!.isWin).toBe(true);
+    expect(eog!.result).toBe("win");
   });
 
   it("creates EOG stats with defeat", () => {
     const eog = createMockEogStats({
-      isWin: false,
+      result: "loss",
       championName: "Ahri",
     });
-    expect(eog!.isWin).toBe(false);
+    expect(eog!.result).toBe("loss");
+  });
+
+  it("creates EOG stats for a remake", () => {
+    const eog = createMockEogStats({
+      result: "remake",
+      championName: "Ahri",
+    });
+    expect(eog!.result).toBe("remake");
   });
 
   it("uses provided game length", () => {
     const eog = createMockEogStats({
-      isWin: true,
+      result: "win",
       championName: "Ahri",
       gameLength: 1800,
     });
@@ -202,7 +210,7 @@ describe("createMockEogStats", () => {
 
   it("defaults game length to 1200 seconds", () => {
     const eog = createMockEogStats({
-      isWin: true,
+      result: "win",
       championName: "Ahri",
     });
     expect(eog!.gameLength).toBe(1200);

--- a/src/simulator/mock-state.ts
+++ b/src/simulator/mock-state.ts
@@ -6,6 +6,7 @@
  */
 
 import type { LiveGameState, EogStats } from "../lib/reactive/types";
+import type { GameResult } from "../lib/game-result";
 import type { ActivePlayerStats, PlayerInfo } from "../lib/game-state/types";
 import type { LoadedGameData } from "../lib/data-ingest";
 import type { ChampionStats } from "../lib/data-ingest/types";
@@ -22,7 +23,7 @@ export interface MockGameOptions {
 }
 
 export interface MockEogOptions {
-  isWin: boolean;
+  result: GameResult;
   championName: string;
   gameLength?: number;
   gameMode?: string;
@@ -179,7 +180,7 @@ export function createMockEogStats(options: MockEogOptions): EogStats {
     gameId: `mock-${Date.now()}`,
     gameLength: options.gameLength ?? 1200,
     gameMode: options.gameMode ?? "ARAM",
-    isWin: options.isWin,
+    result: options.result,
     championId: 0,
     items: [],
   };

--- a/src/surfaces/IdleSurface.module.css
+++ b/src/surfaces/IdleSurface.module.css
@@ -227,6 +227,12 @@
   color: var(--fit-strong);
 }
 
+/* Remake: a voided game, neither a win nor a loss. Neutral ink so it
+   never reads as red (loss) or green (win). */
+.recentResultRemake {
+  color: var(--ink-2);
+}
+
 .recentKda {
   font-family: var(--font-mono);
   font-size: 0.7rem;

--- a/src/surfaces/IdleSurface.tsx
+++ b/src/surfaces/IdleSurface.tsx
@@ -8,7 +8,17 @@ import type { LastGameSnapshot } from "../lib/reactive/coaching-feed-types";
 import type { MatchSummary } from "../lib/match-history/types";
 import type { VoiceDecision } from "../lib/decision-log/types";
 import { formatGameMode } from "../lib/format-game-mode";
+import { resultLabel, type GameResult } from "../lib/game-result";
 import styles from "./IdleSurface.module.css";
+
+/**
+ * CSS class for a result word. Shared by the recent-games rows and the
+ * last-game block, which style win / loss / remake identically.
+ */
+function recentResultClass(result: GameResult): string {
+  if (result === "remake") return styles.recentResultRemake;
+  return result === "win" ? styles.recentResultWin : styles.recentResultLoss;
+}
 
 const WINDOW_DAYS = 7;
 const DAY_MS = 24 * 60 * 60 * 1000;
@@ -52,6 +62,18 @@ export function IdleSurface({
     [windowStats]
   );
   const recent = useMemo(() => recentGames(5), [recentGames]);
+  // gameIds of remade (voided) games, so their coaching activity can be
+  // dropped from the weekly tally below. Match history is in-memory, so
+  // on a cold launch with no LCU this set is empty and a remade game
+  // slips through; acceptable, since a remake is rare and the count
+  // self-corrects once history loads.
+  const remadeGameIds = useMemo(() => {
+    const ids = new Set<string>();
+    for (const m of recentGames(200)) {
+      if (m.result === "remake") ids.add(m.gameId);
+    }
+    return ids;
+  }, [recentGames]);
   const { records: recentDecisions, isValidating: decisionsValidating } =
     useDecisionLogQuery(RECENT_GAMES_QUERY);
   // The pulsing-dots affordance pulses ONLY when a real revalidation is
@@ -67,14 +89,16 @@ export function IdleSurface({
   // the decision log gives a denominator that always matches the numerator.
   const { interventionCount, interventionMatchCount } = useMemo(() => {
     const cutoff = Date.now() - WINDOW_DAYS * DAY_MS;
-    const inWindow = recentDecisions.filter((r) => r.sentAt >= cutoff);
+    const inWindow = recentDecisions.filter(
+      (r) => r.sentAt >= cutoff && !remadeGameIds.has(r.gameId)
+    );
     const gameIds = new Set<string>();
     for (const r of inWindow) gameIds.add(r.gameId);
     return {
       interventionCount: inWindow.length,
       interventionMatchCount: gameIds.size,
     };
-  }, [recentDecisions]);
+  }, [recentDecisions, remadeGameIds]);
 
   // Last-completed-game's most recent voice exchange — fallback for the
   // LastGameBlock Q&A snippet when the in-memory snapshot is absent
@@ -246,9 +270,9 @@ function RecentGameRow({
         {formatGameMode(match.gameMode)}
       </span>
       <span
-        className={`${styles.recentResult} ${match.isWin ? styles.recentResultWin : styles.recentResultLoss}`}
+        className={`${styles.recentResult} ${recentResultClass(match.result)}`}
       >
-        {match.isWin ? "Win" : "Loss"}
+        {resultLabel(match.result)}
       </span>
       <span className={styles.recentKda}>
         {match.kills}/{match.deaths}/{match.assists}
@@ -333,20 +357,20 @@ function LastGameBlock({ meta, snapshot, lastVoice }: LastGameBlockProps) {
   // Prefer the in-memory snapshot's most-recent exchange; fall back to
   // the cached decision-log voice record. Both carry the same shape.
   const exchange = snapshot?.recentExchanges[0] ?? lastVoice;
-  const isWin = meta.isWin ?? false;
+  const result = meta.result;
   const gameMode = formatGameMode(meta.gameMode);
   const championName = meta.championName ?? snapshot?.championName ?? "—";
   return (
     <div className={styles.lastGameBlock}>
       <div className={styles.lastGameHeader}>
         <span className={styles.lastGameChamp}>{championName}</span>
-        <span
-          className={`${styles.lastGameResult} ${
-            isWin ? styles.recentResultWin : styles.recentResultLoss
-          }`}
-        >
-          {isWin ? "Win" : "Loss"}
-        </span>
+        {result !== null ? (
+          <span
+            className={`${styles.lastGameResult} ${recentResultClass(result)}`}
+          >
+            {resultLabel(result)}
+          </span>
+        ) : null}
       </div>
       <div className={styles.lastGameStats}>
         <span>

--- a/src/surfaces/IdleSurface.tsx
+++ b/src/surfaces/IdleSurface.tsx
@@ -55,6 +55,7 @@ export function IdleSurface({
   const {
     windowStats,
     recentGames,
+    matches,
     isValidating: matchesValidating,
   } = useMatchHistory();
   const stats = useMemo(
@@ -63,17 +64,19 @@ export function IdleSurface({
   );
   const recent = useMemo(() => recentGames(5), [recentGames]);
   // gameIds of remade (voided) games, so their coaching activity can be
-  // dropped from the weekly tally below. Match history is in-memory, so
-  // on a cold launch with no LCU this set is empty and a remade game
-  // slips through; acceptable, since a remake is rare and the count
+  // dropped from the weekly tally below. Iterates the full in-memory
+  // match history rather than a fixed slice so a heavy week never
+  // pushes a remake past the cap. Match history is in-memory, so on a
+  // cold launch with no LCU this set is empty and a remade game slips
+  // through; acceptable, since a remake is rare and the count
   // self-corrects once history loads.
   const remadeGameIds = useMemo(() => {
     const ids = new Set<string>();
-    for (const m of recentGames(200)) {
+    for (const m of matches) {
       if (m.result === "remake") ids.add(m.gameId);
     }
     return ids;
-  }, [recentGames]);
+  }, [matches]);
   const { records: recentDecisions, isValidating: decisionsValidating } =
     useDecisionLogQuery(RECENT_GAMES_QUERY);
   // The pulsing-dots affordance pulses ONLY when a real revalidation is

--- a/src/surfaces/PostGameSurface.module.css
+++ b/src/surfaces/PostGameSurface.module.css
@@ -130,6 +130,11 @@
   color: var(--fit-strong);
 }
 
+/* Remake: a voided game, neither a win nor a loss. Neutral ink. */
+.eyebrowResultRemake {
+  color: var(--ink-2);
+}
+
 /* ─── Headline + narrative ─── */
 
 .headline {

--- a/src/surfaces/PostGameSurface.tsx
+++ b/src/surfaces/PostGameSurface.tsx
@@ -216,6 +216,7 @@ export function PostGameSurface({ gameId = null }: PostGameSurfaceProps = {}) {
       <RightColumn
         authoritativeMatch={authoritativeMatch}
         takeaway={summary.takeaway}
+        snapshot={snapshot}
         finalPlan={summary.finalPlan}
         startedAt={summary.startedAt}
         endedAt={summary.endedAt}
@@ -410,6 +411,7 @@ function BuildSection({
 
 interface RightColumnProps {
   takeaway: TakeawayDecision | null;
+  snapshot: LastGameSnapshot | null;
   finalPlan: PlanDecision | null;
   startedAt: number | null;
   endedAt: number | null;
@@ -423,6 +425,7 @@ interface RightColumnProps {
 
 function RightColumn({
   takeaway,
+  snapshot,
   finalPlan,
   startedAt,
   endedAt,
@@ -436,7 +439,7 @@ function RightColumn({
   // Eyebrow lives over here so the left column's headline ("Match recap
   // for X.") is the first thing the eye lands on top-left. Win / mode
   // come from the same merged source the left column uses.
-  const meta = mergeMeta(authoritativeMatch, takeaway, null);
+  const meta = mergeMeta(authoritativeMatch, takeaway, snapshot);
   const gameMode = meta.gameMode ? formatGameMode(meta.gameMode) : null;
   const eyebrowText =
     meta.result === null

--- a/src/surfaces/PostGameSurface.tsx
+++ b/src/surfaces/PostGameSurface.tsx
@@ -141,9 +141,7 @@ export function PostGameSurface({ gameId = null }: PostGameSurfaceProps = {}) {
         <div className={styles.eyebrow}>
           <span>Post-game</span>
         </div>
-        <h2 className={styles.preparingHeadline}>
-          Wrapping up your last game
-        </h2>
+        <h2 className={styles.preparingHeadline}>Wrapping up your last game</h2>
         <p className={styles.preparingBody}>
           Pulling the final stats and the coach&apos;s recap together.
         </p>
@@ -287,6 +285,10 @@ function LeftColumn({
         )}
         {takeaway ? (
           <Narrative text={takeaway.narrative} />
+        ) : meta.result === "remake" ? (
+          <p className={styles.narrativePending}>
+            This game was remade. No result was recorded.
+          </p>
         ) : recapStillPending ? (
           <p className={styles.narrativePending}>
             The coach is writing the recap…
@@ -436,18 +438,28 @@ function RightColumn({
   // come from the same merged source the left column uses.
   const meta = mergeMeta(authoritativeMatch, takeaway, null);
   const gameMode = meta.gameMode ? formatGameMode(meta.gameMode) : null;
-  const result = meta.isWin === null ? null : meta.isWin ? "victory" : "defeat";
-  const resultClass = meta.isWin
-    ? styles.eyebrowResultWin
-    : styles.eyebrowResultLoss;
+  const eyebrowText =
+    meta.result === null
+      ? null
+      : meta.result === "win"
+        ? "victory"
+        : meta.result === "remake"
+          ? "remake"
+          : "defeat";
+  const resultClass =
+    meta.result === "win"
+      ? styles.eyebrowResultWin
+      : meta.result === "remake"
+        ? styles.eyebrowResultRemake
+        : styles.eyebrowResultLoss;
   return (
     <aside className={styles.right}>
       <div className={styles.eyebrow}>
         <span>Post-game</span>
-        {result !== null ? (
+        {eyebrowText !== null ? (
           <>
             <span>·</span>
-            <span className={resultClass}>{result.toUpperCase()}</span>
+            <span className={resultClass}>{eyebrowText.toUpperCase()}</span>
           </>
         ) : null}
         {gameMode ? (


### PR DESCRIPTION
Closes #132.

## Summary

- A `GameResult` union (`win` | `loss` | `remake`) replaces the boolean `isWin` on the live-game result path (end-of-game stats, last-game snapshot, merged metadata, match summary). `TakeawayDecision.isWin` stays boolean since a takeaway is never written for a remake; `mergeMeta` bridges it.
- Both result parsers derive the outcome through one `deriveGameResult(win, gameEndedInEarlySurrender)` helper. The flag was verified empirically: remade games DO appear in `/lol-match-history`, contrary to the prior assumption.
- Weekly W/L and KDA exclude remakes; the coaching-moments count drops decision-log records belonging to remade gameIds.
- The post-game takeaway LLM call is gated on a non-remake result. The History surface shows a short "This game was remade" note instead of the LLM narrative.
- The Home last-game block, recent-games rows, the Game-tab "Last game" banner, and the post-game eyebrow all label "Remake" in neutral ink rather than as a red defeat.
- The simulator gained a Remake button for visual QA. Post-game LCU event log truncation was bumped from 200 to 2000 chars so the next live remake confirms the eog-stats-block top-level flag firsthand.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Remake/voided games are surfaced as a distinct outcome (win/loss/remake) with dedicated neutral styling and labels across UI and simulator.
  * Post-game UI now treats remakes specially and prevents automated takeaway generation for remade games.

* **Bug Fixes**
  * Remakes are excluded from win/loss counts, KDA and match-window stats; post-game visibility now follows phase-readiness logic.

* **Documentation**
  * Technical reference clarifies remake detection and updates SWR guidance and readiness side-effect handling.

* **Tests**
  * Updated and added tests to cover result-based outcomes including remakes.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/niftymonkey/champ-sage/pull/133?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->