### PR TITLE
fix: seed GEP version discovery from League's published floor

### DIFF
--- a/scripts/ow-package-guard.test.ts
+++ b/scripts/ow-package-guard.test.ts
@@ -235,6 +235,50 @@ describe("resolveGepVersion", () => {
     expect(version).toBe("307.4.3");
   });
 
+  it("rejects an unparseable advertised build when the floor is known", async () => {
+    // "clears the floor" has to mean "compared against the floor and won". An
+    // unparseable version cannot be compared at all, so treating it as passing
+    // would let exactly the malformed manifest data this guard exists for walk
+    // straight past League's minimum.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["not-a-version", "307.4.2", "307.4.3"]),
+      manifest: manifestWithGep("not-a-version"),
+      floorLookup: lookup,
+    });
+    expect(version).toBe("307.4.3");
+  });
+
+  it("never serves an unparseable advertised build as the last-resort fallback", async () => {
+    // The below-floor fallback is a deliberate "something beats nothing", but
+    // it is only sound for a version we could actually compare. Serving an
+    // unparseable one is serving a URL nobody has reason to believe in.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["not-a-version"]),
+      manifest: manifestWithGep("not-a-version"),
+      floorLookup: lookup,
+    });
+    expect(version).toBeNull();
+  });
+
+  it("discovers a floor-clearing build when the floor patch is past the scan cap", async () => {
+    // The scan bound is a span from where discovery starts, not an absolute
+    // patch number. Seeding from the floor means the start can be any patch
+    // League has reached, and an absolute cap would silently probe nothing at
+    // all once the floor passed it.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 49 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["306.0.3", "307.4.49", "307.4.50"]),
+      manifest: null,
+      floorLookup: lookup,
+    });
+    expect(version).toBe("307.4.50");
+  });
+
   it("serves a below-floor advertised build when discovery finds nothing better", async () => {
     // Last resort: a below-floor override still beats no override, which lets
     // OWEPM re-stub the cache and lose the overlay too.

--- a/scripts/ow-package-guard.test.ts
+++ b/scripts/ow-package-guard.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, afterEach } from "vitest";
 import {
   manifestIndicatesOutage,
   discoverLatestVersion,
+  discoveryBaseline,
   resolveGepVersion,
   buildOverrideManifest,
   planCacheReconciliation,
@@ -12,10 +13,24 @@ import {
   OVERLAY_UID,
   type OverwolfPackagesManifest,
   type InstalledPackage,
+  type Version,
 } from "./ow-package-guard";
 
 /** A fetcher standing in for an unreachable manifest, forcing CDN discovery. */
 const noManifest = () => Promise.resolve<OverwolfPackagesManifest | null>(null);
+
+/** A floor lookup standing in for an unreachable status endpoint. */
+const noFloor = () => Promise.resolve<Version | null>(null);
+
+/** A floor lookup returning a fixed published floor, plus a call counter. */
+function floorLookupOf(floor: Version | null) {
+  const calls = { count: 0 };
+  const lookup = () => {
+    calls.count++;
+    return Promise.resolve(floor);
+  };
+  return { lookup, calls };
+}
 
 function manifestWithGep(gepVersion: string): OverwolfPackagesManifest {
   return {
@@ -100,6 +115,28 @@ describe("discoverLatestVersion", () => {
   });
 });
 
+describe("discoveryBaseline", () => {
+  const anchor = { major: 306, minor: 0, patch: 0 };
+
+  it("probes from League's floor when it is above the maintained anchor", () => {
+    // The anchor goes stale as Overwolf rotates old lines off the CDN; the
+    // published floor is the live, self-updating lower bound.
+    expect(
+      discoveryBaseline(anchor, { major: 307, minor: 4, patch: 2 })
+    ).toEqual({ major: 307, minor: 4, patch: 2 });
+  });
+
+  it("keeps the anchor when the floor sits below it", () => {
+    expect(
+      discoveryBaseline(anchor, { major: 305, minor: 1, patch: 3 })
+    ).toEqual(anchor);
+  });
+
+  it("keeps the anchor when the floor is unknown", () => {
+    expect(discoveryBaseline(anchor, null)).toEqual(anchor);
+  });
+});
+
 describe("resolveGepVersion", () => {
   const baseline = { major: 306, minor: 0, patch: 0 };
 
@@ -115,6 +152,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.10", "307.4.6"]),
       manifest: manifestWithGep("307.4.6"),
+      floorLookup: noFloor,
     });
     expect(version).toBe("307.4.6");
   });
@@ -125,6 +163,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.2", "306.0.3"]),
       manifest: manifestWithGep("307.9.9"),
+      floorLookup: noFloor,
     });
     expect(version).toBe("306.0.3");
   });
@@ -134,6 +173,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.2", "306.0.3"]),
       manifest: manifestWithGep("0.0.0"),
+      floorLookup: noFloor,
     });
     expect(version).toBe("306.0.3");
   });
@@ -143,6 +183,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.2", "306.0.3"]),
       manifest: null,
+      floorLookup: noFloor,
     });
     expect(version).toBe("306.0.3");
   });
@@ -152,8 +193,59 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe([]),
       manifest: null,
+      floorLookup: noFloor,
     });
     expect(version).toBeNull();
+  });
+
+  it("seeds CDN discovery from the published floor when the manifest fails", async () => {
+    // The stale-anchor scenario: 307.0.x is rotated off, so discovery from
+    // 306.0.0 tops out below the floor and would serve a build League rejects.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["306.0.3", "307.4.2", "307.4.3"]),
+      manifest: null,
+      floorLookup: lookup,
+    });
+    expect(version).toBe("307.4.3");
+  });
+
+  it("reads the floor once per resolve", async () => {
+    const { lookup, calls } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["306.0.10", "307.4.6"]),
+      manifest: manifestWithGep("307.4.6"),
+      floorLookup: lookup,
+    });
+    expect(calls.count).toBe(1);
+  });
+
+  it("rejects a manifest build below the floor and discovers one that clears it", async () => {
+    // A downloadable but stale advertised build is still rejected at
+    // game-attach, so serving it is knowingly serving a dead GEP.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["306.0.10", "307.4.2", "307.4.3"]),
+      manifest: manifestWithGep("306.0.10"),
+      floorLookup: lookup,
+    });
+    expect(version).toBe("307.4.3");
+  });
+
+  it("serves a below-floor advertised build when discovery finds nothing better", async () => {
+    // Last resort: a below-floor override still beats no override, which lets
+    // OWEPM re-stub the cache and lose the overlay too.
+    const { lookup } = floorLookupOf({ major: 307, minor: 4, patch: 2 });
+    const version = await resolveGepVersion({
+      baseline,
+      probe: liveProbe(["306.0.10"]),
+      manifest: manifestWithGep("306.0.10"),
+      floorLookup: lookup,
+    });
+    expect(version).toBe("306.0.10");
   });
 
   it("serves GEP_FORCE_VERSION when that build is downloadable (test hook)", async () => {
@@ -162,6 +254,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.10", "307.4.6"]),
       manifest: manifestWithGep("307.4.6"),
+      floorLookup: noFloor,
     });
     expect(version).toBe("306.0.10");
   });
@@ -172,6 +265,7 @@ describe("resolveGepVersion", () => {
       baseline,
       probe: liveProbe(["306.0.2", "306.0.3"]),
       manifest: null,
+      floorLookup: noFloor,
     });
     expect(version).toBe("306.0.3");
   });
@@ -188,13 +282,29 @@ describe("buildOverrideManifest", () => {
     };
     const manifest = await buildOverrideManifest(
       (channel) => liveProbe(live[channel] ?? []),
-      () => Promise.resolve(manifestWithGep("307.4.6"))
+      () => Promise.resolve(manifestWithGep("307.4.6")),
+      noFloor
     );
     const gep = manifest!.packages.find((p) => p.name === "gep");
     expect(gep!.version).toBe("307.4.6");
     expect(gep!.url).toBe(
       "https://electrondl.overwolf.com/1/307.4.6/module.owepk"
     );
+  });
+
+  it("seeds gep discovery from the floor when the manifest is unreachable", async () => {
+    const live: Record<number, string[]> = {
+      1: ["306.0.3", "307.4.2"],
+      2: ["2.7.5"],
+      3: ["1.12.5"],
+    };
+    const manifest = await buildOverrideManifest(
+      (channel) => liveProbe(live[channel] ?? []),
+      noManifest,
+      () => Promise.resolve({ major: 307, minor: 4, patch: 2 })
+    );
+    const gep = manifest!.packages.find((p) => p.name === "gep");
+    expect(gep!.version).toBe("307.4.2");
   });
 
   it("discovers gep and keeps utility/overlay on their live pins", async () => {
@@ -205,7 +315,8 @@ describe("buildOverrideManifest", () => {
     };
     const manifest = await buildOverrideManifest(
       (channel) => liveProbe(live[channel] ?? []),
-      noManifest
+      noManifest,
+      noFloor
     );
     expect(manifest).not.toBeNull();
 
@@ -236,7 +347,8 @@ describe("buildOverrideManifest", () => {
     };
     const manifest = await buildOverrideManifest(
       (channel) => liveProbe(live[channel] ?? []),
-      noManifest
+      noManifest,
+      noFloor
     );
     const overlay = manifest!.packages.find((p) => p.name === "overlay");
     expect(overlay!.version).toBe("1.12.6");
@@ -245,7 +357,8 @@ describe("buildOverrideManifest", () => {
   it("returns null when gep cannot be resolved (override would be useless)", async () => {
     const manifest = await buildOverrideManifest(
       () => liveProbe([]),
-      noManifest
+      noManifest,
+      noFloor
     );
     expect(manifest).toBeNull();
   });

--- a/scripts/ow-package-guard.ts
+++ b/scripts/ow-package-guard.ts
@@ -128,7 +128,7 @@ export interface DiscoverOptions {
   probe: VersionProbe;
   /** Consecutive misses tolerated before a version line is abandoned. */
   gapTolerance?: number;
-  /** Highest patch probed within a single (major, minor) line. */
+  /** How many patches above a line's starting patch are probed. */
   patchCap?: number;
   /** How many minor lines above the baseline to also scan. */
   minorLookahead?: number;
@@ -258,9 +258,14 @@ async function maxLiveInLine(
 ): Promise<Version | null> {
   let best: Version | null = null;
   let misses = 0;
+  // The cap is a span from where this line starts, not an absolute patch
+  // number. Discovery now seeds from League's published floor, which can sit at
+  // any patch the game has reached, and an absolute cap would silently probe
+  // nothing at all once the floor passed it.
+  const lastPatch = line.startPatch + patchCap;
   for (
     let patch = line.startPatch;
-    patch <= patchCap && misses <= gapTolerance;
+    patch <= lastPatch && misses <= gapTolerance;
     patch++
   ) {
     const candidate = { major: line.major, minor: line.minor, patch };
@@ -385,10 +390,19 @@ export async function resolveGepVersion(args: {
     )?.version;
     if (advertised && (await probe(advertised))) {
       if (clearsFloor(advertised, floor)) return advertised;
-      liveButBelowFloor = advertised;
-      log(
-        `Overwolf manifest advertises gep ${advertised}, below League's floor ${floor ? formatVersion(floor) : "unknown"}; discovering a floor-clearing build via CDN`
-      );
+      // Only a version we could actually compare earns the fallback slot. An
+      // unparseable one failed the floor check by being uncomparable, not by
+      // being old, so there is no reason to believe serving it helps.
+      if (parseVersion(advertised)) {
+        liveButBelowFloor = advertised;
+        log(
+          `Overwolf manifest advertises gep ${advertised}, below League's floor ${floor ? formatVersion(floor) : "unknown"}; discovering a floor-clearing build via CDN`
+        );
+      } else {
+        log(
+          `Overwolf manifest advertises unparseable gep version ${advertised}; discovering via CDN`
+        );
+      }
     } else if (advertised) {
       log(
         `Overwolf manifest advertises gep ${advertised} but the CDN has no such build; discovering via CDN`
@@ -415,7 +429,10 @@ export async function resolveGepVersion(args: {
 function clearsFloor(version: string, floor: Version | null): boolean {
   if (!floor) return true;
   const v = parseVersion(version);
-  return v === null || compareVersions(v, floor) >= 0;
+  // An unparseable version cannot be compared, so it cannot have cleared the
+  // floor. Reading "uncomparable" as "passing" would let the malformed manifest
+  // data this guard exists for walk straight past League's minimum.
+  return v !== null && compareVersions(v, floor) >= 0;
 }
 
 /**

--- a/scripts/ow-package-guard.ts
+++ b/scripts/ow-package-guard.ts
@@ -142,7 +142,11 @@ interface PackageSpec {
   channel: number;
   /** Preferred known-good version. Omitted for gep (always newest-live). */
   pin?: string;
-  /** Anchor for discovery and pin-healing. */
+  /**
+   * Anchor for discovery and pin-healing. For gep this is only the floor-less
+   * fallback: discovery normally starts from League's published floor instead
+   * (see {@link discoveryBaseline}), so the anchor going stale is not fatal.
+   */
   baseline: Version;
   /**
    * "always": resolve to the newest live build every launch (gep, so it keeps
@@ -270,6 +274,38 @@ async function maxLiveInLine(
   return best;
 }
 
+/**
+ * Reads League's published GEP floor as a {@link Version}, or null when the
+ * status endpoint is unreachable or the value is unparseable.
+ */
+export type FloorLookup = () => Promise<Version | null>;
+
+const defaultFloorLookup: FloorLookup = async () => {
+  const floor = await fetchGepFloor(LOL_GAME_ID);
+  return floor ? parseVersion(floor.minGepVersionElectron) : null;
+};
+
+/**
+ * The version CDN discovery should probe upward from: the higher of the
+ * hand-maintained anchor in {@link PACKAGE_SPECS} and League's published floor.
+ *
+ * The anchor cannot be trusted to stay useful. Overwolf rotates whole version
+ * lines off the CDN, and discovery's lookahead window only reaches a couple of
+ * lines above where it starts, so an anchor left behind by a few patches tops
+ * out below the floor and hands OWEPM a build League rejects at game-attach
+ * (observed 2026-07-20: anchor 306.0.0 could reach no higher than 306.2.x while
+ * the floor was 307.4.2, because the entire 307.0.x line was a 403 gap). The
+ * floor is published live and rises with the game, so seeding from it keeps
+ * discovery landing on a build that clears it without a code change. The anchor
+ * remains the fallback for when the status endpoint is unreachable.
+ */
+export function discoveryBaseline(
+  anchor: Version,
+  floor: Version | null
+): Version {
+  return floor && compareVersions(floor, anchor) > 0 ? floor : anchor;
+}
+
 /** Fetches the live Overwolf package manifest, or null when it cannot be reached. */
 export type ManifestFetcher = () => Promise<OverwolfPackagesManifest | null>;
 
@@ -292,25 +328,34 @@ const defaultManifestFetcher: ManifestFetcher = () =>
  * truth for both `--check` and `--serve`, so the version the guard reports and
  * the one it actually serves never diverge.
  *
- * Prefers the version the recovered Overwolf manifest advertises, but only when
- * that exact build is downloadable on the CDN. The manifest can advertise a
- * build whose binary has not yet propagated, and during the 0.0.0 outage it
- * advertises a stub; in those cases, and when the manifest is unreachable, this
- * falls back to CDN baseline discovery so the guard still lands on a live build.
- * Returns null only when neither source yields one.
+ * League's published floor governs BOTH sources, so every launch that can reach
+ * the status endpoint resolves a build the game will actually accept:
  *
- * Seeding from the manifest is what lets the override track League's rising
- * minimum-version floor without a hand-maintained baseline: CDN discovery alone
- * cannot reach a new (major, minor) line beyond its lookahead window once the
- * intervening line is a 403 gap (baseline 306.0.0 cannot see 307.4.x when the
- * whole 307.0.x line is rotated off).
+ * 1. The recovered manifest's advertised version wins when that exact build is
+ *    downloadable AND clears the floor. The manifest can advertise a build whose
+ *    binary has not propagated, a 0.0.0 stub during the outage, or a build that
+ *    has fallen behind the floor; none of those are served.
+ * 2. Otherwise CDN discovery runs from {@link discoveryBaseline}, which starts at
+ *    the floor whenever that is above the spec's anchor. Bare discovery from a
+ *    stale anchor cannot reach a new (major, minor) line beyond its lookahead
+ *    window once the intervening line is a 403 gap (anchor 306.0.0 cannot see
+ *    307.4.x when the whole 307.0.x line is rotated off); the floor seed closes
+ *    exactly that gap.
+ * 3. Only if discovery comes up empty does a live-but-below-floor advertised
+ *    build get served, loudly: an override League rejects still beats no
+ *    override, which lets OWEPM re-stub the cache and take the overlay with it.
+ *
+ * An unreachable status endpoint degrades to the old behavior (anchor-based
+ * discovery, no floor gate) rather than blocking the launch. Returns null only
+ * when no source yields a live build.
  */
 export async function resolveGepVersion(args: {
   baseline: Version;
   probe: VersionProbe;
   manifest: OverwolfPackagesManifest | null;
+  floorLookup?: FloorLookup;
 }): Promise<string | null> {
-  const { baseline, probe, manifest } = args;
+  const { baseline, probe, manifest, floorLookup = defaultFloorLookup } = args;
   // Test hook: GEP_FORCE_VERSION pins the override to a specific (CDN-live)
   // build so a stale-GEP restart can be exercised on demand, e.g. launching
   // with GEP_FORCE_VERSION=306.0.10 loads a below-floor build that the
@@ -327,14 +372,24 @@ export async function resolveGepVersion(args: {
     }
     log(`GEP_FORCE_VERSION=${forced} is not downloadable on the CDN; ignoring`);
   }
+  const floor = await floorLookup();
+
+  // A downloadable advertised build that still clears the floor, kept aside as
+  // the last resort when discovery finds nothing above the floor: a below-floor
+  // override beats no override at all, which lets OWEPM re-stub the cache.
+  let liveButBelowFloor: string | null = null;
+
   if (manifest && !manifestIndicatesOutage(manifest)) {
     const advertised = manifest.packages?.find(
       (p) => p.name === "gep"
     )?.version;
     if (advertised && (await probe(advertised))) {
-      return advertised;
-    }
-    if (advertised) {
+      if (clearsFloor(advertised, floor)) return advertised;
+      liveButBelowFloor = advertised;
+      log(
+        `Overwolf manifest advertises gep ${advertised}, below League's floor ${floor ? formatVersion(floor) : "unknown"}; discovering a floor-clearing build via CDN`
+      );
+    } else if (advertised) {
       log(
         `Overwolf manifest advertises gep ${advertised} but the CDN has no such build; discovering via CDN`
       );
@@ -342,7 +397,25 @@ export async function resolveGepVersion(args: {
   } else if (manifest) {
     log("Overwolf manifest is serving 0.0.0 stubs; discovering GEP via CDN");
   }
-  return discoverLatestVersion({ baseline, probe });
+
+  const discovered = await discoverLatestVersion({
+    baseline: discoveryBaseline(baseline, floor),
+    probe,
+  });
+  if (discovered) return discovered;
+  if (liveButBelowFloor) {
+    log(
+      `no floor-clearing GEP build found; falling back to ${liveButBelowFloor}, which League will reject at game-attach`
+    );
+  }
+  return liveButBelowFloor;
+}
+
+/** Whether `version` is at or above League's floor (true when the floor is unknown). */
+function clearsFloor(version: string, floor: Version | null): boolean {
+  if (!floor) return true;
+  const v = parseVersion(version);
+  return v === null || compareVersions(v, floor) >= 0;
 }
 
 /**
@@ -354,13 +427,19 @@ export async function resolveGepVersion(args: {
  */
 export async function buildOverrideManifest(
   probeFactory: ProbeFactory = makeCdnProbeFactory(),
-  fetchManifest: ManifestFetcher = defaultManifestFetcher
+  fetchManifest: ManifestFetcher = defaultManifestFetcher,
+  floorLookup: FloorLookup = defaultFloorLookup
 ): Promise<OverwolfPackagesManifest | null> {
   const manifest = await fetchManifest();
   const packages: OverwolfPackage[] = [];
   for (const spec of PACKAGE_SPECS) {
     const probe = probeFactory(spec.channel);
-    const version = await resolvePackageVersion(spec, probe, manifest);
+    const version = await resolvePackageVersion(
+      spec,
+      probe,
+      manifest,
+      floorLookup
+    );
     if (!version) {
       log(`could not resolve a live version for ${spec.name}`);
       if (spec.name === "gep") return null;
@@ -380,13 +459,19 @@ export async function buildOverrideManifest(
 async function resolvePackageVersion(
   spec: PackageSpec,
   probe: VersionProbe,
-  manifest: OverwolfPackagesManifest | null
+  manifest: OverwolfPackagesManifest | null,
+  floorLookup: FloorLookup
 ): Promise<string | null> {
   if (spec.resolve === "if-pin-dead" && spec.pin && (await probe(spec.pin))) {
     return spec.pin;
   }
   if (spec.resolve === "always") {
-    return resolveGepVersion({ baseline: spec.baseline, probe, manifest });
+    return resolveGepVersion({
+      baseline: spec.baseline,
+      probe,
+      manifest,
+      floorLookup,
+    });
   }
   return discoverLatestVersion({ baseline: spec.baseline, probe });
 }
@@ -673,7 +758,7 @@ async function serveOverrideManifest(port: number): Promise<void> {
   const initial = await getBody();
   if (!initial) {
     log(
-      "no live GEP build found near baseline; not serving override (bump the gep baseline in PACKAGE_SPECS)"
+      "no live GEP build found near the discovery baseline (League's published floor, or the gep anchor in PACKAGE_SPECS when the status endpoint is unreachable); not serving override"
     );
     process.exit(EXIT_ERROR);
   }


### PR DESCRIPTION
Seeds GEP version discovery from League's published floor, so a launch that can reach the status endpoint resolves a build the game will actually accept.

The hand-maintained anchor in `PACKAGE_SPECS` cannot be trusted to stay useful. Overwolf rotates whole version lines off the CDN and discovery's lookahead only reaches a couple of lines above where it starts, so an anchor left behind by a few patches tops out below the floor and hands OWEPM a build League rejects at game-attach. Observed 2026-07-20: anchor 306.0.0 could reach no higher than 306.2.x while the floor was 307.4.2, because the entire 307.0.x line was a 403 gap.

`discoveryBaseline(anchor, floor)` now starts discovery from whichever is higher, and the floor gates both resolution paths: the manifest's advertised build must be downloadable *and* clear the floor, and CDN discovery probes upward from the floor. A live-but-below-floor advertised build is served only as a last resort when discovery comes up empty, and loudly, because an override League rejects still beats no override at all, which lets OWEPM re-stub the cache and take the overlay with it.

An unreachable status endpoint degrades to the previous behavior (anchor-based discovery, no floor gate) rather than blocking the launch.

Stacked on #151; merge that first.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved version discovery to honor the published minimum supported version.
  - Prevented stale, malformed, unavailable, or below-minimum package manifests from being selected when compliant versions are available.
  - Added fallback handling when the manifest service is unavailable.
  - Improved version probing across release lines and enforced discovery limits.

- **Diagnostics**
  - Startup information now reports the minimum-version baseline used during package discovery.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->